### PR TITLE
fix: address PR review comments for security, CSS, and test isolation

### DIFF
--- a/src/app/api/providers/fal/models/route.ts
+++ b/src/app/api/providers/fal/models/route.ts
@@ -98,17 +98,20 @@ type ModelsResponse = ModelsSuccessResponse | ModelsErrorResponse;
  * Fetches available models from fal.ai API.
  * API key is optional - fal.ai works without but with rate limits.
  *
+ * Headers:
+ *   - X-API-Key: API key for authentication (recommended)
+ *   - Authorization: Alternative auth header
+ *
  * Query params:
  *   - search: Optional search query to filter models
- *   - api_key: Alternative to X-API-Key header
  */
 export async function GET(
   request: NextRequest
 ): Promise<NextResponse<ModelsResponse>> {
-  // Get optional API key from header or query param
+  // Get optional API key from header only (never from query params to avoid credential leakage)
   const apiKey =
     request.headers.get("X-API-Key") ||
-    request.nextUrl.searchParams.get("api_key");
+    request.headers.get("Authorization")?.replace(/^Key\s+/i, "");
 
   const searchQuery = request.nextUrl.searchParams.get("search");
 

--- a/src/app/api/save-generation/__tests__/route.test.ts
+++ b/src/app/api/save-generation/__tests__/route.test.ts
@@ -264,7 +264,11 @@ describe("/api/save-generation route", () => {
 
       expect(data.success).toBe(true);
       expect(data.filename).toContain(expectedHash);
-      expect(global.fetch).toHaveBeenCalledWith("https://example.com/image.png");
+      // Fetch is called with URL and options object containing AbortController signal
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://example.com/image.png",
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
     });
 
     it("should handle failed HTTP fetch", async () => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,9 @@
 :root {
   --background: #0a0a0a;
   --foreground: #fafafa;
+  /* Handle colors (used by labels) */
+  --handle-color-image: #10b981;
+  --handle-color-text: #3b82f6;
 }
 
 html {
@@ -70,15 +73,9 @@ body {
   background: #10b981;
 }
 
-/* Prompt/text handles - soft blue */
-.react-flow__handle[data-handletype="prompt"] {
+/* Text handles - soft blue */
+.react-flow__handle[data-handletype="text"] {
   background: #3b82f6;
-}
-
-/* CSS variables for handle colors (used by labels) */
-:root {
-  --handle-color-image: #10b981;
-  --handle-color-text: #a3a3a3;
 }
 
 .react-flow__edge-path {

--- a/src/components/__tests__/CostDialog.test.tsx
+++ b/src/components/__tests__/CostDialog.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { CostDialog } from "@/components/CostDialog";
 import { PredictedCostResult } from "@/utils/costCalculator";
@@ -18,11 +18,19 @@ vi.mock("@/store/workflowStore", () => ({
 
 // Mock confirm
 const mockConfirm = vi.fn(() => true);
-global.confirm = mockConfirm;
 
 describe("CostDialog", () => {
+  beforeAll(() => {
+    vi.stubGlobal("confirm", mockConfirm);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConfirm.mockReturnValue(true); // Reset default return value
     mockUseWorkflowStore.mockImplementation((selector) => {
       const state = {
         resetIncurredCost: mockResetIncurredCost,

--- a/src/components/__tests__/EdgeToolbar.test.tsx
+++ b/src/components/__tests__/EdgeToolbar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { EdgeToolbar } from "@/components/EdgeToolbar";
 import { ReactFlowProvider } from "@xyflow/react";
 
@@ -18,7 +19,7 @@ vi.mock("@/store/workflowStore", () => ({
 }));
 
 // Wrapper component for React Flow context
-function TestWrapper({ children }: { children: React.ReactNode }) {
+function TestWrapper({ children }: { children: ReactNode }) {
   return <ReactFlowProvider>{children}</ReactFlowProvider>;
 }
 


### PR DESCRIPTION
Security & API route fixes:
- Remove API key query param support in fal/models route to prevent credential leakage
- Fix MIME type fallback in save-generation route (now uses prefix-based fallback: image/* -> png, video/* -> mp4, unknown -> bin)
- Add timeout (60s) and size limits (500MB) for remote fetch in save-generation route using AbortController

CSS fix:
- Consolidate duplicate :root blocks in globals.css
- Change handle selector from data-handletype="prompt" to data-handletype="text"
- Update --handle-color-text CSS variable from #a3a3a3 to #3b82f6

Test file global mock isolation:
- Fix useAnnotationStore mock to support Zustand selector pattern
- Use vi.stubGlobal() instead of direct global assignments to prevent test leakage
- Restore global.Image in afterAll hook in AnnotationModal.test.tsx
- Wrap async Done assertion in waitFor() in AnnotationModal.test.tsx
- Use idiomatic fireEvent.dragOver() in AnnotationNode.test.tsx
- Fix global.confirm stub with proper beforeAll/afterAll lifecycle in CostDialog.test.tsx
- Import ReactNode type properly in EdgeToolbar.test.tsx
- Update save-generation route test to expect AbortController signal in fetch call