### PR TITLE
feat: multi-project dashboard with autosave indicators

### DIFF
--- a/src/app/api/workflow-load/route.ts
+++ b/src/app/api/workflow-load/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+// POST: Load workflow JSON from disk by path
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { directoryPath, filename } = body;
+
+    if (!directoryPath || !filename) {
+      return NextResponse.json(
+        { success: false, error: "Missing required fields: directoryPath and filename" },
+        { status: 400 }
+      );
+    }
+
+    // Same sanitization as the save route
+    const safeName = filename.replace(/[^a-zA-Z0-9-_]/g, "_");
+    const filePath = path.join(directoryPath, `${safeName}.json`);
+
+    // Prevent path traversal
+    const resolvedDir = path.resolve(directoryPath);
+    const resolvedFile = path.resolve(filePath);
+    if (!resolvedFile.startsWith(resolvedDir)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid file path" },
+        { status: 400 }
+      );
+    }
+
+    const content = await fs.readFile(resolvedFile, "utf-8");
+    const workflow = JSON.parse(content);
+
+    return NextResponse.json({ success: true, workflow });
+  } catch (error) {
+    const isNotFound =
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT";
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: isNotFound
+          ? "Workflow file not found"
+          : error instanceof Error
+          ? error.message
+          : "Failed to load workflow",
+      },
+      { status: isNotFound ? 404 : 500 }
+    );
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -72,6 +72,7 @@ export function Header() {
     revertToSnapshot,
     shortcutsDialogOpen,
     setShortcutsDialogOpen,
+    setShowDashboard,
   } = useWorkflowStore();
 
   const [showProjectModal, setShowProjectModal] = useState(false);
@@ -222,6 +223,15 @@ export function Header() {
           <h1 className="text-2xl font-semibold text-neutral-100 tracking-tight">
             Node Banana
           </h1>
+          <button
+            onClick={() => setShowDashboard(true)}
+            className="p-1.5 text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800 rounded transition-colors"
+            title="Project dashboard"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+            </svg>
+          </button>
 
           <div className="flex items-center gap-2 ml-4 pl-4 border-l border-neutral-700">
             {isProjectConfigured ? (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -73,6 +73,7 @@ export function Header() {
     shortcutsDialogOpen,
     setShortcutsDialogOpen,
     setShowDashboard,
+    autoSaveEnabled,
   } = useWorkflowStore();
 
   const [showProjectModal, setShowProjectModal] = useState(false);
@@ -373,12 +374,18 @@ export function Header() {
             </button>
           )}
           <CommentsNavigationIcon />
-          <span className="text-neutral-400">
+          <span className="text-neutral-400 flex items-center gap-1.5">
             {isProjectConfigured ? (
               isSaving ? (
-                "Saving..."
+                <>
+                  <span className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse" />
+                  Saving...
+                </>
               ) : lastSavedAt ? (
-                `Saved ${formatTime(lastSavedAt)}`
+                <>
+                  {autoSaveEnabled && <span className="w-1.5 h-1.5 rounded-full bg-green-500" title="Auto-save enabled" />}
+                  Saved {formatTime(lastSavedAt)}
+                </>
               ) : (
                 "Not saved"
               )

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -56,6 +56,7 @@ import { detectAndSplitGrid } from "@/utils/gridSplitter";
 import { logger } from "@/utils/logger";
 import { WelcomeModal } from "./quickstart";
 import { ProjectSetupModal } from "./ProjectSetupModal";
+import { ProjectDashboard } from "./dashboard/ProjectDashboard";
 import { ChatPanel } from "./ChatPanel";
 import { EditOperation } from "@/lib/chat/editOperations";
 import { stripBinaryData } from "@/lib/chat/contextBuilder";
@@ -239,7 +240,7 @@ const findScrollableAncestor = (target: HTMLElement, deltaX: number, deltaY: num
 };
 
 export function WorkflowCanvas() {
-  const { nodes, edges, groups, onNodesChange, onEdgesChange, onConnect, addNode, updateNodeData, loadWorkflow, getNodeById, addToGlobalHistory, setNodeGroupId, executeWorkflow, isModalOpen, showQuickstart, setShowQuickstart, navigationTarget, setNavigationTarget, captureSnapshot, applyEditOperations, setWorkflowMetadata, canvasNavigationSettings, setShortcutsDialogOpen } =
+  const { nodes, edges, groups, onNodesChange, onEdgesChange, onConnect, addNode, updateNodeData, loadWorkflow, getNodeById, addToGlobalHistory, setNodeGroupId, executeWorkflow, isModalOpen, showQuickstart, setShowQuickstart, showDashboard, setShowDashboard, navigationTarget, setNavigationTarget, captureSnapshot, applyEditOperations, setWorkflowMetadata, canvasNavigationSettings, setShortcutsDialogOpen } =
     useWorkflowStore();
   const { screenToFlowPosition, getViewport, zoomIn, zoomOut, setViewport, setCenter } = useReactFlow();
   const { show: showToast } = useToast();
@@ -254,6 +255,13 @@ export function WorkflowCanvas() {
 
   // Detect if canvas is empty for showing quickstart
   const isCanvasEmpty = nodes.length === 0;
+
+  // Listen for dashboard:new-project event to open new project setup
+  useEffect(() => {
+    const handler = () => setShowNewProjectSetup(true);
+    window.addEventListener("dashboard:new-project", handler);
+    return () => window.removeEventListener("dashboard:new-project", handler);
+  }, []);
 
   // Handle comment navigation - center viewport on target node
   useEffect(() => {
@@ -1605,20 +1613,8 @@ export function WorkflowCanvas() {
         </div>
       )}
 
-      {/* Welcome Modal */}
-      {isCanvasEmpty && showQuickstart && (
-        <WelcomeModal
-          onWorkflowGenerated={async (workflow) => {
-            await loadWorkflow(workflow);
-            setShowQuickstart(false);
-          }}
-          onClose={() => setShowQuickstart(false)}
-          onNewProject={() => {
-            setShowQuickstart(false);
-            setShowNewProjectSetup(true);
-          }}
-        />
-      )}
+      {/* Project Dashboard */}
+      {showDashboard && <ProjectDashboard />}
 
       {/* New Project Setup Modal */}
       {showNewProjectSetup && (
@@ -1628,10 +1624,11 @@ export function WorkflowCanvas() {
           onSave={(id, name, directoryPath) => {
             setWorkflowMetadata(id, name, directoryPath);
             setShowNewProjectSetup(false);
+            setShowDashboard(false);
           }}
           onClose={() => {
             setShowNewProjectSetup(false);
-            setShowQuickstart(true);
+            setShowDashboard(true);
           }}
         />
       )}

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -1770,6 +1770,20 @@ export function WorkflowCanvas() {
       {/* Global image history */}
       <GlobalImageHistory />
 
+      {/* Floating projects button */}
+      {!showDashboard && (
+        <button
+          onClick={() => setShowDashboard(true)}
+          className="absolute bottom-4 left-14 z-20 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-300 bg-neutral-800 hover:bg-neutral-700 border border-neutral-700 rounded-lg shadow-lg transition-colors"
+          title="Open project dashboard"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+          </svg>
+          Projects
+        </button>
+      )}
+
       {/* Chat toggle button - hidden for now */}
 
       {/* Chat panel */}

--- a/src/components/dashboard/ProjectCard.tsx
+++ b/src/components/dashboard/ProjectCard.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import type { DashboardProject } from "@/store/utils/localStorage";
+
+function formatRelativeTime(timestamp: number | undefined | null): string {
+  if (!timestamp) return "Never saved";
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return "Just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+function formatCost(cost: number): string {
+  if (cost === 0) return "";
+  return `$${cost.toFixed(2)}`;
+}
+
+function truncatePath(dirPath: string, maxLen: number = 40): string {
+  if (dirPath.length <= maxLen) return dirPath;
+  const parts = dirPath.split("/");
+  if (parts.length <= 2) return "..." + dirPath.slice(-maxLen);
+  return ".../" + parts.slice(-2).join("/");
+}
+
+interface ProjectCardProps {
+  project: DashboardProject;
+  isCurrent: boolean;
+  onOpen: (workflowId: string) => void;
+  onDelete: (workflowId: string) => void;
+}
+
+export function ProjectCard({ project, isCurrent, onOpen, onDelete }: ProjectCardProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const handleDelete = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (showDeleteConfirm) {
+      onDelete(project.workflowId);
+      setShowDeleteConfirm(false);
+    } else {
+      setShowDeleteConfirm(true);
+    }
+  }, [showDeleteConfirm, onDelete, project.workflowId]);
+
+  const handleCancelDelete = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowDeleteConfirm(false);
+  }, []);
+
+  return (
+    <button
+      onClick={() => onOpen(project.workflowId)}
+      className={`group relative w-full text-left p-4 rounded-lg border transition-all duration-150 ${
+        isCurrent
+          ? "border-blue-500/50 bg-blue-500/10 hover:bg-blue-500/15"
+          : "border-neutral-700/50 hover:border-neutral-600 hover:bg-neutral-800/40"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-medium text-neutral-200 truncate">
+              {project.name}
+            </h3>
+            {isCurrent && (
+              <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide rounded bg-blue-500/20 text-blue-400">
+                Open
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-neutral-500 truncate mt-1" title={project.directoryPath}>
+            {truncatePath(project.directoryPath)}
+          </p>
+        </div>
+
+        {/* Delete button */}
+        <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+          {showDeleteConfirm ? (
+            <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+              <button
+                onClick={handleDelete}
+                className="px-2 py-1 text-[10px] font-medium text-red-400 bg-red-500/10 hover:bg-red-500/20 border border-red-500/30 rounded transition-colors"
+              >
+                Delete
+              </button>
+              <button
+                onClick={handleCancelDelete}
+                className="px-2 py-1 text-[10px] font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-700/50 hover:bg-neutral-700 border border-neutral-600 rounded transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleDelete}
+              className="p-1 text-neutral-500 hover:text-red-400 hover:bg-neutral-700/50 rounded transition-colors"
+              title="Delete project"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Meta row */}
+      <div className="flex items-center gap-3 mt-2.5 text-[11px] text-neutral-500">
+        <span>{formatRelativeTime(project.updatedAt ?? project.lastSavedAt)}</span>
+        {(project.nodeCount != null && project.nodeCount > 0) && (
+          <>
+            <span className="text-neutral-700">·</span>
+            <span>{project.nodeCount} nodes</span>
+          </>
+        )}
+        {project.incurredCost > 0 && (
+          <>
+            <span className="text-neutral-700">·</span>
+            <span>{formatCost(project.incurredCost)}</span>
+          </>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/src/components/dashboard/ProjectCard.tsx
+++ b/src/components/dashboard/ProjectCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import type { DashboardProject } from "@/store/utils/localStorage";
 
 function formatRelativeTime(timestamp: number | undefined | null): string {
@@ -21,12 +21,100 @@ function formatCost(cost: number): string {
   return `$${cost.toFixed(2)}`;
 }
 
-function truncatePath(dirPath: string, maxLen: number = 40): string {
+function truncatePath(dirPath: string, maxLen: number = 50): string {
   if (dirPath.length <= maxLen) return dirPath;
   const parts = dirPath.split("/");
   if (parts.length <= 2) return "..." + dirPath.slice(-maxLen);
   return ".../" + parts.slice(-2).join("/");
 }
+
+// Derive a "workflow type" label from the node composition
+function deriveWorkflowType(summary?: Record<string, number>): { label: string; color: string } | null {
+  if (!summary) return null;
+  const has = (k: string) => (summary[k] ?? 0) > 0;
+
+  if (has("generateVideo")) return { label: "Video", color: "text-purple-400 bg-purple-500/15 border-purple-500/20" };
+  if (has("generate3d")) return { label: "3D", color: "text-orange-400 bg-orange-500/15 border-orange-500/20" };
+  if (has("generateAudio")) return { label: "Audio", color: "text-green-400 bg-green-500/15 border-green-500/20" };
+  if (has("nanoBanana")) return { label: "Image Gen", color: "text-yellow-400 bg-yellow-500/15 border-yellow-500/20" };
+  if (has("llmGenerate")) return { label: "LLM", color: "text-blue-400 bg-blue-500/15 border-blue-500/20" };
+  if (has("annotation")) return { label: "Annotation", color: "text-cyan-400 bg-cyan-500/15 border-cyan-500/20" };
+  return null;
+}
+
+// Small node-type icon pills
+const NODE_TYPE_ICONS: Record<string, { label: string; icon: React.ReactNode }> = {
+  nanoBanana: {
+    label: "Generate",
+    icon: (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+      </svg>
+    ),
+  },
+  generateVideo: {
+    label: "Video",
+    icon: (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z" />
+      </svg>
+    ),
+  },
+  llmGenerate: {
+    label: "LLM",
+    icon: (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+      </svg>
+    ),
+  },
+  prompt: {
+    label: "Prompts",
+    icon: (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+      </svg>
+    ),
+  },
+  imageInput: {
+    label: "Images",
+    icon: (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75Z" />
+      </svg>
+    ),
+  },
+  annotation: {
+    label: "Draw",
+    icon: (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Z" />
+      </svg>
+    ),
+  },
+  generateAudio: {
+    label: "Audio",
+    icon: (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.114 5.636a9 9 0 0 1 0 12.728M16.463 8.288a5.25 5.25 0 0 1 0 7.424M6.75 8.25l4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.009 9.009 0 0 1 2.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75Z" />
+      </svg>
+    ),
+  },
+  generate3d: {
+    label: "3D",
+    icon: (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
+      </svg>
+    ),
+  },
+};
+
+// Ordered by visual priority
+const NODE_TYPE_DISPLAY_ORDER = [
+  "nanoBanana", "generateVideo", "generate3d", "generateAudio",
+  "llmGenerate", "annotation", "prompt", "imageInput",
+];
 
 interface ProjectCardProps {
   project: DashboardProject;
@@ -53,45 +141,66 @@ export function ProjectCard({ project, isCurrent, onOpen, onDelete }: ProjectCar
     setShowDeleteConfirm(false);
   }, []);
 
+  const workflowType = useMemo(
+    () => deriveWorkflowType(project.nodeTypeSummary),
+    [project.nodeTypeSummary]
+  );
+
+  // Get node type pills to show (top 4 by display order)
+  const nodeTypePills = useMemo(() => {
+    if (!project.nodeTypeSummary) return [];
+    return NODE_TYPE_DISPLAY_ORDER
+      .filter((t) => (project.nodeTypeSummary![t] ?? 0) > 0)
+      .slice(0, 4)
+      .map((t) => ({
+        type: t,
+        count: project.nodeTypeSummary![t],
+        ...NODE_TYPE_ICONS[t],
+      }));
+  }, [project.nodeTypeSummary]);
+
   return (
     <button
       onClick={() => onOpen(project.workflowId)}
-      className={`group relative w-full text-left p-4 rounded-lg border transition-all duration-150 ${
+      className={`group relative w-full text-left p-5 rounded-xl border transition-all duration-150 ${
         isCurrent
-          ? "border-blue-500/50 bg-blue-500/10 hover:bg-blue-500/15"
-          : "border-neutral-700/50 hover:border-neutral-600 hover:bg-neutral-800/40"
+          ? "border-blue-500/40 bg-blue-500/[0.07] hover:bg-blue-500/[0.12] shadow-[0_0_0_1px_rgba(59,130,246,0.1)]"
+          : "border-neutral-700/50 hover:border-neutral-600 hover:bg-neutral-750/50"
       }`}
     >
+      {/* Top row: name + badges + delete */}
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h3 className="text-sm font-medium text-neutral-200 truncate">
+          <div className="flex items-center gap-2.5">
+            <h3 className="text-[15px] font-medium text-neutral-100 truncate">
               {project.name}
             </h3>
             {isCurrent && (
-              <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide rounded bg-blue-500/20 text-blue-400">
-                Open
+              <span className="flex-shrink-0 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded-full bg-blue-500/20 text-blue-400 border border-blue-500/20">
+                Active
+              </span>
+            )}
+            {workflowType && (
+              <span className={`flex-shrink-0 px-2 py-0.5 text-[10px] font-medium rounded-full border ${workflowType.color}`}>
+                {workflowType.label}
               </span>
             )}
           </div>
-          <p className="text-xs text-neutral-500 truncate mt-1" title={project.directoryPath}>
-            {truncatePath(project.directoryPath)}
-          </p>
         </div>
 
         {/* Delete button */}
         <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
           {showDeleteConfirm ? (
-            <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
               <button
                 onClick={handleDelete}
-                className="px-2 py-1 text-[10px] font-medium text-red-400 bg-red-500/10 hover:bg-red-500/20 border border-red-500/30 rounded transition-colors"
+                className="px-2.5 py-1 text-[11px] font-medium text-red-400 bg-red-500/10 hover:bg-red-500/20 border border-red-500/30 rounded-md transition-colors"
               >
                 Delete
               </button>
               <button
                 onClick={handleCancelDelete}
-                className="px-2 py-1 text-[10px] font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-700/50 hover:bg-neutral-700 border border-neutral-600 rounded transition-colors"
+                className="px-2.5 py-1 text-[11px] font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-700/50 hover:bg-neutral-700 border border-neutral-600 rounded-md transition-colors"
               >
                 Cancel
               </button>
@@ -99,10 +208,10 @@ export function ProjectCard({ project, isCurrent, onOpen, onDelete }: ProjectCar
           ) : (
             <button
               onClick={handleDelete}
-              className="p-1 text-neutral-500 hover:text-red-400 hover:bg-neutral-700/50 rounded transition-colors"
+              className="p-1.5 text-neutral-500 hover:text-red-400 hover:bg-red-500/10 rounded-md transition-colors"
               title="Delete project"
             >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
               </svg>
             </button>
@@ -110,19 +219,61 @@ export function ProjectCard({ project, isCurrent, onOpen, onDelete }: ProjectCar
         </div>
       </div>
 
-      {/* Meta row */}
-      <div className="flex items-center gap-3 mt-2.5 text-[11px] text-neutral-500">
-        <span>{formatRelativeTime(project.updatedAt ?? project.lastSavedAt)}</span>
+      {/* Path row */}
+      <p className="text-xs text-neutral-500 truncate mt-1.5" title={project.directoryPath}>
+        {truncatePath(project.directoryPath)}
+      </p>
+
+      {/* Node type pills */}
+      {nodeTypePills.length > 0 && (
+        <div className="flex items-center gap-1.5 mt-3 flex-wrap">
+          {nodeTypePills.map((pill) => (
+            <span
+              key={pill.type}
+              className="inline-flex items-center gap-1 px-2 py-0.5 text-[11px] text-neutral-400 bg-neutral-700/40 rounded-md border border-neutral-700/30"
+            >
+              {pill.icon}
+              {pill.count > 1 ? `${pill.label} x${pill.count}` : pill.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Bottom meta row */}
+      <div className="flex items-center gap-3 mt-3 text-xs text-neutral-500">
+        {/* Time */}
+        <span className="flex items-center gap-1">
+          <svg className="w-3 h-3 text-neutral-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+          </svg>
+          {formatRelativeTime(project.updatedAt ?? project.lastSavedAt)}
+        </span>
+
         {(project.nodeCount != null && project.nodeCount > 0) && (
           <>
             <span className="text-neutral-700">·</span>
             <span>{project.nodeCount} nodes</span>
           </>
         )}
+
+        {(project.edgeCount != null && project.edgeCount > 0) && (
+          <>
+            <span className="text-neutral-700">·</span>
+            <span>{project.edgeCount} connections</span>
+          </>
+        )}
+
+        {project.primaryModel && (
+          <>
+            <span className="text-neutral-700">·</span>
+            <span className="text-neutral-400">{project.primaryModel}</span>
+          </>
+        )}
+
         {project.incurredCost > 0 && (
           <>
             <span className="text-neutral-700">·</span>
-            <span>{formatCost(project.incurredCost)}</span>
+            <span className="text-green-500/80">{formatCost(project.incurredCost)}</span>
           </>
         )}
       </div>

--- a/src/components/dashboard/ProjectDashboard.tsx
+++ b/src/components/dashboard/ProjectDashboard.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState, useCallback, useRef, useMemo } from "react";
+import { useWorkflowStore, WorkflowFile } from "@/store/workflowStore";
+import { getAllProjectsForDashboard } from "@/store/utils/localStorage";
+import { ProjectCard } from "./ProjectCard";
+import { TemplateExplorerView } from "../quickstart/TemplateExplorerView";
+import { PromptWorkflowView } from "../quickstart/PromptWorkflowView";
+
+type DashboardView = "main" | "templates" | "vibe";
+
+export function ProjectDashboard() {
+  const {
+    workflowId: currentWorkflowId,
+    hasUnsavedChanges,
+    setShowDashboard,
+    openProject,
+    deleteProject,
+    loadWorkflow,
+    setShowQuickstart,
+  } = useWorkflowStore();
+
+  const [view, setView] = useState<DashboardView>("main");
+  const [refreshKey, setRefreshKey] = useState(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const projects = useMemo(
+    () => getAllProjectsForDashboard(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [refreshKey]
+  );
+
+  const confirmUnsavedChanges = useCallback((): boolean => {
+    if (!hasUnsavedChanges) return true;
+    return window.confirm(
+      "You have unsaved changes. Are you sure you want to switch projects? Your unsaved changes will be lost."
+    );
+  }, [hasUnsavedChanges]);
+
+  const handleOpenProject = useCallback(
+    async (wfId: string) => {
+      // If it's the already-loaded project, just close dashboard
+      if (wfId === currentWorkflowId) {
+        setShowDashboard(false);
+        return;
+      }
+      if (!confirmUnsavedChanges()) return;
+      await openProject(wfId);
+    },
+    [currentWorkflowId, confirmUnsavedChanges, openProject, setShowDashboard]
+  );
+
+  const handleDeleteProject = useCallback(
+    (wfId: string) => {
+      deleteProject(wfId);
+      setRefreshKey((k) => k + 1);
+    },
+    [deleteProject]
+  );
+
+  const handleNewProject = useCallback(() => {
+    if (!confirmUnsavedChanges()) return;
+    setShowDashboard(false);
+    setShowQuickstart(false);
+    // Open the new project setup modal — this is triggered via WorkflowCanvas
+    // by closing the dashboard with no project loaded
+    useWorkflowStore.getState().clearWorkflow();
+    // Dispatch a custom event that WorkflowCanvas listens for
+    window.dispatchEvent(new CustomEvent("dashboard:new-project"));
+  }, [confirmUnsavedChanges, setShowDashboard, setShowQuickstart]);
+
+  const handleLoadFile = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      if (!confirmUnsavedChanges()) {
+        e.target.value = "";
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = async (event) => {
+        try {
+          const workflow = JSON.parse(event.target?.result as string) as WorkflowFile;
+          if (workflow.version && workflow.nodes && workflow.edges) {
+            await loadWorkflow(workflow);
+            setShowDashboard(false);
+          } else {
+            alert("Invalid workflow file format");
+          }
+        } catch {
+          alert("Failed to parse workflow file");
+        }
+      };
+      reader.readAsText(file);
+      e.target.value = "";
+    },
+    [confirmUnsavedChanges, loadWorkflow, setShowDashboard]
+  );
+
+  const handleWorkflowGenerated = useCallback(
+    async (workflow: WorkflowFile) => {
+      await loadWorkflow(workflow);
+      setShowDashboard(false);
+    },
+    [loadWorkflow, setShowDashboard]
+  );
+
+  const dialogWidth = view === "templates" ? "max-w-6xl" : "max-w-3xl";
+  const dialogHeight = view === "templates" ? "max-h-[85vh]" : "max-h-[80vh]";
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onWheelCapture={(e) => e.stopPropagation()}
+    >
+      <div
+        className={`w-full ${dialogWidth} mx-4 bg-neutral-800 rounded-xl border border-neutral-700 shadow-2xl overflow-clip ${dialogHeight} flex flex-col`}
+      >
+        {view === "templates" && (
+          <TemplateExplorerView
+            onBack={() => setView("main")}
+            onWorkflowSelected={handleWorkflowGenerated}
+          />
+        )}
+        {view === "vibe" && (
+          <PromptWorkflowView
+            onBack={() => setView("main")}
+            onWorkflowGenerated={handleWorkflowGenerated}
+          />
+        )}
+        {view === "main" && (
+          <div className="flex h-full max-h-[80vh]">
+            {/* Left column — Info */}
+            <div className="w-56 flex-shrink-0 flex flex-col p-6 border-r border-neutral-700/50">
+              <div className="mb-4">
+                <div className="flex items-center gap-2">
+                  <img src="/banana_icon.png" alt="" className="w-7 h-7" />
+                  <h1 className="text-xl font-medium text-neutral-100">
+                    Node Banana
+                  </h1>
+                </div>
+              </div>
+              <p className="text-xs text-neutral-400 leading-relaxed mb-6">
+                A node based workflow editor for AI image generation.
+              </p>
+
+              <div className="flex flex-col gap-2.5 mt-auto">
+                <a
+                  href="https://node-banana-docs.vercel.app/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+                  </svg>
+                  Docs
+                </a>
+                <a
+                  href="https://discord.com/invite/89Nr6EKkTf"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z" />
+                  </svg>
+                  Discord
+                </a>
+                <a
+                  href="https://x.com/ReflctWillie"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                  </svg>
+                  Willie
+                </a>
+              </div>
+            </div>
+
+            {/* Right column — Projects + actions */}
+            <div className="flex-1 flex flex-col min-w-0 p-6">
+              {/* Action buttons row */}
+              <div className="flex items-center gap-2 mb-4">
+                <button
+                  onClick={handleNewProject}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-200 bg-neutral-700/50 hover:bg-neutral-700 border border-neutral-600 rounded-md transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                  </svg>
+                  New Project
+                </button>
+                <button
+                  onClick={handleLoadFile}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-800/50 hover:bg-neutral-700/50 border border-neutral-700/50 rounded-md transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
+                  </svg>
+                  Load File
+                </button>
+                <button
+                  onClick={() => setView("templates")}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-800/50 hover:bg-neutral-700/50 border border-neutral-700/50 rounded-md transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+                  </svg>
+                  Templates
+                </button>
+                <button
+                  onClick={() => setView("vibe")}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-800/50 hover:bg-neutral-700/50 border border-neutral-700/50 rounded-md transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
+                  </svg>
+                  Prompt
+                  <span className="px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide rounded bg-blue-500/20 text-blue-400">
+                    Beta
+                  </span>
+                </button>
+
+                {/* Close button (when there's a current project to return to) */}
+                {currentWorkflowId && (
+                  <button
+                    onClick={() => setShowDashboard(false)}
+                    className="ml-auto p-1.5 text-neutral-400 hover:text-neutral-200 hover:bg-neutral-700/50 rounded transition-colors"
+                    title="Close dashboard"
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+
+              {/* Projects list */}
+              <div className="flex-1 overflow-y-auto min-h-0">
+                {projects.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center h-full text-center py-12">
+                    <svg className="w-10 h-10 text-neutral-600 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
+                    </svg>
+                    <p className="text-sm text-neutral-400 mb-1">No projects yet</p>
+                    <p className="text-xs text-neutral-500">
+                      Create a new project or load an existing workflow file to get started.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    <p className="text-xs text-neutral-500 mb-1">
+                      {projects.length} project{projects.length !== 1 ? "s" : ""}
+                    </p>
+                    {projects.map((project) => (
+                      <ProjectCard
+                        key={project.workflowId}
+                        project={project}
+                        isCurrent={project.workflowId === currentWorkflowId}
+                        onOpen={handleOpenProject}
+                        onDelete={handleDeleteProject}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Hidden file input for loading workflows */}
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleFileChange}
+        accept=".json"
+        className="hidden"
+      />
+    </div>
+  );
+}

--- a/src/components/dashboard/ProjectDashboard.tsx
+++ b/src/components/dashboard/ProjectDashboard.tsx
@@ -39,7 +39,6 @@ export function ProjectDashboard() {
 
   const handleOpenProject = useCallback(
     async (wfId: string) => {
-      // If it's the already-loaded project, just close dashboard
       if (wfId === currentWorkflowId) {
         setShowDashboard(false);
         return;
@@ -62,10 +61,7 @@ export function ProjectDashboard() {
     if (!confirmUnsavedChanges()) return;
     setShowDashboard(false);
     setShowQuickstart(false);
-    // Open the new project setup modal — this is triggered via WorkflowCanvas
-    // by closing the dashboard with no project loaded
     useWorkflowStore.getState().clearWorkflow();
-    // Dispatch a custom event that WorkflowCanvas listens for
     window.dispatchEvent(new CustomEvent("dashboard:new-project"));
   }, [confirmUnsavedChanges, setShowDashboard, setShowQuickstart]);
 
@@ -110,16 +106,17 @@ export function ProjectDashboard() {
     [loadWorkflow, setShowDashboard]
   );
 
-  const dialogWidth = view === "templates" ? "max-w-6xl" : "max-w-3xl";
-  const dialogHeight = view === "templates" ? "max-h-[85vh]" : "max-h-[80vh]";
+  const dialogWidth = view === "templates" ? "max-w-6xl" : "max-w-5xl";
+  const dialogHeight = view === "templates" ? "max-h-[85vh]" : "max-h-[85vh]";
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
       onWheelCapture={(e) => e.stopPropagation()}
     >
       <div
-        className={`w-full ${dialogWidth} mx-4 bg-neutral-800 rounded-xl border border-neutral-700 shadow-2xl overflow-clip ${dialogHeight} flex flex-col`}
+        className={`w-full ${dialogWidth} mx-4 bg-neutral-850 rounded-2xl border border-neutral-700/80 shadow-2xl overflow-clip ${dialogHeight} flex flex-col`}
+        style={{ backgroundColor: "rgb(28, 28, 30)" }}
       >
         {view === "templates" && (
           <TemplateExplorerView
@@ -134,133 +131,155 @@ export function ProjectDashboard() {
           />
         )}
         {view === "main" && (
-          <div className="flex h-full max-h-[80vh]">
-            {/* Left column — Info */}
-            <div className="w-56 flex-shrink-0 flex flex-col p-6 border-r border-neutral-700/50">
-              <div className="mb-4">
-                <div className="flex items-center gap-2">
-                  <img src="/banana_icon.png" alt="" className="w-7 h-7" />
-                  <h1 className="text-xl font-medium text-neutral-100">
+          <div className="flex h-full max-h-[85vh]">
+            {/* Left column — Branding + links */}
+            <div className="w-64 flex-shrink-0 flex flex-col p-8 border-r border-neutral-700/40 bg-neutral-900/40">
+              <div className="mb-5">
+                <div className="flex items-center gap-2.5">
+                  <img src="/banana_icon.png" alt="" className="w-8 h-8" />
+                  <h1 className="text-2xl font-semibold text-neutral-100 tracking-tight">
                     Node Banana
                   </h1>
                 </div>
               </div>
-              <p className="text-xs text-neutral-400 leading-relaxed mb-6">
-                A node based workflow editor for AI image generation.
+              <p className="text-sm text-neutral-400 leading-relaxed mb-8">
+                A node based workflow editor for AI image generation. Connect nodes to build pipelines.
               </p>
 
-              <div className="flex flex-col gap-2.5 mt-auto">
+              {/* Quick stats */}
+              {projects.length > 0 && (
+                <div className="mb-8 p-3.5 rounded-lg bg-neutral-800/50 border border-neutral-700/30">
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <p className="text-lg font-semibold text-neutral-200">{projects.length}</p>
+                      <p className="text-[11px] text-neutral-500">Projects</p>
+                    </div>
+                    <div>
+                      <p className="text-lg font-semibold text-neutral-200">
+                        {projects.reduce((sum, p) => sum + (p.nodeCount ?? 0), 0)}
+                      </p>
+                      <p className="text-[11px] text-neutral-500">Total Nodes</p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              <div className="flex flex-col gap-3 mt-auto">
                 <a
                   href="https://node-banana-docs.vercel.app/"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-2 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
+                  className="flex items-center gap-2.5 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
                 >
-                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
                   </svg>
-                  Docs
+                  Documentation
                 </a>
                 <a
                   href="https://discord.com/invite/89Nr6EKkTf"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-2 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
+                  className="flex items-center gap-2.5 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
                 >
-                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z" />
                   </svg>
-                  Discord
+                  Discord Community
                 </a>
                 <a
                   href="https://x.com/ReflctWillie"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-2 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
+                  className="flex items-center gap-2.5 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
                 >
-                  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
                   </svg>
-                  Willie
+                  Made by Willie
                 </a>
               </div>
             </div>
 
             {/* Right column — Projects + actions */}
-            <div className="flex-1 flex flex-col min-w-0 p-6">
+            <div className="flex-1 flex flex-col min-w-0 p-8">
+              {/* Header with title + close */}
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-lg font-medium text-neutral-200">Your Projects</h2>
+                {currentWorkflowId && (
+                  <button
+                    onClick={() => setShowDashboard(false)}
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-800/50 hover:bg-neutral-700/50 border border-neutral-700/50 rounded-lg transition-colors"
+                    title="Return to current project"
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
+                    </svg>
+                    Back to project
+                  </button>
+                )}
+              </div>
+
               {/* Action buttons row */}
-              <div className="flex items-center gap-2 mb-4">
+              <div className="flex items-center gap-2 mb-5">
                 <button
                   onClick={handleNewProject}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-200 bg-neutral-700/50 hover:bg-neutral-700 border border-neutral-600 rounded-md transition-colors"
+                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-100 bg-blue-600/90 hover:bg-blue-600 rounded-lg transition-colors shadow-sm"
                 >
-                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
                   </svg>
                   New Project
                 </button>
                 <button
                   onClick={handleLoadFile}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-800/50 hover:bg-neutral-700/50 border border-neutral-700/50 rounded-md transition-colors"
+                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-300 hover:text-neutral-100 bg-neutral-800/80 hover:bg-neutral-700/80 border border-neutral-700/50 rounded-lg transition-colors"
                 >
-                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
                   </svg>
                   Load File
                 </button>
+                <div className="w-px h-5 bg-neutral-700/50 mx-1" />
                 <button
                   onClick={() => setView("templates")}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-800/50 hover:bg-neutral-700/50 border border-neutral-700/50 rounded-md transition-colors"
+                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-300 hover:text-neutral-100 bg-neutral-800/80 hover:bg-neutral-700/80 border border-neutral-700/50 rounded-lg transition-colors"
                 >
-                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
                   </svg>
                   Templates
                 </button>
                 <button
                   onClick={() => setView("vibe")}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-neutral-200 bg-neutral-800/50 hover:bg-neutral-700/50 border border-neutral-700/50 rounded-md transition-colors"
+                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-neutral-300 hover:text-neutral-100 bg-neutral-800/80 hover:bg-neutral-700/80 border border-neutral-700/50 rounded-lg transition-colors"
                 >
-                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
                   </svg>
                   Prompt
-                  <span className="px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide rounded bg-blue-500/20 text-blue-400">
+                  <span className="px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider rounded-full bg-blue-500/20 text-blue-400 border border-blue-500/20">
                     Beta
                   </span>
                 </button>
-
-                {/* Close button (when there's a current project to return to) */}
-                {currentWorkflowId && (
-                  <button
-                    onClick={() => setShowDashboard(false)}
-                    className="ml-auto p-1.5 text-neutral-400 hover:text-neutral-200 hover:bg-neutral-700/50 rounded transition-colors"
-                    title="Close dashboard"
-                  >
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
-                )}
               </div>
 
               {/* Projects list */}
-              <div className="flex-1 overflow-y-auto min-h-0">
+              <div className="flex-1 overflow-y-auto min-h-0 -mx-1 px-1">
                 {projects.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center h-full text-center py-12">
-                    <svg className="w-10 h-10 text-neutral-600 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
-                    </svg>
-                    <p className="text-sm text-neutral-400 mb-1">No projects yet</p>
-                    <p className="text-xs text-neutral-500">
-                      Create a new project or load an existing workflow file to get started.
+                  <div className="flex flex-col items-center justify-center h-full text-center py-16">
+                    <div className="w-16 h-16 rounded-2xl bg-neutral-800/50 border border-neutral-700/30 flex items-center justify-center mb-4">
+                      <svg className="w-8 h-8 text-neutral-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
+                      </svg>
+                    </div>
+                    <p className="text-sm font-medium text-neutral-300 mb-1.5">No projects yet</p>
+                    <p className="text-xs text-neutral-500 max-w-xs leading-relaxed">
+                      Create a new project, load an existing workflow file, or start from a template to get going.
                     </p>
                   </div>
                 ) : (
-                  <div className="flex flex-col gap-2">
-                    <p className="text-xs text-neutral-500 mb-1">
-                      {projects.length} project{projects.length !== 1 ? "s" : ""}
-                    </p>
+                  <div className="flex flex-col gap-2.5">
                     {projects.map((project) => (
                       <ProjectCard
                         key={project.workflowId}

--- a/src/store/utils/localStorage.ts
+++ b/src/store/utils/localStorage.ts
@@ -60,8 +60,66 @@ export const loadSaveConfigs = (): Record<string, WorkflowSaveConfig> => {
 export const saveSaveConfig = (config: WorkflowSaveConfig): void => {
   if (typeof window === "undefined") return;
   const configs = loadSaveConfigs();
-  configs[config.workflowId] = config;
+  const existing = configs[config.workflowId];
+  const now = Date.now();
+  configs[config.workflowId] = {
+    ...config,
+    createdAt: config.createdAt ?? existing?.createdAt ?? now,
+    updatedAt: now,
+  };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(configs));
+};
+
+export const deleteSaveConfig = (workflowId: string): void => {
+  if (typeof window === "undefined") return;
+  const configs = loadSaveConfigs();
+  delete configs[workflowId];
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(configs));
+  // Clean up cost data
+  const costStored = localStorage.getItem(COST_DATA_STORAGE_KEY);
+  if (costStored) {
+    try {
+      const allCosts: Record<string, WorkflowCostData> = JSON.parse(costStored);
+      delete allCosts[workflowId];
+      localStorage.setItem(COST_DATA_STORAGE_KEY, JSON.stringify(allCosts));
+    } catch { /* ignore */ }
+  }
+};
+
+export interface DashboardProject {
+  workflowId: string;
+  name: string;
+  directoryPath: string;
+  lastSavedAt: number | null;
+  createdAt?: number;
+  updatedAt?: number;
+  nodeCount?: number;
+  edgeCount?: number;
+  incurredCost: number;
+}
+
+export const getAllProjectsForDashboard = (): DashboardProject[] => {
+  if (typeof window === "undefined") return [];
+  const configs = loadSaveConfigs();
+  let allCosts: Record<string, WorkflowCostData> = {};
+  const costStored = localStorage.getItem(COST_DATA_STORAGE_KEY);
+  if (costStored) {
+    try { allCosts = JSON.parse(costStored); } catch { /* ignore */ }
+  }
+
+  return Object.values(configs)
+    .map((config) => ({
+      workflowId: config.workflowId,
+      name: config.name,
+      directoryPath: config.directoryPath,
+      lastSavedAt: config.lastSavedAt,
+      createdAt: config.createdAt,
+      updatedAt: config.updatedAt,
+      nodeCount: config.nodeCount,
+      edgeCount: config.edgeCount,
+      incurredCost: allCosts[config.workflowId]?.incurredCost ?? 0,
+    }))
+    .sort((a, b) => (b.updatedAt ?? b.lastSavedAt ?? 0) - (a.updatedAt ?? a.lastSavedAt ?? 0));
 };
 
 // Cost data helpers

--- a/src/store/utils/localStorage.ts
+++ b/src/store/utils/localStorage.ts
@@ -95,6 +95,8 @@ export interface DashboardProject {
   updatedAt?: number;
   nodeCount?: number;
   edgeCount?: number;
+  nodeTypeSummary?: Record<string, number>;
+  primaryModel?: string;
   incurredCost: number;
 }
 
@@ -117,6 +119,8 @@ export const getAllProjectsForDashboard = (): DashboardProject[] => {
       updatedAt: config.updatedAt,
       nodeCount: config.nodeCount,
       edgeCount: config.edgeCount,
+      nodeTypeSummary: config.nodeTypeSummary,
+      primaryModel: config.primaryModel,
       incurredCost: allCosts[config.workflowId]?.incurredCost ?? 0,
     }))
     .sort((a, b) => (b.updatedAt ?? b.lastSavedAt ?? 0) - (a.updatedAt ?? a.lastSavedAt ?? 0));

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -31,6 +31,7 @@ import { EditOperation, applyEditOperations as executeEditOps } from "@/lib/chat
 import {
   loadSaveConfigs,
   saveSaveConfig,
+  deleteSaveConfig,
   loadWorkflowCostData,
   saveWorkflowCostData,
   getProviderSettings,
@@ -209,9 +210,15 @@ interface WorkflowStore {
   openModalCount: number;
   isModalOpen: boolean;
   showQuickstart: boolean;
+  showDashboard: boolean;
   incrementModalCount: () => void;
   decrementModalCount: () => void;
   setShowQuickstart: (show: boolean) => void;
+  setShowDashboard: (show: boolean) => void;
+
+  // Dashboard actions
+  openProject: (workflowId: string) => Promise<void>;
+  deleteProject: (workflowId: string) => void;
 
   // Execution
   isRunning: boolean;
@@ -378,6 +385,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   openModalCount: 0,
   isModalOpen: false,
   showQuickstart: true,
+  showDashboard: true,
   isRunning: false,
   currentNodeIds: [],  // Changed from currentNodeId for parallel execution
   pausedAtNodeId: null,
@@ -445,6 +453,47 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
 
   setShowQuickstart: (show: boolean) => {
     set({ showQuickstart: show });
+  },
+
+  setShowDashboard: (show: boolean) => {
+    set({ showDashboard: show });
+  },
+
+  openProject: async (workflowId: string) => {
+    const configs = loadSaveConfigs();
+    const config = configs[workflowId];
+    if (!config) return;
+
+    try {
+      const response = await fetch("/api/workflow-load", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          directoryPath: config.directoryPath,
+          filename: config.name,
+        }),
+      });
+      const result = await response.json();
+      if (result.success && result.workflow) {
+        await get().loadWorkflow(result.workflow, config.directoryPath);
+        set({ showDashboard: false, showQuickstart: false });
+      } else {
+        useToast.getState().show(`Failed to load project: ${result.error || "Unknown error"}`, "error");
+      }
+    } catch (error) {
+      useToast.getState().show(
+        `Failed to load project: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "error"
+      );
+    }
+  },
+
+  deleteProject: (workflowId: string) => {
+    deleteSaveConfig(workflowId);
+    // If the deleted project is currently loaded, clear it
+    if (get().workflowId === workflowId) {
+      get().clearWorkflow();
+    }
   },
 
   addNode: (type: NodeType, position: XYPosition, initialData?: Partial<WorkflowNodeData>) => {
@@ -1814,6 +1863,8 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
           generationsPath: get().generationsPath,
           lastSavedAt: timestamp,
           useExternalImageStorage,
+          nodeCount: get().nodes.length,
+          edgeCount: get().edges.length,
         });
 
         return true;

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -1855,6 +1855,23 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
           });
         }
 
+        // Compute summary metadata for dashboard
+        const currentNodesSnap = get().nodes;
+        const nodeTypeSummary: Record<string, number> = {};
+        let primaryModel: string | undefined;
+        const modelCounts: Record<string, number> = {};
+        for (const node of currentNodesSnap) {
+          const t = node.type || "unknown";
+          nodeTypeSummary[t] = (nodeTypeSummary[t] || 0) + 1;
+          const data = node.data as Record<string, unknown>;
+          const sel = data.selectedModel as { displayName?: string } | undefined;
+          if (sel?.displayName) {
+            modelCounts[sel.displayName] = (modelCounts[sel.displayName] || 0) + 1;
+          }
+        }
+        const topModel = Object.entries(modelCounts).sort((a, b) => b[1] - a[1])[0];
+        if (topModel) primaryModel = topModel[0];
+
         // Update localStorage
         saveSaveConfig({
           workflowId,
@@ -1863,8 +1880,10 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
           generationsPath: get().generationsPath,
           lastSavedAt: timestamp,
           useExternalImageStorage,
-          nodeCount: get().nodes.length,
+          nodeCount: currentNodesSnap.length,
           edgeCount: get().edges.length,
+          nodeTypeSummary,
+          primaryModel,
         });
 
         return true;

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -24,6 +24,10 @@ export interface WorkflowSaveConfig {
   generationsPath: string | null;
   lastSavedAt: number | null;
   useExternalImageStorage?: boolean;  // Whether to store images as files vs embedded base64
+  createdAt?: number;       // Set on first save
+  updatedAt?: number;       // Set on every save
+  nodeCount?: number;       // Snapshot at save time
+  edgeCount?: number;       // Snapshot at save time
 }
 
 // Cost tracking data stored per-workflow in localStorage

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -28,6 +28,8 @@ export interface WorkflowSaveConfig {
   updatedAt?: number;       // Set on every save
   nodeCount?: number;       // Snapshot at save time
   edgeCount?: number;       // Snapshot at save time
+  nodeTypeSummary?: Record<string, number>;  // e.g. { nanoBanana: 2, prompt: 3 }
+  primaryModel?: string;    // Display name of most-used generation model
 }
 
 // Cost tracking data stored per-workflow in localStorage


### PR DESCRIPTION
## Summary

- **Multi-project dashboard** — full-screen overlay replacing the old WelcomeModal/quickstart, showing all saved projects with the ability to open, create, delete, and switch between them
- **Rich project cards** — each card shows project name, workflow type badge (Image Gen, Video, 3D, Audio, LLM), node type pills with icons, primary model, node/edge counts, cost, and relative time
- **Dashboard access from anywhere** — grid icon in the header + floating "Projects" button on the canvas bottom-left
- **Autosave visual indicators** — green dot when auto-save is active, yellow pulsing dot while saving
- **New API route** `/api/workflow-load` to load workflow JSON from disk by path (enables opening projects from the dashboard)
- **Extended `WorkflowSaveConfig`** with `createdAt`, `updatedAt`, `nodeCount`, `edgeCount`, `nodeTypeSummary`, `primaryModel` metadata — all computed automatically on each save

### Files changed (8 files, +832 lines)

| File | Change |
|------|--------|
| `src/types/workflow.ts` | Extended `WorkflowSaveConfig` with dashboard metadata fields |
| `src/store/utils/localStorage.ts` | Added `deleteSaveConfig`, `getAllProjectsForDashboard`, `DashboardProject` interface |
| `src/app/api/workflow-load/route.ts` | **New** — POST endpoint to load workflow from disk |
| `src/store/workflowStore.ts` | Added `showDashboard`, `openProject`, `deleteProject` state/actions; enriched save metadata |
| `src/components/dashboard/ProjectCard.tsx` | **New** — Rich project card with type badges, node pills, metadata |
| `src/components/dashboard/ProjectDashboard.tsx` | **New** — Full dashboard overlay (left sidebar + project list + actions) |
| `src/components/WorkflowCanvas.tsx` | Replaced WelcomeModal with ProjectDashboard; added floating Projects button |
| `src/components/Header.tsx` | Added dashboard button in header; autosave status indicators |

## Test plan

- [ ] Open app — dashboard should appear instead of old quickstart
- [ ] Create a new project via "New Project" button — verify it saves and appears in dashboard
- [ ] Click the grid icon in header — dashboard opens showing the project
- [ ] Click the floating "Projects" button on canvas — same result
- [ ] Create a second project — both appear sorted by recency
- [ ] Click a project card — loads the workflow
- [ ] Delete a project from dashboard — removed from list
- [ ] Reload page — projects persist across sessions
- [ ] Verify green dot appears next to save time (auto-save indicator)
- [ ] Trigger a save — yellow pulsing dot appears briefly
- [ ] Save a project with generate nodes — verify node type pills and model name appear on the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)