### PR TITLE
Rebrand Node Banana to Big Box Studio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "node-banana",
+  "name": "bigbox-studio",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "node-banana",
+      "name": "bigbox-studio",
       "version": "1.0.0",
       "dependencies": {
         "@google/genai": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-banana",
+  "name": "bigbox-studio",
   "version": "1.0.0",
   "private": true,
   "scripts": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,7 @@
   --foreground: #fafafa;
   /* Handle colors (used by labels) */
   --handle-color-image: #10b981;
-  --handle-color-text: #3b82f6;
+  --handle-color-text: #f59e0b;
 }
 
 html {
@@ -82,9 +82,9 @@ body {
   background: #10b981;
 }
 
-/* Text handles - soft blue */
+/* Text handles - warm amber */
 .react-flow__handle[data-handletype="text"] {
-  background: #3b82f6;
+  background: #f59e0b;
 }
 
 .react-flow__edge-path {
@@ -96,7 +96,7 @@ body {
 
 .react-flow__edge.selected .react-flow__edge-path,
 .react-flow__edge:hover .react-flow__edge-path {
-  stroke: #3b82f6;
+  stroke: #f59e0b;
 }
 
 /* Hide resize handles but show resize cursor on edges */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,8 @@ import "./globals.css";
 import { Toast } from "@/components/Toast";
 
 export const metadata: Metadata = {
-  title: "Node Banana - AI Image Workflow",
-  description: "Node-based image annotation and generation workflow using Nano Banana Pro",
+  title: "Big Box Studio - AI Image Workflow",
+  description: "Node-based AI image generation workflow by Big Box Creative",
 };
 
 export default function RootLayout({

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -174,9 +174,11 @@ export function Header() {
       />
       <header className="h-11 bg-neutral-900 border-b border-neutral-800 flex items-center justify-between px-4 shrink-0">
         <div className="flex items-center gap-2">
-          <img src="/banana_icon.png" alt="Banana" className="w-6 h-6" />
+          <div className="w-6 h-6 rounded bg-amber-500 flex items-center justify-center">
+            <span className="text-xs font-bold text-neutral-900 leading-none">BB</span>
+          </div>
           <h1 className="text-2xl font-semibold text-neutral-100 tracking-tight">
-            Node Banana
+            Big Box Studio
           </h1>
 
           <div className="flex items-center gap-2 ml-4 pl-4 border-l border-neutral-700">
@@ -373,29 +375,12 @@ export function Header() {
           </span>
           <span className="text-neutral-500">·</span>
           <a
-            href="https://x.com/ReflctWillie"
+            href="https://bigboxcreative.africa"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-neutral-400 hover:text-neutral-200 transition-colors"
+            className="text-neutral-400 hover:text-amber-400 transition-colors"
           >
-            Made by Willie
-          </a>
-          <span className="text-neutral-500">·</span>
-          <a
-            href="https://discord.com/invite/89Nr6EKkTf"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-neutral-400 hover:text-neutral-200 transition-colors"
-            title="Support"
-          >
-            <svg
-              className="w-4 h-4"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z"/>
-            </svg>
+            Big Box Creative
           </a>
         </div>
       </header>

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -68,26 +68,18 @@ describe("Header", () => {
   describe("Basic Rendering", () => {
     it("should render the app title", () => {
       render(<Header />);
-      expect(screen.getByText("Node Banana")).toBeInTheDocument();
+      expect(screen.getByText("Big Box Studio")).toBeInTheDocument();
     });
 
-    it("should render the banana icon", () => {
+    it("should render the Big Box Creative logo mark", () => {
       render(<Header />);
-      const icon = screen.getByAltText("Banana");
-      expect(icon).toBeInTheDocument();
-      expect(icon).toHaveAttribute("src", "/banana_icon.png");
+      expect(screen.getByText("BB")).toBeInTheDocument();
     });
 
-    it("should render 'Made by Willie' link", () => {
+    it("should render 'Big Box Creative' link", () => {
       render(<Header />);
-      const link = screen.getByText("Made by Willie");
-      expect(link).toHaveAttribute("href", "https://x.com/ReflctWillie");
-    });
-
-    it("should render Discord support link", () => {
-      render(<Header />);
-      const link = screen.getByTitle("Support");
-      expect(link).toHaveAttribute("href", "https://discord.com/invite/89Nr6EKkTf");
+      const link = screen.getByText("Big Box Creative");
+      expect(link).toHaveAttribute("href", "https://bigboxcreative.africa");
     });
   });
 

--- a/src/components/__tests__/QuickstartInitialView.test.tsx
+++ b/src/components/__tests__/QuickstartInitialView.test.tsx
@@ -17,7 +17,7 @@ describe("QuickstartInitialView", () => {
   });
 
   describe("Basic Rendering", () => {
-    it("should render the Node Banana title and logo", () => {
+    it("should render the Big Box Studio title and logo", () => {
       render(
         <QuickstartInitialView
           onSelectBlankCanvas={mockOnSelectBlankCanvas}
@@ -27,8 +27,8 @@ describe("QuickstartInitialView", () => {
         />
       );
 
-      expect(screen.getByText("Node Banana")).toBeInTheDocument();
-      expect(screen.getByAltText("")).toBeInTheDocument(); // Logo image
+      expect(screen.getByText("Big Box Studio")).toBeInTheDocument();
+      expect(screen.getByText("BB")).toBeInTheDocument(); // Logo mark
     });
 
     it("should render the description text", () => {
@@ -174,7 +174,7 @@ describe("QuickstartInitialView", () => {
   });
 
   describe("External Links", () => {
-    it("should render Discord link with correct URL", () => {
+    it("should render Big Box Creative website link", () => {
       render(
         <QuickstartInitialView
           onSelectBlankCanvas={mockOnSelectBlankCanvas}
@@ -184,45 +184,13 @@ describe("QuickstartInitialView", () => {
         />
       );
 
-      const discordLink = screen.getByText("Discord").closest("a");
-      expect(discordLink).toHaveAttribute(
+      const websiteLink = screen.getByText("bigboxcreative.africa").closest("a");
+      expect(websiteLink).toHaveAttribute(
         "href",
-        "https://discord.com/invite/89Nr6EKkTf"
+        "https://bigboxcreative.africa"
       );
-      expect(discordLink).toHaveAttribute("target", "_blank");
-      expect(discordLink).toHaveAttribute("rel", "noopener noreferrer");
-    });
-
-    it("should render Twitter/X link with correct URL", () => {
-      render(
-        <QuickstartInitialView
-          onSelectBlankCanvas={mockOnSelectBlankCanvas}
-          onSelectTemplates={mockOnSelectTemplates}
-          onSelectVibe={mockOnSelectVibe}
-          onSelectLoad={mockOnSelectLoad}
-        />
-      );
-
-      const twitterLink = screen.getByText("Willie").closest("a");
-      expect(twitterLink).toHaveAttribute("href", "https://x.com/ReflctWillie");
-      expect(twitterLink).toHaveAttribute("target", "_blank");
-      expect(twitterLink).toHaveAttribute("rel", "noopener noreferrer");
-    });
-
-    it("should render docs link", () => {
-      render(
-        <QuickstartInitialView
-          onSelectBlankCanvas={mockOnSelectBlankCanvas}
-          onSelectTemplates={mockOnSelectTemplates}
-          onSelectVibe={mockOnSelectVibe}
-          onSelectLoad={mockOnSelectLoad}
-        />
-      );
-
-      const docsLink = screen.getByText("Docs").closest("a");
-      expect(docsLink).toHaveAttribute("href", "https://node-banana-docs.vercel.app/");
-      expect(docsLink).toHaveAttribute("target", "_blank");
-      expect(docsLink).toHaveAttribute("rel", "noopener noreferrer");
+      expect(websiteLink).toHaveAttribute("target", "_blank");
+      expect(websiteLink).toHaveAttribute("rel", "noopener noreferrer");
     });
   });
 

--- a/src/components/__tests__/WelcomeModal.test.tsx
+++ b/src/components/__tests__/WelcomeModal.test.tsx
@@ -64,7 +64,7 @@ describe("WelcomeModal", () => {
         />
       );
 
-      expect(screen.getByText("Node Banana")).toBeInTheDocument();
+      expect(screen.getByText("Big Box Studio")).toBeInTheDocument();
       expect(screen.getByText("Blank canvas")).toBeInTheDocument();
       expect(screen.getByText("Templates")).toBeInTheDocument();
       expect(screen.getByText("Prompt a workflow")).toBeInTheDocument();
@@ -153,7 +153,7 @@ describe("WelcomeModal", () => {
         fireEvent.click(screen.getByText("Back"));
       });
 
-      expect(screen.getByText("Node Banana")).toBeInTheDocument();
+      expect(screen.getByText("Big Box Studio")).toBeInTheDocument();
       expect(screen.getByText("Blank canvas")).toBeInTheDocument();
     });
 
@@ -172,7 +172,7 @@ describe("WelcomeModal", () => {
       // Click back
       fireEvent.click(screen.getByText("Back"));
 
-      expect(screen.getByText("Node Banana")).toBeInTheDocument();
+      expect(screen.getByText("Big Box Studio")).toBeInTheDocument();
     });
   });
 

--- a/src/components/quickstart/QuickstartInitialView.tsx
+++ b/src/components/quickstart/QuickstartInitialView.tsx
@@ -20,9 +20,11 @@ export function QuickstartInitialView({
         <div className="flex-1 flex flex-col">
           <div className="mb-4">
             <div className="flex items-center gap-2">
-              <img src="/banana_icon.png" alt="" className="w-7 h-7" />
+              <div className="w-7 h-7 rounded bg-amber-500 flex items-center justify-center">
+                <span className="text-xs font-bold text-neutral-900 leading-none">BB</span>
+              </div>
               <h1 className="text-2xl font-medium text-neutral-100">
-                Node Banana
+                Big Box Studio
               </h1>
             </div>
           </div>
@@ -33,10 +35,10 @@ export function QuickstartInitialView({
 
           <div className="flex flex-col gap-2.5 mt-auto">
             <a
-              href="https://node-banana-docs.vercel.app/"
+              href="https://bigboxcreative.africa"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
+              className="flex items-center gap-2 text-sm text-neutral-400 hover:text-amber-400 transition-colors"
             >
               <svg
                 className="w-4 h-4"
@@ -48,40 +50,10 @@ export function QuickstartInitialView({
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+                  d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 003 12c0-1.605.42-3.113 1.157-4.418"
                 />
               </svg>
-              Docs
-            </a>
-            <a
-              href="https://discord.com/invite/89Nr6EKkTf"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
-            >
-              <svg
-                className="w-4 h-4"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z" />
-              </svg>
-              Discord
-            </a>
-            <a
-              href="https://x.com/ReflctWillie"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
-            >
-              <svg
-                className="w-4 h-4"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-              </svg>
-              Willie
+              bigboxcreative.africa
             </a>
           </div>
         </div>

--- a/src/components/quickstart/QuickstartTemplatesView.tsx
+++ b/src/components/quickstart/QuickstartTemplatesView.tsx
@@ -316,18 +316,18 @@ export function QuickstartTemplatesView({
             </div>
           )}
 
-          {/* Discord CTA */}
+          {/* Website CTA */}
           <p className="text-xs text-neutral-500 mt-3">
             Want to share your workflow?{" "}
             <a
-              href="https://discord.com/invite/89Nr6EKkTf"
+              href="https://bigboxcreative.africa"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-purple-400 hover:text-purple-300 underline"
+              className="text-amber-400 hover:text-amber-300 underline"
             >
-              Join our Discord
+              Visit our website
             </a>{" "}
-            to submit it to the community templates.
+            to get in touch.
           </p>
         </div>
 

--- a/src/lib/quickstart/prompts.ts
+++ b/src/lib/quickstart/prompts.ts
@@ -9,7 +9,7 @@ export function buildQuickstartPrompt(
 ): string {
   const timestamp = Date.now();
 
-  return `You are a workflow designer for Node Banana, a visual node-based AI image generation tool. Your task is to create a workflow JSON based on the user's description.
+  return `You are a workflow designer for Big Box Studio, a visual node-based AI image generation tool. Your task is to create a workflow JSON based on the user's description.
 
 ## CRITICAL: OUTPUT FORMAT
 You MUST output ONLY valid JSON. No explanations, no markdown, no code blocks. Just the raw JSON object starting with { and ending with }.
@@ -410,7 +410,7 @@ OUTPUT ONLY THE JSON:`;
  * Build a simpler prompt for quick generation
  */
 export function buildSimplePrompt(description: string): string {
-  return `Create a Node Banana workflow JSON for: "${description}"
+  return `Create a Big Box Studio workflow JSON for: "${description}"
 
 Node types: imageInput (output: image), prompt (output: text), nanoBanana (inputs: image+text, output: image), llmGenerate (input: text, output: text), annotation (input: image, output: image), splitGrid (input: image, creates child nodes for each cell), output (input: image).
 

--- a/src/store/utils/__tests__/nodeDefaults.test.ts
+++ b/src/store/utils/__tests__/nodeDefaults.test.ts
@@ -190,7 +190,7 @@ describe("nodeDefaults utilities", () => {
         useGoogleSearch: true,
       };
       localStorageMock.setItem(
-        "node-banana-nanoBanana-defaults",
+        "bigbox-studio-generate-defaults",
         JSON.stringify(customSettings)
       );
 
@@ -211,7 +211,7 @@ describe("nodeDefaults utilities", () => {
         },
       };
       localStorageMock.setItem(
-        "node-banana-node-defaults",
+        "bigbox-studio-node-defaults",
         JSON.stringify(nodeDefaultsConfig)
       );
 
@@ -233,7 +233,7 @@ describe("nodeDefaults utilities", () => {
         },
       };
       localStorageMock.setItem(
-        "node-banana-node-defaults",
+        "bigbox-studio-node-defaults",
         JSON.stringify(nodeDefaultsConfig)
       );
 
@@ -262,7 +262,7 @@ describe("nodeDefaults utilities", () => {
         },
       };
       localStorageMock.setItem(
-        "node-banana-node-defaults",
+        "bigbox-studio-node-defaults",
         JSON.stringify(nodeDefaultsConfig)
       );
 
@@ -290,7 +290,7 @@ describe("nodeDefaults utilities", () => {
         },
       };
       localStorageMock.setItem(
-        "node-banana-node-defaults",
+        "bigbox-studio-node-defaults",
         JSON.stringify(nodeDefaultsConfig)
       );
 

--- a/src/store/utils/localStorage.ts
+++ b/src/store/utils/localStorage.ts
@@ -10,12 +10,12 @@ import {
 } from "@/types";
 
 // Storage keys
-export const STORAGE_KEY = "node-banana-workflow-configs";
-export const COST_DATA_STORAGE_KEY = "node-banana-workflow-costs";
-export const GENERATE_IMAGE_DEFAULTS_KEY = "node-banana-nanoBanana-defaults";
-export const PROVIDER_SETTINGS_KEY = "node-banana-provider-settings";
-export const RECENT_MODELS_KEY = "node-banana-recent-models";
-export const NODE_DEFAULTS_KEY = "node-banana-node-defaults";
+export const STORAGE_KEY = "bigbox-studio-workflow-configs";
+export const COST_DATA_STORAGE_KEY = "bigbox-studio-workflow-costs";
+export const GENERATE_IMAGE_DEFAULTS_KEY = "bigbox-studio-generate-defaults";
+export const PROVIDER_SETTINGS_KEY = "bigbox-studio-provider-settings";
+export const RECENT_MODELS_KEY = "bigbox-studio-recent-models";
+export const NODE_DEFAULTS_KEY = "bigbox-studio-node-defaults";
 
 // Maximum recent models to store (show 4 in UI, keep 8 for persistence)
 export const MAX_RECENT_MODELS = 8;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,5 @@
 /**
- * Centralized logging utility for Node Banana
+ * Centralized logging utility for Big Box Studio
  *
  * Features:
  * - Session-based logging (one log file per workflow execution)


### PR DESCRIPTION
## Summary
Complete rebrand of the application from "Node Banana" to "Big Box Studio" with updated branding, color scheme, and external links.

## Key Changes

### Branding & Naming
- Updated project name in `package.json` and `package-lock.json` from "node-banana" to "bigbox-studio"
- Changed app title from "Node Banana - AI Image Workflow" to "Big Box Studio - AI Image Workflow"
- Updated all metadata and descriptions throughout the codebase

### Visual Design
- Replaced banana icon with "BB" logo mark (amber-500 rounded badge with bold text)
- Changed text handle color from blue (#3b82f6) to warm amber (#f59e0b) in CSS
- Updated hover states and edge selection colors to use amber theme
- Updated comments to reflect new color scheme ("warm amber" instead of "soft blue")

### External Links & Attribution
- Replaced "Made by Willie" Twitter link with "Big Box Creative" website link (https://bigboxcreative.africa)
- Removed Discord community link
- Updated all footer and quickstart view links to point to Big Box Creative website
- Changed link hover colors to amber theme

### Storage & Configuration
- Updated all localStorage keys from "node-banana-*" to "bigbox-studio-*" prefix
- Updated AI prompt templates to reference "Big Box Studio" instead of "Node Banana"

### Tests
- Updated all test cases to reflect new branding
- Updated test descriptions and assertions for new logo mark and links
- Removed tests for old social media links

## Implementation Details
- Maintained all functionality while updating branding
- Consistent color scheme change throughout (blue → amber)
- All localStorage keys updated to maintain data isolation between versions
- Updated both component code and test files for consistency

https://claude.ai/code/session_01H7SocNenYcm4xhQw2kRdtg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color scheme from blue to amber throughout the interface.

* **Chores**
  * Rebranded product name from "Node Banana" to "Big Box Studio."
  * Updated logo and branding assets.
  * Changed brand attribution links to bigboxcreative.africa.
  * Updated internal storage keys to reflect new branding.

* **Tests**
  * Updated test expectations to match new branding and visual changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->