### PR TITLE
fix: set isRunning guard before async logger call

### DIFF
--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -882,11 +882,11 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
       return;
     }
 
-    // Start logging session
-    await logger.startSession();
-
     const isResuming = startFromNodeId === get().pausedAtNodeId;
     set({ isRunning: true, pausedAtNodeId: null });
+
+    // Start logging session
+    await logger.startSession();
 
     logger.info('workflow.start', 'Workflow execution started', {
       nodeCount: nodes.length,
@@ -1791,13 +1791,13 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
       return;
     }
 
+    set({ isRunning: true, currentNodeId: nodeId });
+
     await logger.startSession();
     logger.info('node.execution', 'Regenerating node', {
       nodeId,
       nodeType: node.type,
     });
-
-    set({ isRunning: true, currentNodeId: nodeId });
 
     try {
       if (node.type === "nanoBanana") {


### PR DESCRIPTION
## Summary
- Move `set({ isRunning: true })` before `await logger.startSession()` in both `executeWorkflow` and `regenerateNode` to prevent a second call from passing the `isRunning` guard during the async gap
- Add 4 integration tests verifying concurrent calls don't produce duplicate executions

## Test plan
- [x] All 1330 existing tests pass
- [x] New tests verify concurrent `executeWorkflow` calls only execute nodes once
- [x] New tests verify `isRunning` is set synchronously (no async gap)
- [x] New tests verify concurrent `regenerateNode` calls only execute once
- [x] New tests verify N disconnected nodes produce exactly N fetch calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for race condition prevention, verifying concurrent workflow execution handles simultaneous operations safely without duplicate executions.

* **Bug Fixes**
  * Enhanced workflow execution reliability by improving state initialization ordering during concurrent operations.
  * Improved synchronization of running state indicators during workflow execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->