### PR TITLE
feat: loop edges with iteration support

### DIFF
--- a/src/components/ConnectionDropMenu.tsx
+++ b/src/components/ConnectionDropMenu.tsx
@@ -412,6 +412,15 @@ const VIDEO_TARGET_OPTIONS: MenuOption[] = [
     ),
   },
   {
+    type: "outputGallery",
+    label: "Output Gallery",
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+      </svg>
+    ),
+  },
+  {
     type: "router",
     label: "Router",
     icon: (

--- a/src/components/EdgeToolbar.tsx
+++ b/src/components/EdgeToolbar.tsx
@@ -5,7 +5,7 @@ import { WorkflowEdgeData } from "@/types";
 import { useMemo, useEffect, useState, useRef } from "react";
 
 export function EdgeToolbar() {
-  const { edges, toggleEdgePause, removeEdge } = useWorkflowStore();
+  const { edges, toggleEdgePause, removeEdge, setLoopCount } = useWorkflowStore();
   const [clickPosition, setClickPosition] = useState<{ x: number; y: number } | null>(null);
   const previousSelectedEdgeId = useRef<string | null>(null);
 
@@ -79,6 +79,12 @@ export function EdgeToolbar() {
     }
   };
 
+  const handleLoopCountChange = (delta: number) => {
+    if (selectedEdge) {
+      setLoopCount(selectedEdge.id, loopCount + delta);
+    }
+  };
+
   const handleDelete = () => {
     if (selectedEdge) {
       removeEdge(selectedEdge.id);
@@ -88,6 +94,8 @@ export function EdgeToolbar() {
   if (!toolbarPosition || !selectedEdge) return null;
 
   const hasPause = selectedEdge.data?.hasPause;
+  const isLoop = selectedEdge.data?.isLoop;
+  const loopCount = selectedEdge.data?.loopCount ?? 3;
 
   return (
     <div
@@ -103,8 +111,36 @@ export function EdgeToolbar() {
           Image {sequenceNumber}
         </span>
       )}
-      <button
-        onClick={handleTogglePause}
+      {isLoop && (
+        <>
+          <span className="text-[10px] font-medium text-fuchsia-300 px-1.5">Loop</span>
+          <button
+            onClick={() => handleLoopCountChange(-1)}
+            disabled={loopCount <= 1}
+            className="p-1 rounded hover:bg-neutral-700 text-fuchsia-300 hover:text-fuchsia-100 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            title="Decrease loop count"
+          >
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" d="M5 12h14" />
+            </svg>
+          </button>
+          <span className="text-[11px] font-mono text-fuchsia-100 min-w-[20px] text-center">{loopCount}</span>
+          <button
+            onClick={() => handleLoopCountChange(1)}
+            disabled={loopCount >= 100}
+            className="p-1 rounded hover:bg-neutral-700 text-fuchsia-300 hover:text-fuchsia-100 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            title="Increase loop count"
+          >
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" d="M12 5v14M5 12h14" />
+            </svg>
+          </button>
+          <div className="w-px h-4 bg-neutral-600" />
+        </>
+      )}
+      {!isLoop && (
+        <button
+          onClick={handleTogglePause}
         className={`p-1.5 rounded hover:bg-neutral-700 transition-colors ${
           hasPause
             ? "text-amber-400 hover:text-amber-300"
@@ -124,6 +160,7 @@ export function EdgeToolbar() {
           </svg>
         )}
       </button>
+      )}
       <button
         onClick={handleDelete}
         className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-red-400 transition-colors"

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -168,7 +168,7 @@ const getNodeHandles = (nodeType: string): { inputs: string[]; outputs: string[]
     case "output":
       return { inputs: ["image", "video", "audio"], outputs: [] };
     case "outputGallery":
-      return { inputs: ["image"], outputs: [] };
+      return { inputs: ["image", "video"], outputs: [] };
     case "imageCompare":
       return { inputs: ["image"], outputs: [] };
     case "videoStitch":

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -70,6 +70,7 @@ import { stripBinaryData } from "@/lib/chat/contextBuilder";
 import { PromptEditorModal } from "./modals/PromptEditorModal";
 import { PromptConstructorEditorModal } from "./modals/PromptConstructorEditorModal";
 import { resolveTextSourcesThroughRouters } from "@/store/utils/connectedInputs";
+import { wouldCreateCycle } from "@/store/utils/executionUtils";
 import { parseVarTags } from "@/utils/parseVarTags";
 import { AnnotationModal } from "./AnnotationModal";
 import { browseRegistry } from "@/utils/browseRegistry";
@@ -664,7 +665,12 @@ export function WorkflowCanvas() {
               }
             }
             if (resolved.targetHandle) batchUsed.add(resolved.targetHandle);
-            onConnect(resolved);
+            // Check for cycle and mark as loop edge if detected
+            if (wouldCreateCycle(resolved.source!, resolved.target!, edges)) {
+              onConnect(resolved, { isLoop: true, loopCount: 3 });
+            } else {
+              onConnect(resolved);
+            }
             return;
           }
 
@@ -705,7 +711,12 @@ export function WorkflowCanvas() {
           resolved = resolveSwitchHandle(resolved);
           if (resolved.targetHandle) batchUsed.add(resolved.targetHandle);
           if (isValidConnection(resolved)) {
-            onConnect(resolved);
+            // Check for cycle and mark as loop edge if detected
+            if (wouldCreateCycle(resolved.source!, resolved.target!, edges)) {
+              onConnect(resolved, { isLoop: true, loopCount: 3 });
+            } else {
+              onConnect(resolved);
+            }
           }
         });
       } else {
@@ -714,7 +725,12 @@ export function WorkflowCanvas() {
         resolved = resolveRouterHandle(resolved);
         resolved = resolveRouterSourceHandle(resolved);
         resolved = resolveSwitchHandle(resolved);
-        onConnect(resolved);
+        // Check for cycle and mark as loop edge if detected
+        if (wouldCreateCycle(resolved.source!, resolved.target!, edges)) {
+          onConnect(resolved, { isLoop: true, loopCount: 3 });
+        } else {
+          onConnect(resolved);
+        }
       }
     },
     [onConnect, nodes, edges]

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -536,7 +536,7 @@ export function WorkflowCanvas() {
         if (!targetNode) return false;
 
         const targetNodeType = targetNode.type;
-        if (targetNodeType === "generateVideo" || targetNodeType === "videoStitch" || targetNodeType === "easeCurve" || targetNodeType === "videoTrim" || targetNodeType === "videoFrameGrab" || targetNodeType === "videoInput" || targetNodeType === "output" || targetNodeType === "router") {
+        if (targetNodeType === "generateVideo" || targetNodeType === "videoStitch" || targetNodeType === "easeCurve" || targetNodeType === "videoTrim" || targetNodeType === "videoFrameGrab" || targetNodeType === "videoInput" || targetNodeType === "output" || targetNodeType === "outputGallery" || targetNodeType === "router") {
           // For output node, we allow video even though its handle is typed as "image"
           // because output node can display both images and videos
           return true;

--- a/src/components/edges/EditableEdge.tsx
+++ b/src/components/edges/EditableEdge.tsx
@@ -103,6 +103,32 @@ export function EditableEdge({
 
   // Calculate the path based on edge style
   const [edgePath, labelX, labelY] = useMemo(() => {
+    // Loop edges: smooth arc that exits/enters along handle directions, bowed below nodes
+    if (edgeData?.isLoop) {
+      const dist = Math.sqrt((targetX - sourceX) ** 2 + (targetY - sourceY) ** 2);
+      const extent = Math.max(100, dist * 0.4);
+      const drop = Math.max(120, dist * 0.4);
+
+      // Direction vectors matching handle positions
+      const dir: Record<string, [number, number]> = {
+        top: [0, -1], bottom: [0, 1], left: [-1, 0], right: [1, 0],
+      };
+      const [sdx, sdy] = dir[sourcePosition] ?? [1, 0];
+      const [tdx, tdy] = dir[targetPosition] ?? [-1, 0];
+
+      // Follow handle direction + push arc below the nodes
+      const cp1x = sourceX + sdx * extent;
+      const cp1y = sourceY + sdy * extent + drop;
+      const cp2x = targetX + tdx * extent;
+      const cp2y = targetY + tdy * extent + drop;
+
+      const path = `M${sourceX},${sourceY} C${cp1x},${cp1y} ${cp2x},${cp2y} ${targetX},${targetY}`;
+      // Label at bezier midpoint (t=0.5)
+      const lx = 0.125 * sourceX + 0.375 * cp1x + 0.375 * cp2x + 0.125 * targetX;
+      const ly = 0.125 * sourceY + 0.375 * cp1y + 0.375 * cp2y + 0.125 * targetY;
+      return [path, lx, ly] as [string, number, number];
+    }
+
     if (edgeStyle === "curved") {
       return getBezierPath({
         sourceX,
@@ -125,7 +151,7 @@ export function EditableEdge({
         offset: offsetX,
       });
     }
-  }, [edgeStyle, sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, offsetX]);
+  }, [edgeStyle, edgeData?.isLoop, sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition, offsetX]);
 
   // Calculate handle positions on the path segments (only for angular mode)
   const handlePositions = useMemo(() => {

--- a/src/components/edges/EditableEdge.tsx
+++ b/src/components/edges/EditableEdge.tsx
@@ -29,6 +29,7 @@ const EDGE_COLORS: Record<string, string> = {
   text: "#2563eb", // Blue for text connections
   "3d": "#06b6d4", // Cyan for 3D connections
   easeCurve: "#f59e0b", // Amber for ease curve connections
+  loop: "#d946ef", // Magenta for loop edges
 };
 
 export function EditableEdge({
@@ -71,18 +72,23 @@ export function EditableEdge({
     return (targetNode.data as NanoBananaNodeData).status === "loading";
   });
 
-  // Determine edge color based on handle type (orange if paused)
+  // Determine edge color based on handle type (magenta for loop edges, orange if paused)
   const edgeColor = useMemo(() => {
+    if (edgeData?.isLoop) return EDGE_COLORS.loop;
     if (hasPause) return EDGE_COLORS.pause;
     // Use source handle to determine color (or target if source is not available)
     // Strip numeric suffixes (e.g., "image-0" -> "image") for lookup
     const handleType = sourceHandleId || targetHandleId || "";
     const normalizedType = handleType.replace(/-\d+$/, "");
     return EDGE_COLORS[normalizedType] || EDGE_COLORS.default;
-  }, [hasPause, sourceHandleId, targetHandleId]);
+  }, [edgeData?.isLoop, hasPause, sourceHandleId, targetHandleId]);
 
   // Reference shared gradient by color key + selection state
   const gradientId = useMemo(() => {
+    if (edgeData?.isLoop) {
+      const selectionKey = isConnectedToSelection ? "active" : "dimmed";
+      return getSharedGradientId("loop", selectionKey);
+    }
     if (hasPause) {
       const selectionKey = isConnectedToSelection ? "active" : "dimmed";
       return getSharedGradientId("pause", selectionKey);
@@ -93,7 +99,7 @@ export function EditableEdge({
     const colorKey = normalizedType in EDGE_COLORS ? normalizedType : "default";
     const selectionKey = isConnectedToSelection ? "active" : "dimmed";
     return getSharedGradientId(colorKey, selectionKey);
-  }, [hasPause, sourceHandleId, targetHandleId, isConnectedToSelection]);
+  }, [edgeData?.isLoop, hasPause, sourceHandleId, targetHandleId, isConnectedToSelection]);
 
   // Calculate the path based on edge style
   const [edgePath, labelX, labelY] = useMemo(() => {
@@ -263,6 +269,22 @@ export function EditableEdge({
           <rect x={-4} y={-5} width={2.5} height={10} fill={edgeColor} rx={1} />
           <rect x={1.5} y={-5} width={2.5} height={10} fill={edgeColor} rx={1} />
         </g>
+      )}
+
+      {/* Loop indicator at edge midpoint */}
+      {edgeData?.isLoop && (
+        <foreignObject
+          x={labelX - 28}
+          y={labelY - 12}
+          width={56}
+          height={24}
+          className="pointer-events-none"
+        >
+          <div className="flex items-center justify-center gap-1 px-2 py-0.5 bg-neutral-800/90 border border-fuchsia-500/60 rounded-full text-[10px] font-medium">
+            <span className="text-fuchsia-300">↻</span>
+            <span className="text-fuchsia-100">{edgeData.loopCount || 3}×</span>
+          </div>
+        </foreignObject>
       )}
 
       {/* Draggable handles on segments */}

--- a/src/components/edges/SharedEdgeGradients.tsx
+++ b/src/components/edges/SharedEdgeGradients.tsx
@@ -15,6 +15,7 @@ const EDGE_COLORS: Record<string, string> = {
   text: "#2563eb",
   "3d": "#06b6d4",
   easeCurve: "#f59e0b",
+  loop: "#d946ef",
 };
 
 const SELECTION_STATES = ["active", "dimmed"] as const;

--- a/src/components/nodes/EaseCurveNode.tsx
+++ b/src/components/nodes/EaseCurveNode.tsx
@@ -11,7 +11,6 @@ import { useVideoAutoplay } from "@/hooks/useVideoAutoplay";
 
 type EaseCurveNodeType = Node<EaseCurveNodeData, "easeCurve">;
 
-const VIDEO_HEIGHT = 320;
 
 export function EaseCurveNode({ id, data, selected }: NodeProps<EaseCurveNodeType>) {
   const nodeData = data;
@@ -120,7 +119,6 @@ export function EaseCurveNode({ id, data, selected }: NodeProps<EaseCurveNodeTyp
         selected={selected}
         fullBleed
         minWidth={340}
-        minHeight={VIDEO_HEIGHT}
       >
         {renderHandles()}
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center px-4">
@@ -151,7 +149,6 @@ export function EaseCurveNode({ id, data, selected }: NodeProps<EaseCurveNodeTyp
         selected={selected}
         fullBleed
         minWidth={340}
-        minHeight={VIDEO_HEIGHT}
       >
         {renderHandles()}
         <div className="flex-1 flex items-center justify-center">
@@ -175,7 +172,6 @@ export function EaseCurveNode({ id, data, selected }: NodeProps<EaseCurveNodeTyp
       isExecuting={isRunning}
       hasError={nodeData.status === "error"}
       minWidth={340}
-      minHeight={VIDEO_HEIGHT}
       aspectFitMedia={nodeData.outputVideo}
     >
       {renderHandles()}

--- a/src/components/nodes/OutputGalleryNode.tsx
+++ b/src/components/nodes/OutputGalleryNode.tsx
@@ -2,11 +2,14 @@
 
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { createPortal } from "react-dom";
-import { Handle, Position, NodeProps, Node } from "@xyflow/react";
+import { Handle, Position, NodeProps, Node, useReactFlow } from "@xyflow/react";
 import { BaseNode } from "./BaseNode";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { OutputGalleryNodeData } from "@/types";
 import { useAdaptiveImageSrc } from "@/hooks/useAdaptiveImageSrc";
+import { defaultNodeDimensions } from "@/store/utils/nodeDefaults";
+
+type MediaItem = { type: "image" | "video"; src: string };
 
 function AdaptiveGalleryThumbnail({ src, alt, nodeId }: { src: string; alt: string; nodeId: string }) {
   const adaptiveSrc = useAdaptiveImageSrc(src, nodeId);
@@ -24,43 +27,18 @@ type OutputGalleryNodeType = Node<OutputGalleryNodeData, "outputGallery">;
 export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGalleryNodeType>) {
   const nodeData = data;
   const updateNodeData = useWorkflowStore((state) => state.updateNodeData);
-  const edges = useWorkflowStore((state) => state.edges);
-  const nodes = useWorkflowStore((state) => state.nodes);
+  const addNode = useWorkflowStore((state) => state.addNode);
+  const { getNodes, setNodes } = useReactFlow();
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
-  // Collect images in real-time from connected nodes (not just during execution)
-  const displayImages = useMemo(() => {
-    // Start with images from execution (data.images)
-    const executionImages = [...(nodeData.images || [])];
-
-    // Also collect images from currently connected nodes
-    const connectedImages: string[] = [];
-    edges
-      .filter((edge) => edge.target === id)
-      .forEach((edge) => {
-        const sourceNode = nodes.find((n) => n.id === edge.source);
-        if (!sourceNode) return;
-
-        let image: string | null = null;
-
-        // Extract image from different node types
-        if (sourceNode.type === "imageInput") {
-          image = (sourceNode.data as any).image;
-        } else if (sourceNode.type === "annotation") {
-          image = (sourceNode.data as any).outputImage;
-        } else if (sourceNode.type === "nanoBanana") {
-          image = (sourceNode.data as any).outputImage;
-        }
-
-        if (image) {
-          connectedImages.push(image);
-        }
-      });
-
-    // Combine both sources, removing duplicates
-    const allImages = [...new Set([...executionImages, ...connectedImages])];
-    return allImages;
-  }, [nodeData.images, edges, nodes, id]);
+  // Display stored media only — items are accumulated during workflow execution
+  const displayMedia = useMemo(() => {
+    const media: MediaItem[] = [
+      ...(nodeData.images || []).map((src): MediaItem => ({ type: "image", src })),
+      ...(nodeData.videos || []).map((src): MediaItem => ({ type: "video", src })),
+    ];
+    return media;
+  }, [nodeData.images, nodeData.videos]);
 
   const openLightbox = useCallback((index: number) => {
     setLightboxIndex(index);
@@ -76,26 +54,85 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
 
       if (direction === "prev" && lightboxIndex > 0) {
         setLightboxIndex(lightboxIndex - 1);
-      } else if (direction === "next" && lightboxIndex < displayImages.length - 1) {
+      } else if (direction === "next" && lightboxIndex < displayMedia.length - 1) {
         setLightboxIndex(lightboxIndex + 1);
       }
     },
-    [lightboxIndex, displayImages.length]
+    [lightboxIndex, displayMedia.length]
   );
 
-  const downloadImage = useCallback(() => {
+  const downloadMedia = useCallback(() => {
     if (lightboxIndex === null) return;
 
-    const image = displayImages[lightboxIndex];
-    if (!image) return;
+    const item = displayMedia[lightboxIndex];
+    if (!item) return;
 
     const link = document.createElement("a");
-    link.href = image;
-    link.download = `gallery-image-${lightboxIndex + 1}.png`;
+    link.href = item.src;
+    link.download = item.type === "video"
+      ? `gallery-video-${lightboxIndex + 1}.mp4`
+      : `gallery-image-${lightboxIndex + 1}.png`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-  }, [lightboxIndex, displayImages]);
+  }, [lightboxIndex, displayMedia]);
+
+  const removeMedia = useCallback((index: number) => {
+    const item = displayMedia[index];
+    if (!item) return;
+
+    if (item.type === "image") {
+      const filtered = (nodeData.images || []).filter((img) => img !== item.src);
+      updateNodeData(id, { images: filtered });
+    } else {
+      const filtered = (nodeData.videos || []).filter((vid) => vid !== item.src);
+      updateNodeData(id, { videos: filtered });
+    }
+
+    // Adjust lightbox after removal
+    if (lightboxIndex !== null) {
+      if (displayMedia.length <= 1) {
+        setLightboxIndex(null);
+      } else if (lightboxIndex >= displayMedia.length - 1) {
+        setLightboxIndex(displayMedia.length - 2);
+      }
+    }
+  }, [displayMedia, nodeData.images, nodeData.videos, updateNodeData, id, lightboxIndex]);
+
+  const handleExtractToInputNodes = useCallback(() => {
+    const galleryNode = getNodes().find((n) => n.id === id);
+    if (!galleryNode) return;
+
+    const galleryWidth = galleryNode.measured?.width ?? defaultNodeDimensions.outputGallery.width;
+    const startX = galleryNode.position.x + galleryWidth + 100;
+    let currentY = galleryNode.position.y;
+    const gap = 20;
+
+    const newNodeIds: string[] = [];
+    const images = nodeData.images || [];
+    const videos = nodeData.videos || [];
+
+    for (let i = 0; i < images.length; i++) {
+      const nodeId = addNode("imageInput", { x: startX, y: currentY }, { image: images[i], filename: `gallery-image-${i + 1}.png` });
+      newNodeIds.push(nodeId);
+      currentY += defaultNodeDimensions.imageInput.height + gap;
+    }
+
+    for (let i = 0; i < videos.length; i++) {
+      const nodeId = addNode("videoInput", { x: startX, y: currentY }, { video: videos[i], filename: `gallery-video-${i + 1}.mp4` });
+      newNodeIds.push(nodeId);
+      currentY += defaultNodeDimensions.videoInput.height + gap;
+    }
+
+    if (newNodeIds.length > 0) {
+      setNodes((nodes) =>
+        nodes.map((n) => ({
+          ...n,
+          selected: newNodeIds.includes(n.id),
+        }))
+      );
+    }
+  }, [id, nodeData.images, nodeData.videos, getNodes, addNode, setNodes]);
 
   // Keyboard navigation for lightbox
   useEffect(() => {
@@ -119,6 +156,8 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [lightboxIndex, closeLightbox, navigateLightbox]);
 
+  const currentItem = lightboxIndex !== null ? displayMedia[lightboxIndex] : null;
+
   return (
     <>
       <BaseNode
@@ -131,24 +170,81 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
           position={Position.Left}
           id="image"
           data-handletype="image"
+          style={{ top: "40%" }}
         />
+        <div
+          className="absolute text-[10px] font-medium whitespace-nowrap pointer-events-none text-right"
+          style={{ right: "calc(100% + 8px)", top: "calc(40% - 18px)", color: "rgb(59, 130, 246)" }}
+        >
+          Image
+        </div>
 
-        {displayImages.length === 0 ? (
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="video"
+          data-handletype="video"
+          style={{ top: "60%" }}
+        />
+        <div
+          className="absolute text-[10px] font-medium whitespace-nowrap pointer-events-none text-right"
+          style={{ right: "calc(100% + 8px)", top: "calc(60% - 18px)", color: "rgb(168, 85, 247)" }}
+        >
+          Video
+        </div>
+
+        {displayMedia.length > 0 && (
+          <div className="flex items-center justify-between px-2 py-1">
+            <span className="text-neutral-400 text-[10px]">
+              {displayMedia.length} {displayMedia.length === 1 ? "item" : "items"}
+            </span>
+            <button
+              onClick={handleExtractToInputNodes}
+              className="nodrag nopan flex items-center gap-1 px-1.5 py-0.5 text-[10px] text-neutral-400 hover:text-white hover:bg-neutral-700 rounded transition-colors"
+              title="Extract each item as an input node"
+            >
+              <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+              Extract
+            </button>
+          </div>
+        )}
+
+        {displayMedia.length === 0 ? (
           <div className="w-full flex-1 min-h-[200px] border border-dashed border-neutral-600 rounded flex items-center justify-center">
             <span className="text-neutral-500 text-[10px] text-center px-4">
-              Connect image nodes to view gallery
+              Connect image or video nodes to view gallery
             </span>
           </div>
         ) : (
           <div className="flex-1 overflow-y-auto nodrag nopan nowheel">
             <div className="grid grid-cols-3 gap-1.5 p-1">
-              {displayImages.map((img, idx) => (
+              {displayMedia.map((item, idx) => (
                 <button
                   key={idx}
                   onClick={() => openLightbox(idx)}
-                  className="aspect-square rounded border border-neutral-700 hover:border-neutral-500 overflow-hidden transition-colors"
+                  className="aspect-square rounded border border-neutral-700 hover:border-neutral-500 overflow-hidden transition-colors relative"
                 >
-                  <AdaptiveGalleryThumbnail src={img} alt={`Image ${idx + 1}`} nodeId={id} />
+                  {item.type === "video" ? (
+                    <>
+                      <video
+                        src={item.src}
+                        className="w-full h-full object-cover"
+                        muted
+                        playsInline
+                        preload="metadata"
+                      />
+                      {/* Video play icon overlay */}
+                      <div className="absolute inset-0 flex items-center justify-center bg-black/20">
+                        <svg className="w-5 h-5 text-white drop-shadow" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      </div>
+                    </>
+                  ) : (
+                    <AdaptiveGalleryThumbnail src={item.src} alt={`Image ${idx + 1}`} nodeId={id} />
+                  )}
                 </button>
               ))}
             </div>
@@ -157,18 +253,28 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
       </BaseNode>
 
       {/* Lightbox Portal */}
-      {lightboxIndex !== null && typeof document !== "undefined" &&
+      {lightboxIndex !== null && currentItem && typeof document !== "undefined" &&
         createPortal(
           <div
             className="fixed inset-0 bg-black/90 z-[100] flex items-center justify-center p-8"
             onClick={closeLightbox}
           >
             <div className="relative max-w-full max-h-full" onClick={(e) => e.stopPropagation()}>
-              <img
-                src={displayImages[lightboxIndex]}
-                alt={`Gallery image ${lightboxIndex + 1}`}
-                className="max-w-full max-h-[90vh] object-contain rounded"
-              />
+              {currentItem.type === "video" ? (
+                <video
+                  src={currentItem.src}
+                  className="max-w-full max-h-[90vh] object-contain rounded"
+                  controls
+                  autoPlay
+                  playsInline
+                />
+              ) : (
+                <img
+                  src={currentItem.src}
+                  alt={`Gallery image ${lightboxIndex + 1}`}
+                  className="max-w-full max-h-[90vh] object-contain rounded"
+                />
+              )}
 
               {/* Close button */}
               <button
@@ -180,16 +286,27 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
                 </svg>
               </button>
 
-              {/* Download button */}
-              <button
-                onClick={downloadImage}
-                className="absolute top-4 left-4 px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded text-white text-xs font-medium transition-colors flex items-center gap-1.5"
-              >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
-                </svg>
-                Download
-              </button>
+              {/* Download + Remove buttons */}
+              <div className="absolute top-4 left-4 flex gap-1.5">
+                <button
+                  onClick={downloadMedia}
+                  className="px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded text-white text-xs font-medium transition-colors flex items-center gap-1.5"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                  </svg>
+                  Download
+                </button>
+                <button
+                  onClick={() => removeMedia(lightboxIndex)}
+                  className="px-3 py-1.5 bg-white/10 hover:bg-red-600/80 rounded text-white text-xs font-medium transition-colors flex items-center gap-1.5"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+                  </svg>
+                  Remove
+                </button>
+              </div>
 
               {/* Left arrow */}
               {lightboxIndex > 0 && (
@@ -204,7 +321,7 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
               )}
 
               {/* Right arrow */}
-              {lightboxIndex < displayImages.length - 1 && (
+              {lightboxIndex < displayMedia.length - 1 && (
                 <button
                   onClick={() => navigateLightbox("next")}
                   className="absolute right-4 top-1/2 -translate-y-1/2 w-10 h-10 bg-white/10 hover:bg-white/20 rounded-full text-white transition-colors flex items-center justify-center"
@@ -215,9 +332,9 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
                 </button>
               )}
 
-              {/* Image counter */}
+              {/* Media counter */}
               <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1.5 bg-black/50 rounded text-white text-xs font-medium">
-                {lightboxIndex + 1} / {displayImages.length}
+                {lightboxIndex + 1} / {displayMedia.length}
               </div>
             </div>
           </div>,

--- a/src/components/nodes/OutputGalleryNode.tsx
+++ b/src/components/nodes/OutputGalleryNode.tsx
@@ -112,14 +112,18 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
     const images = nodeData.images || [];
     const videos = nodeData.videos || [];
 
-    for (let i = 0; i < images.length; i++) {
-      const nodeId = addNode("imageInput", { x: startX, y: currentY }, { image: images[i], filename: `gallery-image-${i + 1}.png` });
+    // Reverse so oldest items (end of array) appear at top, newest at bottom
+    const reversedImages = [...images].reverse();
+    const reversedVideos = [...videos].reverse();
+
+    for (let i = 0; i < reversedImages.length; i++) {
+      const nodeId = addNode("imageInput", { x: startX, y: currentY }, { image: reversedImages[i], filename: `gallery-image-${i + 1}.png` });
       newNodeIds.push(nodeId);
       currentY += defaultNodeDimensions.imageInput.height + gap;
     }
 
-    for (let i = 0; i < videos.length; i++) {
-      const nodeId = addNode("videoInput", { x: startX, y: currentY }, { video: videos[i], filename: `gallery-video-${i + 1}.mp4` });
+    for (let i = 0; i < reversedVideos.length; i++) {
+      const nodeId = addNode("videoInput", { x: startX, y: currentY }, { video: reversedVideos[i], filename: `gallery-video-${i + 1}.mp4` });
       newNodeIds.push(nodeId);
       currentY += defaultNodeDimensions.videoInput.height + gap;
     }

--- a/src/components/nodes/VideoFrameGrabNode.tsx
+++ b/src/components/nodes/VideoFrameGrabNode.tsx
@@ -109,31 +109,29 @@ export function VideoFrameGrabNode({ id, data, selected }: NodeProps<VideoFrameG
           )}
         </div>
 
-        {/* Frame position toggle (only when source video connected) */}
-        {hasSourceVideo && (
-          <div className="nodrag nowheel shrink-0 flex gap-1 px-1">
-            <button
-              onClick={() => updateNodeData(id, { framePosition: "first", outputImage: null })}
-              className={`flex-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
-                nodeData.framePosition === "first"
-                  ? "bg-blue-600 text-white"
-                  : "bg-neutral-800 text-neutral-400 hover:text-neutral-200"
-              }`}
-            >
-              First
-            </button>
-            <button
-              onClick={() => updateNodeData(id, { framePosition: "last", outputImage: null })}
-              className={`flex-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
-                nodeData.framePosition === "last"
-                  ? "bg-blue-600 text-white"
-                  : "bg-neutral-800 text-neutral-400 hover:text-neutral-200"
-              }`}
-            >
-              Last
-            </button>
-          </div>
-        )}
+        {/* Frame position toggle */}
+        <div className="nodrag nowheel shrink-0 flex gap-1 px-1">
+          <button
+            onClick={() => updateNodeData(id, { framePosition: "first", outputImage: null })}
+            className={`flex-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
+              nodeData.framePosition === "first"
+                ? "bg-blue-600 text-white"
+                : "bg-neutral-800 text-neutral-400 hover:text-neutral-200"
+            }`}
+          >
+            First
+          </button>
+          <button
+            onClick={() => updateNodeData(id, { framePosition: "last", outputImage: null })}
+            className={`flex-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
+              nodeData.framePosition === "last"
+                ? "bg-blue-600 text-white"
+                : "bg-neutral-800 text-neutral-400 hover:text-neutral-200"
+            }`}
+          >
+            Last
+          </button>
+        </div>
 
         {/* Extract Frame button */}
         <div className="shrink-0 flex justify-end px-1">

--- a/src/hooks/useStitchVideos.ts
+++ b/src/hooks/useStitchVideos.ts
@@ -7,6 +7,7 @@ import {
   VideoSampleSink,
   VideoSampleSource,
   AudioBufferSource,
+  AudioBufferSink,
   BlobSource,
   ALL_FORMATS,
   BufferTarget,
@@ -211,6 +212,68 @@ export async function stitchVideosAsync(
       rotation: aggregateRotation,
     });
 
+    // Extract embedded audio from source videos when no external audio override is provided
+    let effectiveAudioData = audioData ?? null;
+    if (!effectiveAudioData) {
+      updateProgress('processing', 'Extracting audio from source videos...', 8);
+      const allAudioBuffers: AudioBuffer[] = [];
+      let referenceSampleRate: number | null = null;
+      let referenceChannels: number | null = null;
+
+      for (let i = 0; i < videoBlobs.length; i++) {
+        try {
+          const blobSource = new BlobSource(videoBlobs[i]);
+          const input = new Input({ source: blobSource, formats: ALL_FORMATS });
+          try {
+            const audioTracks = await input.getAudioTracks();
+            if (audioTracks.length > 0) {
+              const audioTrack = audioTracks[0];
+              const sink = new AudioBufferSink(audioTrack);
+              const duration = await input.computeDuration();
+              for await (const wrapped of sink.buffers(0, duration)) {
+                if (referenceSampleRate === null) {
+                  referenceSampleRate = wrapped.buffer.sampleRate;
+                  referenceChannels = wrapped.buffer.numberOfChannels;
+                }
+                if (
+                  wrapped.buffer.sampleRate === referenceSampleRate &&
+                  wrapped.buffer.numberOfChannels === referenceChannels
+                ) {
+                  allAudioBuffers.push(wrapped.buffer);
+                }
+              }
+            }
+          } finally {
+            input.dispose();
+          }
+        } catch (err) {
+          console.warn(`Failed to extract audio from video ${i + 1}:`, err);
+        }
+      }
+
+      if (allAudioBuffers.length > 0 && referenceSampleRate && referenceChannels) {
+        const totalSamples = allAudioBuffers.reduce((sum, b) => sum + b.length, 0);
+        const concatenated = new AudioBuffer({
+          length: Math.max(1, totalSamples),
+          numberOfChannels: referenceChannels,
+          sampleRate: referenceSampleRate,
+        });
+
+        let offset = 0;
+        for (const buffer of allAudioBuffers) {
+          for (let ch = 0; ch < referenceChannels; ch++) {
+            concatenated.getChannelData(ch).set(buffer.getChannelData(ch), offset);
+          }
+          offset += buffer.length;
+        }
+
+        effectiveAudioData = {
+          buffer: concatenated,
+          duration: totalSamples / referenceSampleRate,
+        };
+      }
+    }
+
     // Create output
     updateProgress('processing', 'Creating output container...', 10);
 
@@ -226,19 +289,19 @@ export async function stitchVideosAsync(
 
     output.addVideoTrack(videoSource, { rotation: aggregateRotation, frameRate: MAX_OUTPUT_FPS });
 
-    // Add audio track if provided
+    // Add audio track if provided (external audio input or extracted from source videos)
     let audioSource: AudioBufferSource | null = null;
     let pendingAudioBuffer: AudioBuffer | null = null;
     let outputStarted = false;
 
-    if (audioData) {
+    if (effectiveAudioData) {
       updateProgress('processing', 'Detecting supported audio codec...', 8);
 
       // Detect the best supported audio codec for MP4
       // Try common codecs in order of preference: aac, mp3 (no opus - Twitter doesn't support it)
       const audioCodec = await getFirstEncodableAudioCodec(['aac', 'mp3'], {
-        numberOfChannels: audioData.buffer.numberOfChannels,
-        sampleRate: audioData.buffer.sampleRate,
+        numberOfChannels: effectiveAudioData.buffer.numberOfChannels,
+        sampleRate: effectiveAudioData.buffer.sampleRate,
         bitrate: 128000,
       });
 
@@ -255,7 +318,7 @@ export async function stitchVideosAsync(
         });
 
         output.addAudioTrack(audioSource);
-        pendingAudioBuffer = audioData.buffer;
+        pendingAudioBuffer = effectiveAudioData.buffer;
       }
     }
 
@@ -267,7 +330,7 @@ export async function stitchVideosAsync(
     // Writing audio after all video causes broken interleaving (Discord won't play audio).
     if (audioSource && pendingAudioBuffer) {
       updateProgress('processing', 'Encoding audio track...', 12);
-      const trimTarget = probedVideoDuration > 0 ? probedVideoDuration : audioData!.duration;
+      const trimTarget = probedVideoDuration > 0 ? probedVideoDuration : effectiveAudioData!.duration;
       const trimmedBuffer = trimAudioBuffer(pendingAudioBuffer, trimTarget);
       await audioSource.add(trimmedBuffer);
       await audioSource.close();

--- a/src/store/__tests__/loopEdge.integration.test.ts
+++ b/src/store/__tests__/loopEdge.integration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Loop Edge Integration Tests
+ *
+ * Tests the runtime behavior of loop edges during workflow execution.
+ * These tests validate that loops execute N times with correct data flow.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useWorkflowStore } from "../workflowStore";
+import { WorkflowNode, WorkflowEdge, WorkflowNodeData } from "@/types";
+
+// Test helpers
+function makeNode(id: string, type: string, data?: Partial<WorkflowNodeData>): WorkflowNode {
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: data || {},
+  } as WorkflowNode;
+}
+
+function makeEdge(
+  source: string,
+  target: string,
+  opts?: { isLoop?: boolean; loopCount?: number; hasPause?: boolean }
+): WorkflowEdge {
+  return {
+    id: `${source}-${target}`,
+    source,
+    target,
+    data: opts || {},
+  } as WorkflowEdge;
+}
+
+function setupStore(nodes: WorkflowNode[], edges: WorkflowEdge[]): void {
+  useWorkflowStore.setState({ nodes, edges });
+}
+
+describe("setLoopCount", () => {
+  beforeEach(() => {
+    // Reset store to clean state
+    useWorkflowStore.setState({
+      nodes: [],
+      edges: [],
+      groups: {},
+      isRunning: false,
+      hasUnsavedChanges: false,
+    });
+  });
+
+  it("updates edge data loopCount", () => {
+    const edge = makeEdge("a", "b", { isLoop: true, loopCount: 3 });
+    setupStore([], [edge]);
+
+    useWorkflowStore.getState().setLoopCount(edge.id, 5);
+
+    const updatedEdge = useWorkflowStore.getState().edges.find((e) => e.id === edge.id);
+    expect(updatedEdge?.data?.loopCount).toBe(5);
+  });
+
+  it("clamps loop count to minimum 1", () => {
+    const edge = makeEdge("a", "b", { isLoop: true, loopCount: 3 });
+    setupStore([], [edge]);
+
+    useWorkflowStore.getState().setLoopCount(edge.id, 0);
+
+    const updatedEdge = useWorkflowStore.getState().edges.find((e) => e.id === edge.id);
+    expect(updatedEdge?.data?.loopCount).toBe(1);
+  });
+
+  it("clamps loop count to maximum 100", () => {
+    const edge = makeEdge("a", "b", { isLoop: true, loopCount: 3 });
+    setupStore([], [edge]);
+
+    useWorkflowStore.getState().setLoopCount(edge.id, 150);
+
+    const updatedEdge = useWorkflowStore.getState().edges.find((e) => e.id === edge.id);
+    expect(updatedEdge?.data?.loopCount).toBe(100);
+  });
+});
+
+describe("executeWorkflow with loop edges", () => {
+  beforeEach(() => {
+    // Reset store to clean state
+    useWorkflowStore.setState({
+      nodes: [],
+      edges: [],
+      groups: {},
+      isRunning: false,
+      hasUnsavedChanges: false,
+    });
+  });
+
+  it("executes loop subgraph exactly N times", async () => {
+    // Create A(imageInput) → B(prompt) → C(output) with loop edge C→A (loopCount: 3)
+    const nodeA = makeNode("a", "imageInput", { image: "data:image/png;base64,test" });
+    const nodeB = makeNode("b", "prompt", { prompt: "test prompt" });
+    const nodeC = makeNode("c", "output");
+
+    const edges = [
+      makeEdge("a", "b"),
+      makeEdge("b", "c"),
+      makeEdge("c", "a", { isLoop: true, loopCount: 3 }),
+    ];
+
+    setupStore([nodeA, nodeB, nodeC], edges);
+
+    // Spy on copyLoopOutput to count iterations
+    const copyLoopOutputSpy = vi.spyOn(
+      await import("../utils/executionUtils"),
+      "copyLoopOutput"
+    );
+
+    await useWorkflowStore.getState().executeWorkflow();
+
+    // copyLoopOutput should be called (loopCount - 1) times
+    // because first iteration uses original input
+    expect(copyLoopOutputSpy).toHaveBeenCalledTimes(2); // 3 iterations - 1 = 2 calls
+  });
+
+  it("executes non-loop prefix and suffix nodes once", async () => {
+    // Create PREFIX(imageInput) → A(prompt) → B(prompt) → SUFFIX(output)
+    // with loop edge B→A (loopCount: 3)
+    const prefix = makeNode("prefix", "imageInput", { image: "data:image/png;base64,test" });
+    const nodeA = makeNode("a", "prompt", { prompt: "loop start" });
+    const nodeB = makeNode("b", "prompt", { prompt: "loop end" });
+    const suffix = makeNode("suffix", "output");
+
+    const edges = [
+      makeEdge("prefix", "a"),
+      makeEdge("a", "b"),
+      makeEdge("b", "suffix"),
+      makeEdge("b", "a", { isLoop: true, loopCount: 3 }),
+    ];
+
+    setupStore([prefix, nodeA, nodeB, suffix], edges);
+
+    // Spy on updateNodeData to track execution
+    const updateNodeDataSpy = vi.spyOn(useWorkflowStore.getState(), "updateNodeData");
+
+    await useWorkflowStore.getState().executeWorkflow();
+
+    // Check that prefix and suffix nodes were updated less frequently than loop nodes
+    // (This is a simplified check - in real execution, loop nodes would be updated more)
+    const prefixUpdates = updateNodeDataSpy.mock.calls.filter((call) => call[0] === "prefix");
+    const suffixUpdates = updateNodeDataSpy.mock.calls.filter((call) => call[0] === "suffix");
+    const loopNodeUpdates = updateNodeDataSpy.mock.calls.filter(
+      (call) => call[0] === "a" || call[0] === "b"
+    );
+
+    // Prefix and suffix should have fewer updates than loop nodes
+    expect(prefixUpdates.length).toBeLessThan(loopNodeUpdates.length);
+    expect(suffixUpdates.length).toBeLessThan(loopNodeUpdates.length);
+  });
+
+  it("does not affect workflows with no loop edges", async () => {
+    // Standard A → B → C workflow
+    const nodeA = makeNode("a", "imageInput", { image: "data:image/png;base64,test" });
+    const nodeB = makeNode("b", "prompt", { prompt: "test" });
+    const nodeC = makeNode("c", "output");
+
+    const edges = [makeEdge("a", "b"), makeEdge("b", "c")];
+
+    setupStore([nodeA, nodeB, nodeC], edges);
+
+    // Should execute without errors
+    await useWorkflowStore.getState().executeWorkflow();
+
+    // Verify workflow completed
+    expect(useWorkflowStore.getState().isRunning).toBe(false);
+  });
+
+  it("treats loopCount:1 same as no loop", async () => {
+    // Create A(imageInput) → B(prompt) with loop edge B→A (loopCount: 1)
+    const nodeA = makeNode("a", "imageInput", { image: "data:image/png;base64,test" });
+    const nodeB = makeNode("b", "prompt", { prompt: "test" });
+
+    const edges = [makeEdge("a", "b"), makeEdge("b", "a", { isLoop: true, loopCount: 1 })];
+
+    setupStore([nodeA, nodeB], edges);
+
+    // Spy on copyLoopOutput
+    const copyLoopOutputSpy = vi.spyOn(
+      await import("../utils/executionUtils"),
+      "copyLoopOutput"
+    );
+
+    await useWorkflowStore.getState().executeWorkflow();
+
+    // With loopCount=1, copyLoopOutput should never be called (no iterations to feedback)
+    expect(copyLoopOutputSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("stops loop mid-iteration when aborted", async () => {
+    // Create loop with loopCount: 10
+    const nodeA = makeNode("a", "imageInput", { image: "data:image/png;base64,test" });
+    const nodeB = makeNode("b", "prompt", { prompt: "test" });
+
+    const edges = [makeEdge("a", "b"), makeEdge("b", "a", { isLoop: true, loopCount: 10 })];
+
+    setupStore([nodeA, nodeB], edges);
+
+    // Start execution (don't await)
+    const executionPromise = useWorkflowStore.getState().executeWorkflow();
+
+    // Abort after a short delay
+    setTimeout(() => {
+      useWorkflowStore.getState().stopWorkflow();
+    }, 10);
+
+    await executionPromise;
+
+    // Verify execution was stopped
+    expect(useWorkflowStore.getState().isRunning).toBe(false);
+  });
+});

--- a/src/store/__tests__/loopEdge.integration.test.ts
+++ b/src/store/__tests__/loopEdge.integration.test.ts
@@ -119,39 +119,48 @@ describe("executeWorkflow with loop edges", () => {
     copyLoopOutputSpy.mockRestore();
   });
 
-  it("executes non-loop prefix and suffix nodes once", async () => {
-    // Create PREFIX(imageInput) → A(prompt) → B(prompt) → SUFFIX(output)
+  it("executes prefix nodes once and downstream nodes each iteration", async () => {
+    // Create PREFIX(imageInput) → A(prompt) → B(prompt) → DOWNSTREAM(output)
     // with loop edge B→A (loopCount: 3)
+    // PREFIX is not downstream of the loop body — it only feeds INTO A
+    // DOWNSTREAM is connected from B (loop body) — it should iterate with the loop
     const prefix = makeNode("prefix", "imageInput", { image: "data:image/png;base64,test" });
     const nodeA = makeNode("a", "prompt", { prompt: "loop start" });
     const nodeB = makeNode("b", "prompt", { prompt: "loop end" });
-    const suffix = makeNode("suffix", "output");
+    const downstream = makeNode("downstream", "output");
 
     const edges = [
       makeEdge("prefix", "a"),
       makeEdge("a", "b"),
-      makeEdge("b", "suffix"),
+      makeEdge("b", "downstream"),
       makeEdge("b", "a", { isLoop: true, loopCount: 3 }),
     ];
 
-    setupStore([prefix, nodeA, nodeB, suffix], edges);
+    setupStore([prefix, nodeA, nodeB, downstream], edges);
 
-    // Spy on updateNodeData to track execution
-    const updateNodeDataSpy = vi.spyOn(useWorkflowStore.getState(), "updateNodeData");
+    // Track which nodes are executed by subscribing to currentNodeIds changes.
+    // Only push when the reference changes (Zustand preserves refs for unchanged fields).
+    const executedNodeIds: string[] = [];
+    let prevRef: string[] = [];
+    const unsubscribe = useWorkflowStore.subscribe((state) => {
+      if (state.currentNodeIds !== prevRef && state.currentNodeIds.length > 0) {
+        executedNodeIds.push(...state.currentNodeIds);
+        prevRef = state.currentNodeIds;
+      }
+    });
 
     await useWorkflowStore.getState().executeWorkflow();
+    unsubscribe();
 
-    // Check that prefix and suffix nodes were updated less frequently than loop nodes
-    // (This is a simplified check - in real execution, loop nodes would be updated more)
-    const prefixUpdates = updateNodeDataSpy.mock.calls.filter((call) => call[0] === "prefix");
-    const suffixUpdates = updateNodeDataSpy.mock.calls.filter((call) => call[0] === "suffix");
-    const loopNodeUpdates = updateNodeDataSpy.mock.calls.filter(
-      (call) => call[0] === "a" || call[0] === "b"
-    );
+    const countExecutions = (id: string) => executedNodeIds.filter((nid) => nid === id).length;
 
-    // Prefix and suffix should have fewer updates than loop nodes
-    expect(prefixUpdates.length).toBeLessThan(loopNodeUpdates.length);
-    expect(suffixUpdates.length).toBeLessThan(loopNodeUpdates.length);
+    // Prefix feeds into the loop but is not downstream — executes once
+    expect(countExecutions("prefix")).toBe(1);
+    // Loop body nodes execute 3 times (loopCount: 3)
+    expect(countExecutions("a")).toBe(3);
+    expect(countExecutions("b")).toBe(3);
+    // Downstream is connected from loop body node B — iterates with the loop
+    expect(countExecutions("downstream")).toBe(3);
   });
 
   it("does not affect workflows with no loop edges", async () => {

--- a/src/store/__tests__/loopEdge.integration.test.ts
+++ b/src/store/__tests__/loopEdge.integration.test.ts
@@ -106,16 +106,17 @@ describe("executeWorkflow with loop edges", () => {
     setupStore([nodeA, nodeB, nodeC], edges);
 
     // Spy on copyLoopOutput to count iterations
-    const copyLoopOutputSpy = vi.spyOn(
-      await import("../utils/executionUtils"),
-      "copyLoopOutput"
-    );
+    const executionUtils = await import("../utils/executionUtils");
+    const copyLoopOutputSpy = vi.spyOn(executionUtils, "copyLoopOutput");
+    copyLoopOutputSpy.mockClear(); // Clear any previous calls
 
     await useWorkflowStore.getState().executeWorkflow();
 
     // copyLoopOutput should be called (loopCount - 1) times
     // because first iteration uses original input
     expect(copyLoopOutputSpy).toHaveBeenCalledTimes(2); // 3 iterations - 1 = 2 calls
+
+    copyLoopOutputSpy.mockRestore();
   });
 
   it("executes non-loop prefix and suffix nodes once", async () => {
@@ -179,16 +180,17 @@ describe("executeWorkflow with loop edges", () => {
 
     setupStore([nodeA, nodeB], edges);
 
-    // Spy on copyLoopOutput
-    const copyLoopOutputSpy = vi.spyOn(
-      await import("../utils/executionUtils"),
-      "copyLoopOutput"
-    );
+    // Spy on copyLoopOutput with a fresh mock
+    const executionUtils = await import("../utils/executionUtils");
+    const copyLoopOutputSpy = vi.spyOn(executionUtils, "copyLoopOutput");
+    copyLoopOutputSpy.mockClear(); // Clear any previous calls
 
     await useWorkflowStore.getState().executeWorkflow();
 
     // With loopCount=1, copyLoopOutput should never be called (no iterations to feedback)
     expect(copyLoopOutputSpy).toHaveBeenCalledTimes(0);
+
+    copyLoopOutputSpy.mockRestore();
   });
 
   it("stops loop mid-iteration when aborted", async () => {

--- a/src/store/execution/simpleNodeExecutors.ts
+++ b/src/store/execution/simpleNodeExecutors.ts
@@ -290,21 +290,34 @@ export async function executeOutput(ctx: NodeExecutionContext): Promise<void> {
 }
 
 /**
- * OutputGallery node: accumulates images from upstream nodes.
+ * OutputGallery node: accumulates images and videos from upstream nodes.
  */
 export async function executeOutputGallery(ctx: NodeExecutionContext): Promise<void> {
   const { node, getConnectedInputs, updateNodeData, getFreshNode } = ctx;
-  const { images } = getConnectedInputs(node.id);
+  const { images, videos } = getConnectedInputs(node.id);
   // Use fresh node data — the stale `node` from topological sort may be missing
   // images pushed by appendOutputGalleryImage during upstream batch execution.
   const freshNode = getFreshNode(node.id);
-  const galleryImages = ((freshNode?.data ?? node.data) as OutputGalleryNodeData).images || [];
-  const existing = new Set(galleryImages);
-  const newImages = images.filter((img) => !existing.has(img));
+  const freshData = (freshNode?.data ?? node.data) as OutputGalleryNodeData;
+  const galleryImages = freshData.images || [];
+  const galleryVideos = freshData.videos || [];
+
+  const updates: Partial<OutputGalleryNodeData> = {};
+
+  const existingImages = new Set(galleryImages);
+  const newImages = images.filter((img) => !existingImages.has(img));
   if (newImages.length > 0) {
-    updateNodeData(node.id, {
-      images: [...newImages, ...galleryImages],
-    });
+    updates.images = [...newImages, ...galleryImages];
+  }
+
+  const existingVideos = new Set(galleryVideos);
+  const newVideos = videos.filter((v) => !existingVideos.has(v));
+  if (newVideos.length > 0) {
+    updates.videos = [...newVideos, ...galleryVideos];
+  }
+
+  if (Object.keys(updates).length > 0) {
+    updateNodeData(node.id, updates);
   }
 }
 

--- a/src/store/utils/__tests__/loopEdge.test.ts
+++ b/src/store/utils/__tests__/loopEdge.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Loop Edge Utilities Tests
+ *
+ * Tests for cycle detection, loop subgraph identification, and loop data copying.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  wouldCreateCycle,
+  findLoopSubgraph,
+  copyLoopOutput,
+} from "@/store/utils/executionUtils";
+import { WorkflowEdge, WorkflowNode, WorkflowNodeData } from "@/types";
+
+// Helper to create minimal edge objects
+function makeEdge(source: string, target: string, data?: Record<string, unknown>): WorkflowEdge {
+  return {
+    id: `${source}-${target}`,
+    source,
+    target,
+    data: data || {},
+  };
+}
+
+// Helper to create minimal node objects
+function makeNode(id: string, type: string, data: Partial<WorkflowNodeData> = {}): WorkflowNode {
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: data as WorkflowNodeData,
+  };
+}
+
+describe("wouldCreateCycle", () => {
+  it("detects cycle in linear chain A→B→C when connecting C→A", () => {
+    const edges = [makeEdge("A", "B"), makeEdge("B", "C")];
+    expect(wouldCreateCycle("C", "A", edges)).toBe(true);
+  });
+
+  it("returns false when no cycle: A→B, connecting A→C", () => {
+    const edges = [makeEdge("A", "B")];
+    expect(wouldCreateCycle("A", "C", edges)).toBe(false);
+  });
+
+  it("detects cycle in diamond: A→B→D, A→C→D, connecting D→A", () => {
+    const edges = [
+      makeEdge("A", "B"),
+      makeEdge("A", "C"),
+      makeEdge("B", "D"),
+      makeEdge("C", "D"),
+    ];
+    expect(wouldCreateCycle("D", "A", edges)).toBe(true);
+  });
+
+  it("detects self-loop: connecting A→A", () => {
+    const edges: WorkflowEdge[] = [];
+    expect(wouldCreateCycle("A", "A", edges)).toBe(true);
+  });
+
+  it("returns false for disconnected graph: A→B, C→D, connecting D→A", () => {
+    const edges = [makeEdge("A", "B"), makeEdge("C", "D")];
+    expect(wouldCreateCycle("D", "A", edges)).toBe(false);
+  });
+});
+
+describe("findLoopSubgraph", () => {
+  it("identifies simple loop A→B→C with loop edge C→A", () => {
+    const edges = [makeEdge("A", "B"), makeEdge("B", "C")];
+    const result = findLoopSubgraph("C", "A", edges);
+    expect(result.sort()).toEqual(["A", "B", "C"].sort());
+  });
+
+  it("excludes nodes outside loop: A→B→C→D with loop edge C→A", () => {
+    const edges = [makeEdge("A", "B"), makeEdge("B", "C"), makeEdge("C", "D")];
+    const result = findLoopSubgraph("C", "A", edges);
+    expect(result.sort()).toEqual(["A", "B", "C"].sort());
+    expect(result).not.toContain("D");
+  });
+
+  it("includes branch within loop: A→B→C, B→D→C with loop edge C→A", () => {
+    const edges = [
+      makeEdge("A", "B"),
+      makeEdge("B", "C"),
+      makeEdge("B", "D"),
+      makeEdge("D", "C"),
+    ];
+    const result = findLoopSubgraph("C", "A", edges);
+    expect(result.sort()).toEqual(["A", "B", "C", "D"].sort());
+  });
+});
+
+describe("copyLoopOutput", () => {
+  it("copies image from nanoBanana to imageInput", () => {
+    const sourceNode = makeNode("source", "nanoBanana", {
+      outputImage: "data:image/png;base64,abc123",
+    });
+    const targetNode = makeNode("target", "imageInput", {});
+    const updateNodeData = vi.fn();
+
+    copyLoopOutput(sourceNode, "image", targetNode, "image", updateNodeData);
+
+    expect(updateNodeData).toHaveBeenCalledWith("target", {
+      image: "data:image/png;base64,abc123",
+    });
+  });
+
+  it("copies video from generateVideo to videoInput", () => {
+    const sourceNode = makeNode("source", "generateVideo", {
+      outputVideo: "data:video/mp4;base64,xyz789",
+    });
+    const targetNode = makeNode("target", "videoInput", {});
+    const updateNodeData = vi.fn();
+
+    copyLoopOutput(sourceNode, "video", targetNode, "video", updateNodeData);
+
+    expect(updateNodeData).toHaveBeenCalledWith("target", {
+      video: "data:video/mp4;base64,xyz789",
+    });
+  });
+
+  it("copies text from llmGenerate to prompt", () => {
+    const sourceNode = makeNode("source", "llmGenerate", {
+      outputText: "Generated prompt text",
+    });
+    const targetNode = makeNode("target", "prompt", {});
+    const updateNodeData = vi.fn();
+
+    copyLoopOutput(sourceNode, "text", targetNode, "text", updateNodeData);
+
+    expect(updateNodeData).toHaveBeenCalledWith("target", {
+      prompt: "Generated prompt text",
+    });
+  });
+
+  it("copies audio from generateAudio to audioInput", () => {
+    const sourceNode = makeNode("source", "generateAudio", {
+      outputAudio: "data:audio/mp3;base64,audio123",
+    });
+    const targetNode = makeNode("target", "audioInput", {});
+    const updateNodeData = vi.fn();
+
+    copyLoopOutput(sourceNode, "audio", targetNode, "audio", updateNodeData);
+
+    expect(updateNodeData).toHaveBeenCalledWith("target", {
+      audioFile: "data:audio/mp3;base64,audio123",
+    });
+  });
+
+  it("does nothing when source value is null", () => {
+    const sourceNode = makeNode("source", "nanoBanana", {
+      outputImage: null,
+    });
+    const targetNode = makeNode("target", "imageInput", {});
+    const updateNodeData = vi.fn();
+
+    copyLoopOutput(sourceNode, "image", targetNode, "image", updateNodeData);
+
+    expect(updateNodeData).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/utils/connectedInputs.ts
+++ b/src/store/utils/connectedInputs.ts
@@ -63,7 +63,7 @@ function isTextHandle(handleId: string | null | undefined): boolean {
 /**
  * Extract output data and type from a source node
  */
-function getSourceOutput(
+export function getSourceOutput(
   sourceNode: WorkflowNode,
   sourceHandle: string | null | undefined,
   edgeData?: Record<string, unknown>
@@ -220,7 +220,7 @@ export function getConnectedInputsPure(
   const passthroughCache = new Map<string, ConnectedInputs>();
 
   edges
-    .filter((edge) => edge.target === nodeId)
+    .filter((edge) => edge.target === nodeId && !edge.data?.isLoop)
     .forEach((edge) => {
       const sourceNode = nodes.find((n) => n.id === edge.source);
       if (!sourceNode) return;

--- a/src/store/utils/executionUtils.ts
+++ b/src/store/utils/executionUtils.ts
@@ -6,6 +6,7 @@
  */
 
 import { WorkflowNode, WorkflowEdge, WorkflowNodeData } from "@/types";
+import { getSourceOutput } from "./connectedInputs";
 
 // Concurrency settings
 export const CONCURRENCY_SETTINGS_KEY = "node-banana-concurrency-limit";
@@ -138,4 +139,139 @@ export function clearNodeImageRefs(nodes: WorkflowNode[]): WorkflowNode[] {
 
     return { ...node, data: data as WorkflowNodeData } as WorkflowNode;
   });
+}
+
+/**
+ * Check if adding an edge from sourceId to targetId would create a cycle.
+ * Uses iterative DFS to check if targetId can reach sourceId through existing edges.
+ */
+export function wouldCreateCycle(
+  sourceId: string,
+  targetId: string,
+  edges: WorkflowEdge[]
+): boolean {
+  // Self-loop check
+  if (sourceId === targetId) return true;
+
+  // Build adjacency list (edge.source → edge.target)
+  const adjList = new Map<string, string[]>();
+  edges.forEach((edge) => {
+    if (!adjList.has(edge.source)) {
+      adjList.set(edge.source, []);
+    }
+    adjList.get(edge.source)!.push(edge.target);
+  });
+
+  // DFS from targetId to see if we can reach sourceId
+  const visited = new Set<string>();
+  const stack = [targetId];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current === sourceId) return true;
+    if (visited.has(current)) continue;
+
+    visited.add(current);
+    const neighbors = adjList.get(current) || [];
+    for (const neighbor of neighbors) {
+      if (!visited.has(neighbor)) {
+        stack.push(neighbor);
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Find all nodes that are part of a loop body.
+ * Returns the intersection of nodes reachable forward from loopTarget
+ * and nodes reachable backward from loopSource.
+ */
+export function findLoopSubgraph(
+  loopSource: string,
+  loopTarget: string,
+  forwardEdges: WorkflowEdge[]
+): string[] {
+  // Build adjacency lists
+  const forward = new Map<string, string[]>();
+  const backward = new Map<string, string[]>();
+
+  forwardEdges.forEach((edge) => {
+    if (!forward.has(edge.source)) {
+      forward.set(edge.source, []);
+    }
+    forward.get(edge.source)!.push(edge.target);
+
+    if (!backward.has(edge.target)) {
+      backward.set(edge.target, []);
+    }
+    backward.get(edge.target)!.push(edge.source);
+  });
+
+  // BFS forward from loopTarget
+  const forwardReachable = new Set<string>();
+  const forwardQueue = [loopTarget];
+  while (forwardQueue.length > 0) {
+    const current = forwardQueue.shift()!;
+    if (forwardReachable.has(current)) continue;
+    forwardReachable.add(current);
+
+    const neighbors = forward.get(current) || [];
+    for (const neighbor of neighbors) {
+      if (!forwardReachable.has(neighbor)) {
+        forwardQueue.push(neighbor);
+      }
+    }
+  }
+
+  // BFS backward from loopSource
+  const backwardReachable = new Set<string>();
+  const backwardQueue = [loopSource];
+  while (backwardQueue.length > 0) {
+    const current = backwardQueue.shift()!;
+    if (backwardReachable.has(current)) continue;
+    backwardReachable.add(current);
+
+    const neighbors = backward.get(current) || [];
+    for (const neighbor of neighbors) {
+      if (!backwardReachable.has(neighbor)) {
+        backwardQueue.push(neighbor);
+      }
+    }
+  }
+
+  // Return intersection
+  const intersection = Array.from(forwardReachable).filter((node) =>
+    backwardReachable.has(node)
+  );
+  return intersection;
+}
+
+/**
+ * Copy output data from source node to target node input field.
+ * Used for loop edges to transfer data from loop end back to loop start.
+ */
+export function copyLoopOutput(
+  sourceNode: WorkflowNode,
+  sourceHandle: string | null,
+  targetNode: WorkflowNode,
+  targetHandle: string | null,
+  updateNodeData: (nodeId: string, data: Partial<WorkflowNodeData>) => void
+): void {
+  const { type, value } = getSourceOutput(sourceNode, sourceHandle);
+
+  // If value is null, do nothing
+  if (value === null) return;
+
+  // Map output type to target input field based on node type
+  if (type === "image" && targetNode.type === "imageInput") {
+    updateNodeData(targetNode.id, { image: value });
+  } else if (type === "video" && targetNode.type === "videoInput") {
+    updateNodeData(targetNode.id, { video: value });
+  } else if (type === "text" && targetNode.type === "prompt") {
+    updateNodeData(targetNode.id, { prompt: value });
+  } else if (type === "audio" && targetNode.type === "audioInput") {
+    updateNodeData(targetNode.id, { audioFile: value });
+  }
 }

--- a/src/store/utils/nodeDefaults.ts
+++ b/src/store/utils/nodeDefaults.ts
@@ -53,7 +53,7 @@ export const defaultNodeDimensions: Record<NodeType, { width: number; height: nu
   outputGallery: { width: 320, height: 360 },
   imageCompare: { width: 400, height: 360 },
   videoStitch: { width: 400, height: 280 },
-  easeCurve: { width: 340, height: 480 },
+  easeCurve: { width: 340, height: 280 },
   videoTrim: { width: 360, height: 360 },
   videoFrameGrab: { width: 320, height: 320 },
   router: { width: 200, height: 80 },
@@ -258,6 +258,7 @@ export const createDefaultNodeData = (type: NodeType): WorkflowNodeData => {
     case "outputGallery":
       return {
         images: [],
+        videos: [],
       } as OutputGalleryNodeData;
     case "imageCompare":
       return {

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -1497,33 +1497,34 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
         const loopEdge = loopEdges[0];
         const loopBodyIds = new Set(findLoopSubgraph(loopEdge.source, loopEdge.target, forwardEdges));
 
-        // Partition levels into prefix (before loop), loop body, and suffix (after loop)
+        // Expand loop body to include downstream nodes that depend on loop output.
+        // These nodes (e.g. outputGallery connected to a looped generateVideo) should
+        // execute each iteration so they can collect results from every pass.
+        const loopIterationIds = new Set(loopBodyIds);
+        let expanded = true;
+        while (expanded) {
+          expanded = false;
+          for (const edge of forwardEdges) {
+            if (loopIterationIds.has(edge.source) && !loopIterationIds.has(edge.target)) {
+              loopIterationIds.add(edge.target);
+              expanded = true;
+            }
+          }
+        }
+
+        // Partition levels: iterating nodes run each loop pass, non-iterating run once as prefix
         const prefixLevels: typeof levels = [];
         const loopLevels: typeof levels = [];
-        const suffixLevels: typeof levels = [];
-
-        let foundLoop = false;
 
         for (const level of levels) {
-          const hasLoopNode = level.nodeIds.some(id => loopBodyIds.has(id));
+          const iteratingIds = level.nodeIds.filter(id => loopIterationIds.has(id));
+          const nonIteratingIds = level.nodeIds.filter(id => !loopIterationIds.has(id));
 
-          if (!foundLoop && !hasLoopNode) {
-            prefixLevels.push(level);
-          } else if (hasLoopNode) {
-            foundLoop = true;
-            // Filter level to only include loop body nodes
-            const loopNodeIds = level.nodeIds.filter(id => loopBodyIds.has(id));
-            const nonLoopNodeIds = level.nodeIds.filter(id => !loopBodyIds.has(id));
-
-            if (loopNodeIds.length > 0) {
-              loopLevels.push({ level: level.level, nodeIds: loopNodeIds });
-            }
-            // Non-loop nodes at the same level as loop nodes go to suffix
-            if (nonLoopNodeIds.length > 0) {
-              suffixLevels.push({ level: level.level, nodeIds: nonLoopNodeIds });
-            }
-          } else if (foundLoop) {
-            suffixLevels.push(level);
+          if (iteratingIds.length > 0) {
+            loopLevels.push({ level: level.level, nodeIds: iteratingIds });
+          }
+          if (nonIteratingIds.length > 0) {
+            prefixLevels.push({ level: level.level, nodeIds: nonIteratingIds });
           }
         }
 
@@ -1554,14 +1555,8 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
 
           logger.info('node.execution', `Loop iteration ${i + 1}/${loopCount}`);
 
-          // Execute loop body levels with fresh node state
+          // Execute loop body + downstream levels with fresh node state
           await executeLevels(loopLevels);
-        }
-
-        if (!abortController.signal.aborted) {
-          // Execute suffix once
-          logger.info('node.execution', 'Executing suffix levels', { count: suffixLevels.length });
-          await executeLevels(suffixLevels);
         }
       }
 

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -235,6 +235,7 @@ interface WorkflowStore {
   addEdgeWithType: (connection: Connection, edgeType: string, edgeDataOverrides?: Record<string, unknown>) => void;
   removeEdge: (edgeId: string) => void;
   toggleEdgePause: (edgeId: string) => void;
+  setLoopCount: (edgeId: string, count: number) => void;
 
   // Copy/Paste operations
   copySelectedNodes: () => void;
@@ -887,6 +888,19 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
       edges: state.edges.map((edge) =>
         edge.id === edgeId
           ? { ...edge, data: { ...edge.data, hasPause: !edge.data?.hasPause } }
+          : edge
+      ),
+      hasUnsavedChanges: true,
+    }));
+  },
+
+  setLoopCount: (edgeId: string, count: number) => {
+    const clamped = Math.max(1, Math.min(100, count));
+    pushUndoCheckpoint(get, set);
+    set((state) => ({
+      edges: state.edges.map((edge) =>
+        edge.id === edgeId
+          ? { ...edge, data: { ...edge.data, loopCount: clamped } }
           : edge
       ),
       hasUnsavedChanges: true,

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -59,6 +59,8 @@ import {
   groupNodesByLevel,
   chunk,
   clearNodeImageRefs,
+  findLoopSubgraph,
+  copyLoopOutput,
 } from "./utils/executionUtils";
 import { getConnectedInputsPure, validateWorkflowPure, type ConnectedInputs } from "./utils/connectedInputs";
 import { evaluateRule } from "./utils/ruleEvaluation";
@@ -1234,16 +1236,6 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
       maxConcurrentCalls,
     });
 
-    // Group nodes by level for parallel execution
-    const levels = groupNodesByLevel(nodes, edges);
-
-    // Find starting level if startFromNodeId specified
-    let startLevel = 0;
-    if (startFromNodeId) {
-      const foundLevel = levels.findIndex((l) => l.nodeIds.includes(startFromNodeId));
-      if (foundLevel !== -1) startLevel = foundLevel;
-    }
-
     // Helper to execute a single node - returns true if successful, throws on error
     const executeSingleNode = async (node: WorkflowNode, signal: AbortSignal): Promise<void> => {
       // Check for abort before starting
@@ -1424,26 +1416,28 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
         }
     }; // End of executeSingleNode helper
 
-    try {
-      // Execute levels sequentially, but nodes within each level in parallel
+    // Helper to execute a set of levels sequentially, with parallel batches within each level
+    const executeLevels = async (
+      levels: ReturnType<typeof groupNodesByLevel>,
+      startLevel: number = 0
+    ): Promise<void> => {
       for (let levelIdx = startLevel; levelIdx < levels.length; levelIdx++) {
-        // Check if execution was stopped
         if (abortController.signal.aborted || !get().isRunning) break;
 
         const level = levels[levelIdx];
+        // Get fresh node references from the store for each level
+        const currentNodes = get().nodes;
         const levelNodes = level.nodeIds
-          .map((id) => nodes.find((n) => n.id === id))
+          .map((id) => currentNodes.find((n) => n.id === id))
           .filter((n): n is WorkflowNode => n !== undefined);
 
         if (levelNodes.length === 0) continue;
 
-        // Execute nodes in batches respecting concurrency limit
         const batches = chunk(levelNodes, maxConcurrentCalls);
 
         for (const batch of batches) {
           if (abortController.signal.aborted || !get().isRunning) break;
 
-          // Update currentNodeIds to show which nodes are executing
           const batchIds = batch.map((n) => n.id);
           set({ currentNodeIds: batchIds });
 
@@ -1453,12 +1447,10 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
             nodeIds: batchIds,
           });
 
-          // Execute batch in parallel
           const results = await Promise.allSettled(
             batch.map((node) => executeSingleNode(node, abortController.signal))
           );
 
-          // Check for failures with node context (fail-fast behavior)
           for (let i = 0; i < results.length; i++) {
             const r = results[i];
             if (r.status === 'rejected' &&
@@ -1474,6 +1466,102 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
               throw r.reason;
             }
           }
+        }
+      }
+    };
+
+    try {
+      // Partition edges into loop and forward edges
+      const loopEdges = edges.filter(e => e.data?.isLoop);
+      const forwardEdges = edges.filter(e => !e.data?.isLoop);
+
+      // Group nodes by level using ONLY forward edges (loop edges excluded from topological sort)
+      const levels = groupNodesByLevel(nodes, forwardEdges);
+
+      // Find starting level if startFromNodeId specified
+      let startLevel = 0;
+      if (startFromNodeId) {
+        const foundLevel = levels.findIndex((l) => l.nodeIds.includes(startFromNodeId));
+        if (foundLevel !== -1) startLevel = foundLevel;
+      }
+
+      if (loopEdges.length === 0) {
+        // No loops — existing execution path
+        await executeLevels(levels, startLevel);
+      } else {
+        // Warn if multiple loop edges (single loop supported in Phase 48)
+        if (loopEdges.length > 1) {
+          useToast.getState().show("Multiple loop edges detected — only the first loop will execute", "warning");
+        }
+
+        const loopEdge = loopEdges[0];
+        const loopBodyIds = new Set(findLoopSubgraph(loopEdge.source, loopEdge.target, forwardEdges));
+
+        // Partition levels into prefix (before loop), loop body, and suffix (after loop)
+        const prefixLevels: typeof levels = [];
+        const loopLevels: typeof levels = [];
+        const suffixLevels: typeof levels = [];
+
+        let foundLoop = false;
+
+        for (const level of levels) {
+          const hasLoopNode = level.nodeIds.some(id => loopBodyIds.has(id));
+
+          if (!foundLoop && !hasLoopNode) {
+            prefixLevels.push(level);
+          } else if (hasLoopNode) {
+            foundLoop = true;
+            // Filter level to only include loop body nodes
+            const loopNodeIds = level.nodeIds.filter(id => loopBodyIds.has(id));
+            const nonLoopNodeIds = level.nodeIds.filter(id => !loopBodyIds.has(id));
+
+            if (loopNodeIds.length > 0) {
+              loopLevels.push({ level: level.level, nodeIds: loopNodeIds });
+            }
+            // Non-loop nodes at the same level as loop nodes go to suffix
+            if (nonLoopNodeIds.length > 0) {
+              suffixLevels.push({ level: level.level, nodeIds: nonLoopNodeIds });
+            }
+          } else if (foundLoop) {
+            suffixLevels.push(level);
+          }
+        }
+
+        // Execute prefix once
+        logger.info('node.execution', 'Executing prefix levels', { count: prefixLevels.length });
+        await executeLevels(prefixLevels, startLevel);
+
+        // Execute loop N times
+        const loopCount = loopEdge.data?.loopCount ?? 3;
+        for (let i = 0; i < loopCount; i++) {
+          if (abortController.signal.aborted || !get().isRunning) break;
+
+          // Copy output → input between iterations (skip first — uses original input)
+          if (i > 0) {
+            const freshNodes = get().nodes;
+            const sourceNode = freshNodes.find(n => n.id === loopEdge.source);
+            const targetNode = freshNodes.find(n => n.id === loopEdge.target);
+            if (sourceNode && targetNode) {
+              copyLoopOutput(
+                sourceNode,
+                loopEdge.sourceHandle ?? null,
+                targetNode,
+                loopEdge.targetHandle ?? null,
+                get().updateNodeData
+              );
+            }
+          }
+
+          logger.info('node.execution', `Loop iteration ${i + 1}/${loopCount}`);
+
+          // Execute loop body levels with fresh node state
+          await executeLevels(loopLevels);
+        }
+
+        if (!abortController.signal.aborted) {
+          // Execute suffix once
+          logger.info('node.execution', 'Executing suffix levels', { count: suffixLevels.length });
+          await executeLevels(suffixLevels);
         }
       }
 

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -308,6 +308,9 @@ export interface OutputNodeData extends BaseNodeData {
  */
 export interface OutputGalleryNodeData extends BaseNodeData {
   images: string[]; // Array of base64 data URLs from connected nodes
+  imageRefs?: string[]; // External storage refs for images
+  videos: string[]; // Array of video URLs from connected nodes
+  videoRefs?: string[]; // External storage refs for videos
 }
 
 /**

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -11,6 +11,8 @@ import { Edge } from "@xyflow/react";
 export interface WorkflowEdgeData extends Record<string, unknown> {
   hasPause?: boolean;
   createdAt?: number;
+  isLoop?: boolean;
+  loopCount?: number;
 }
 
 // Workflow Edge

--- a/src/utils/mediaStorage.ts
+++ b/src/utils/mediaStorage.ts
@@ -436,9 +436,57 @@ async function externalizeNodeMedia(
 
     case "outputGallery": {
       const d = data as import("@/types").OutputGalleryNodeData;
-      // OutputGallery content is regenerated on each workflow run
-      // Clear images array to keep workflow file small
-      newData = { ...d, images: [] };
+      const galleryImageRefs: string[] = d.imageRefs ? [...d.imageRefs] : [];
+      const galleryVideoRefs: string[] = d.videoRefs ? [...d.videoRefs] : [];
+
+      // Externalize gallery images
+      for (let i = 0; i < (d.images?.length || 0); i++) {
+        const img = d.images[i];
+        const existingRef = galleryImageRefs[i];
+        if (existingRef && isDataUrl(img)) {
+          // Already has ref, just keep it
+        } else if (isDataUrl(img)) {
+          galleryImageRefs[i] = await saveImageAndGetId(img, workflowPath, savedImageIds, "generations");
+        } else if (isHttpUrl(img)) {
+          // Keep HTTP URLs inline (small, no ref needed)
+          galleryImageRefs[i] = ""; // placeholder to keep indices aligned
+        }
+      }
+
+      // Externalize gallery videos
+      for (let i = 0; i < (d.videos?.length || 0); i++) {
+        const vid = d.videos[i];
+        const existingRef = galleryVideoRefs[i];
+        if (existingRef && isDataUrl(vid)) {
+          // Already has ref, just keep it
+        } else if (isDataUrl(vid)) {
+          const ref = await saveVideoAndGetRef(vid, workflowPath, savedMediaIds);
+          if (ref) galleryVideoRefs[i] = ref;
+        } else if (isHttpUrl(vid)) {
+          // Keep HTTP URLs inline (small, no ref needed)
+          galleryVideoRefs[i] = ""; // placeholder to keep indices aligned
+        }
+      }
+
+      // Build cleaned arrays: clear base64 data where refs exist, keep HTTP URLs
+      const cleanedImages = d.images.map((img, i) =>
+        galleryImageRefs[i] && isDataUrl(img) ? "" : img
+      );
+      const cleanedVideos = d.videos.map((vid, i) =>
+        galleryVideoRefs[i] && isDataUrl(vid) ? "" : vid
+      );
+
+      // Filter out empty placeholders from refs
+      const hasImageRefs = galleryImageRefs.some(r => r && r !== "");
+      const hasVideoRefs = galleryVideoRefs.some(r => r && r !== "");
+
+      newData = {
+        ...d,
+        images: cleanedImages,
+        imageRefs: hasImageRefs ? galleryImageRefs : undefined,
+        videos: cleanedVideos,
+        videoRefs: hasVideoRefs ? galleryVideoRefs : undefined,
+      };
       break;
     }
 
@@ -990,8 +1038,36 @@ async function hydrateNodeMedia(
     }
 
     case "outputGallery": {
-      // OutputGallery content is not persisted - it's regenerated on each workflow run
-      newData = data;
+      const d = data as import("@/types").OutputGalleryNodeData;
+      const images = [...(d.images || [])];
+      const videos = [...(d.videos || [])];
+
+      // Hydrate images from refs
+      if (d.imageRefs && d.imageRefs.length > 0) {
+        for (let i = 0; i < d.imageRefs.length; i++) {
+          const ref = d.imageRefs[i];
+          if (ref && ref !== "" && (!images[i] || images[i] === "")) {
+            images[i] = await loadMediaById(ref, workflowPath, loadedMedia, "image");
+          }
+        }
+      }
+
+      // Hydrate videos from refs
+      if (d.videoRefs && d.videoRefs.length > 0) {
+        for (let i = 0; i < d.videoRefs.length; i++) {
+          const ref = d.videoRefs[i];
+          if (ref && ref !== "" && (!videos[i] || videos[i] === "")) {
+            videos[i] = await loadMediaById(ref, workflowPath, loadedMedia, "video");
+          }
+        }
+      }
+
+      // Filter out any empty entries that failed to hydrate
+      newData = {
+        ...d,
+        images: images.filter(img => img && img !== ""),
+        videos: videos.filter(vid => vid && vid !== ""),
+      };
       break;
     }
 

--- a/src/utils/mediaStorage.ts
+++ b/src/utils/mediaStorage.ts
@@ -469,10 +469,10 @@ async function externalizeNodeMedia(
       }
 
       // Build cleaned arrays: clear base64 data where refs exist, keep HTTP URLs
-      const cleanedImages = d.images.map((img, i) =>
+      const cleanedImages = (d.images || []).map((img, i) =>
         galleryImageRefs[i] && isDataUrl(img) ? "" : img
       );
-      const cleanedVideos = d.videos.map((vid, i) =>
+      const cleanedVideos = (d.videos || []).map((vid, i) =>
         galleryVideoRefs[i] && isDataUrl(vid) ? "" : vid
       );
 
@@ -1062,11 +1062,31 @@ async function hydrateNodeMedia(
         }
       }
 
-      // Filter out any empty entries that failed to hydrate
+      // Filter out any empty entries that failed to hydrate, keeping refs in sync
+      const filteredImages: string[] = [];
+      const filteredImageRefs: string[] = [];
+      for (let i = 0; i < images.length; i++) {
+        if (images[i] && images[i] !== "") {
+          filteredImages.push(images[i]);
+          if (d.imageRefs?.[i]) filteredImageRefs.push(d.imageRefs[i]);
+          else filteredImageRefs.push("");
+        }
+      }
+      const filteredVideos: string[] = [];
+      const filteredVideoRefs: string[] = [];
+      for (let i = 0; i < videos.length; i++) {
+        if (videos[i] && videos[i] !== "") {
+          filteredVideos.push(videos[i]);
+          if (d.videoRefs?.[i]) filteredVideoRefs.push(d.videoRefs[i]);
+          else filteredVideoRefs.push("");
+        }
+      }
       newData = {
         ...d,
-        images: images.filter(img => img && img !== ""),
-        videos: videos.filter(vid => vid && vid !== ""),
+        images: filteredImages,
+        imageRefs: filteredImageRefs.some(r => r !== "") ? filteredImageRefs : d.imageRefs,
+        videos: filteredVideos,
+        videoRefs: filteredVideoRefs.some(r => r !== "") ? filteredVideoRefs : d.videoRefs,
       };
       break;
     }


### PR DESCRIPTION
## Summary
- **Loop edges**: New edge type that creates feedback loops in workflows. Edges connecting a downstream node back to an upstream node are auto-detected as loops, styled with magenta coloring, and support configurable iteration counts via the EdgeToolbar.
- **Loop execution**: Workflow engine repeats the loop body for the configured number of iterations, feeding each pass's output back as input to the next.
- **OutputGallery enhancements**: Extract button for batch input node creation, video handle support, and media ref/data sync fixes.
- **Bug fixes**: Preserve embedded audio when stitching videos, guard undefined arrays in mediaStorage, keep refs in sync after hydration filtering.

## Changes
- 10 commits across 19 files (+1,174 / -149 lines)
- Loop edge utilities with full test coverage (unit + integration)
- Auto-detect loop edges with magenta visual styling and EdgeToolbar controls
- Loop iteration in workflow execution engine
- OutputGallery video connection support and Extract button
- mediaStorage robustness fixes (undefined guards, ref/data index sync)

## Test plan
- [x] `npx vitest run` — 2010 tests pass (1 pre-existing failure unrelated)
- [x] `npx tsc --noEmit` — no new type errors in changed files
- [ ] Manual: create a loop edge by connecting a downstream node back upstream, verify magenta styling and iteration count control
- [ ] Manual: run a workflow with a loop edge, verify it iterates the configured number of times
- [ ] Manual: connect a video output to an outputGallery node, verify connection is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loop edge support with configurable iteration counts (1–100) for creating feedback loops in workflows.
  * Extended Output Gallery to accept and display videos alongside images with media extraction to input nodes.
  * Video stitching now automatically extracts embedded audio from input videos.

* **Improvements**
  * Enhanced edge toolbar to display loop controls when an edge is configured as a loop.
  * Adjusted Ease Curve node default sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->