### PR TITLE
fix: normalize directory path hostname prefix from macOS network volumes

### DIFF
--- a/src/app/api/browse-directory/__tests__/route.test.ts
+++ b/src/app/api/browse-directory/__tests__/route.test.ts
@@ -32,9 +32,14 @@ describe("normalizeSelectedPath", () => {
       .toBe("C:\\Users\\guy");
   });
 
-  it("should preserve Windows drive root", () => {
+  it("should preserve Windows drive root with backslash", () => {
     expect(normalizeSelectedPath("C:\\", "win32"))
       .toBe("C:\\");
+  });
+
+  it("should preserve Windows drive root with forward slash", () => {
+    expect(normalizeSelectedPath("C:/", "win32"))
+      .toBe("C:/");
   });
 
   it("should preserve Unix root /", () => {

--- a/src/app/api/browse-directory/route.ts
+++ b/src/app/api/browse-directory/route.ts
@@ -26,7 +26,7 @@ export function normalizeSelectedPath(selectedPath: string, platform: string): s
 
   // Remove trailing slash/backslash (except root paths like "/" or "C:\")
   if (selectedPath.length > 1 && (selectedPath.endsWith("/") || selectedPath.endsWith("\\"))) {
-    if (!(platform === "win32" && /^[A-Za-z]:\\$/.test(selectedPath))) {
+    if (!(platform === "win32" && /^[A-Za-z]:[\\\/]$/.test(selectedPath))) {
       selectedPath = selectedPath.slice(0, -1);
     }
   }

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -200,8 +200,8 @@ export function ProjectSetupModal({
     }
 
     const trimmedPath = directoryPath.trim();
-    if (!(trimmedPath.startsWith("/") || /^[A-Za-z]:/.test(trimmedPath))) {
-      setError("Project directory must be an absolute path (starting with / or a drive letter)");
+    if (!(trimmedPath.startsWith("/") || /^[A-Za-z]:[\\\/]/.test(trimmedPath) || trimmedPath.startsWith("\\\\"))) {
+      setError("Project directory must be an absolute path (starting with /, a drive letter, or a UNC path)");
       return;
     }
 

--- a/src/components/__tests__/ProjectSetupModal.test.tsx
+++ b/src/components/__tests__/ProjectSetupModal.test.tsx
@@ -407,7 +407,7 @@ describe("ProjectSetupModal", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("Project directory must be an absolute path (starting with / or a drive letter)")
+          screen.getByText("Project directory must be an absolute path (starting with /, a drive letter, or a UNC path)")
         ).toBeInTheDocument();
       });
       expect(onSave).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- **Server-side**: Extracts a `normalizeSelectedPath()` function in the browse-directory API route that strips hostname prefixes from paths returned by macOS `osascript` on network volumes (e.g. `AT-ALGKG9VR/Users/guy/Desktop` → `/Users/guy/Desktop`)
- **Client-side**: Adds an absolute path validation check in `ProjectSetupModal` before the directory validation API call, rejecting paths that don't start with `/` or a drive letter
- **Tests**: Adds 10 new tests — 9 for path normalization edge cases and 1 for the client-side validation guard

## Test plan

- [x] `npm run test:run` — all 43 tests pass (9 new path normalization + 1 new validation + 33 existing)
- [x] `npm run build` — no compilation errors
- [ ] Manual: on a Mac with a network-mounted home directory, use Browse to select a folder and verify the path is normalized correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-aware path normalization for selected directories and enforced absolute-path validation in the New Project flow.
  * Client-side validation now blocks invalid/relative paths early and shows clearer error messages.

* **Tests**
  * Added tests covering path normalization and validation across macOS, Linux, Windows and UNC/hostname-prefixed scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->