### PR TITLE
Add gpt-image-2 image generation (OpenAI direct + Kie.ai)

### DIFF
--- a/src/app/api/generate/providers/kie.ts
+++ b/src/app/api/generate/providers/kie.ts
@@ -25,6 +25,13 @@ export function getKieModelDefaults(modelId: string): Record<string, unknown> {
         quality: "medium",
       };
 
+    case "gpt-image-2/text-to-image":
+    case "gpt-image-2/image-to-image":
+      return {
+        aspect_ratio: "1:1",
+        quality: "medium",
+      };
+
     // Z-Image model
     case "z-image":
       return {
@@ -239,6 +246,7 @@ export function getKieImageInputKey(modelId: string): string {
   if (modelId === "nano-banana-pro") return "image_input";
   if (modelId === "seedream/4.5-edit") return "image_urls";
   if (modelId === "gpt-image/1.5-image-to-image") return "input_urls";
+  if (modelId === "gpt-image-2/image-to-image") return "input_urls";
   // Flux-2 I2I models use input_urls
   if (modelId === "flux-2/pro-image-to-image" || modelId === "flux-2/flex-image-to-image") return "input_urls";
   // Wan 2.7 Image uses input_urls

--- a/src/app/api/generate/providers/openai.ts
+++ b/src/app/api/generate/providers/openai.ts
@@ -1,0 +1,385 @@
+/**
+ * OpenAI Provider for Generate API Route
+ *
+ * Handles image generation using OpenAI's Images API.
+ *
+ * Supported models:
+ *   - gpt-image-2 (text-to-image via /v1/images/generations,
+ *                  image-to-image via /v1/images/edits)
+ *
+ * Reference: https://developers.openai.com/api/docs/models/gpt-image-2
+ *
+ * Notes:
+ * - gpt-image-2 always returns base64 in `data[].b64_json` (no `response_format`).
+ * - The edits endpoint is multipart/form-data and accepts up to 16 source images,
+ *   each PNG/WEBP/JPG and <50MB.
+ */
+
+import { GenerationInput, GenerationOutput } from "@/lib/providers/types";
+
+const OPENAI_GENERATIONS_URL = "https://api.openai.com/v1/images/generations";
+const OPENAI_EDITS_URL = "https://api.openai.com/v1/images/edits";
+
+const MAX_EDIT_IMAGES = 16;
+const MAX_EDIT_IMAGE_BYTES = 50 * 1024 * 1024; // 50MB per edit source
+
+/**
+ * Parameters that we forward verbatim to OpenAI's Images API for gpt-image-2.
+ *
+ * Anything not in this list is dropped to avoid surfacing UI-only knobs as
+ * unknown OpenAI parameters (which would 400 the request).
+ */
+const GPT_IMAGE_2_FORWARDED_PARAMS = new Set([
+  "size",
+  "quality",
+  "n",
+  "output_format",
+  "output_compression",
+  "background",
+  "moderation",
+  "thinking",
+  "user",
+]);
+
+/**
+ * Coerce a possibly-numeric param value into a sensible JSON value.
+ * The schema endpoint may emit numbers as strings ("1") from <input> elements;
+ * OpenAI is strict about types for `n` and `output_compression`.
+ */
+function coerceNumericIfNeeded(name: string, value: unknown): unknown {
+  if (name === "n" || name === "output_compression") {
+    if (typeof value === "string" && value.trim() !== "" && !Number.isNaN(Number(value))) {
+      return Number(value);
+    }
+  }
+  return value;
+}
+
+/**
+ * Build the JSON body for /v1/images/generations from a GenerationInput.
+ */
+function buildGenerationBody(input: GenerationInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: input.model.id,
+    prompt: input.prompt,
+  };
+
+  if (input.parameters) {
+    for (const [key, rawValue] of Object.entries(input.parameters)) {
+      if (!GPT_IMAGE_2_FORWARDED_PARAMS.has(key)) continue;
+      if (rawValue === null || rawValue === undefined || rawValue === "") continue;
+      body[key] = coerceNumericIfNeeded(key, rawValue);
+    }
+  }
+
+  return body;
+}
+
+/**
+ * Convert a base64 data URL or raw base64 into a Blob suitable for FormData.
+ *
+ * Returns a tuple of (blob, filename). The filename's extension reflects the
+ * detected mime type so OpenAI accepts it.
+ */
+function base64ToBlob(input: string, indexHint: number): { blob: Blob; filename: string } {
+  let mimeType = "image/png";
+  let dataPart = input;
+
+  if (input.startsWith("data:")) {
+    const m = input.match(/^data:([^;]+);base64,(.+)$/);
+    if (m) {
+      mimeType = m[1];
+      dataPart = m[2];
+    }
+  }
+
+  const buffer = Buffer.from(dataPart, "base64");
+
+  if (buffer.length > MAX_EDIT_IMAGE_BYTES) {
+    throw new Error(
+      `Image #${indexHint + 1} too large for OpenAI edits (${(buffer.length / (1024 * 1024)).toFixed(1)}MB > 50MB)`
+    );
+  }
+
+  let ext = "png";
+  if (mimeType === "image/jpeg" || mimeType === "image/jpg") ext = "jpg";
+  else if (mimeType === "image/webp") ext = "webp";
+
+  // Node 18+ has Blob in globals; new Blob expects a Uint8Array view.
+  const blob = new Blob([new Uint8Array(buffer)], { type: mimeType });
+  return { blob, filename: `image_${indexHint + 1}.${ext}` };
+}
+
+/**
+ * Collect all image inputs for an edit request, preferring dynamicInputs over
+ * the legacy `images` array but falling back to it if no dynamic inputs were
+ * routed to a known image key.
+ */
+function collectEditImages(input: GenerationInput): string[] {
+  const collected: string[] = [];
+
+  if (input.dynamicInputs) {
+    for (const [key, value] of Object.entries(input.dynamicInputs)) {
+      // gpt-image-2 only accepts an "image" field on edits; we accept any
+      // image-shaped input the schema may have surfaced.
+      if (
+        key !== "image" &&
+        key !== "images" &&
+        key !== "image_urls" &&
+        key !== "input_urls"
+      ) {
+        continue;
+      }
+      if (value === null || value === undefined || value === "") continue;
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (typeof item === "string" && item) collected.push(item);
+        }
+      } else if (typeof value === "string") {
+        collected.push(value);
+      }
+    }
+  }
+
+  if (collected.length === 0 && input.images && input.images.length > 0) {
+    collected.push(...input.images);
+  }
+
+  return collected;
+}
+
+/**
+ * Fetch a remote URL and return base64 — used so we can submit URL-only inputs
+ * to /v1/images/edits, which only accepts file uploads.
+ */
+async function urlToBase64(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch image from ${url.substring(0, 80)}: ${response.status}`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  const contentType = response.headers.get("content-type") || "image/png";
+  const base64 = Buffer.from(arrayBuffer).toString("base64");
+  return `data:${contentType};base64,${base64}`;
+}
+
+interface OpenAIImagesResponse {
+  data?: Array<{ b64_json?: string; url?: string; revised_prompt?: string }>;
+  error?: { message?: string; type?: string; code?: string };
+}
+
+/**
+ * Pull the first image from an OpenAI Images API response and convert it into
+ * a base64 data URL the rest of Node Banana expects.
+ */
+function extractFirstImageDataUrl(json: OpenAIImagesResponse, fallbackMime = "image/png"): string | null {
+  const first = json.data?.[0];
+  if (!first) return null;
+  if (first.b64_json) {
+    return `data:${fallbackMime};base64,${first.b64_json}`;
+  }
+  // gpt-image-2 doesn't currently return URLs, but handle it defensively
+  // in case OpenAI changes the response shape later.
+  if (first.url) {
+    return first.url;
+  }
+  return null;
+}
+
+/**
+ * Determine the output mime type for a given response so the data URL is
+ * well-formed when the user picked a non-default output_format.
+ */
+function inferOutputMimeType(parameters?: Record<string, unknown>): string {
+  const fmt = parameters?.output_format;
+  if (fmt === "jpeg" || fmt === "jpg") return "image/jpeg";
+  if (fmt === "webp") return "image/webp";
+  return "image/png";
+}
+
+/**
+ * Decide whether this generation should hit the edits endpoint or the
+ * generations endpoint.
+ */
+function isEditRequest(input: GenerationInput): boolean {
+  if (input.images && input.images.length > 0) return true;
+  if (input.dynamicInputs) {
+    for (const key of ["image", "images", "image_urls", "input_urls"] as const) {
+      const value = input.dynamicInputs[key];
+      if (value === null || value === undefined || value === "") continue;
+      if (Array.isArray(value) && value.some((v) => typeof v === "string" && v)) return true;
+      if (typeof value === "string" && value) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Build a friendly error string from an OpenAI error response body.
+ */
+async function readOpenAIError(response: Response, modelName: string): Promise<string> {
+  const text = await response.text();
+  let detail = text;
+  try {
+    const parsed = JSON.parse(text) as OpenAIImagesResponse;
+    if (parsed.error?.message) detail = parsed.error.message;
+  } catch {
+    // keep raw text
+  }
+  if (response.status === 429) {
+    return `${modelName}: Rate limit exceeded. Try again in a moment.`;
+  }
+  if (response.status === 401) {
+    return `${modelName}: OpenAI rejected the API key (401). Check OPENAI_API_KEY in Settings.`;
+  }
+  return `${modelName}: ${detail.substring(0, 500)}`;
+}
+
+/**
+ * POST /v1/images/generations for text-to-image.
+ */
+async function generateOpenAITextToImage(
+  requestId: string,
+  apiKey: string,
+  input: GenerationInput
+): Promise<GenerationOutput> {
+  const body = buildGenerationBody(input);
+
+  console.log(
+    `[API:${requestId}] OpenAI generations - Model: ${input.model.id}, Prompt: ${input.prompt.length} chars`
+  );
+
+  const response = await fetch(OPENAI_GENERATIONS_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    return { success: false, error: await readOpenAIError(response, input.model.name) };
+  }
+
+  const json = (await response.json()) as OpenAIImagesResponse;
+  const dataUrl = extractFirstImageDataUrl(json, inferOutputMimeType(input.parameters));
+  if (!dataUrl) {
+    return { success: false, error: `${input.model.name}: No image data in OpenAI response` };
+  }
+
+  console.log(`[API:${requestId}] SUCCESS - Returning OpenAI image`);
+  return {
+    success: true,
+    outputs: [{ type: "image", data: dataUrl }],
+  };
+}
+
+/**
+ * POST /v1/images/edits (multipart) for image editing / multi-image composition.
+ *
+ * gpt-image-2 supports up to 16 source images shared across one prompt.
+ */
+async function generateOpenAIImageEdit(
+  requestId: string,
+  apiKey: string,
+  input: GenerationInput
+): Promise<GenerationOutput> {
+  const sourceImages = collectEditImages(input);
+  if (sourceImages.length === 0) {
+    // Should be unreachable (caller picks the endpoint), but guard explicitly.
+    return generateOpenAITextToImage(requestId, apiKey, input);
+  }
+
+  if (sourceImages.length > MAX_EDIT_IMAGES) {
+    return {
+      success: false,
+      error: `${input.model.name}: ${sourceImages.length} images exceeds OpenAI's ${MAX_EDIT_IMAGES}-image limit for edits.`,
+    };
+  }
+
+  console.log(
+    `[API:${requestId}] OpenAI edits - Model: ${input.model.id}, Images: ${sourceImages.length}, Prompt: ${input.prompt.length} chars`
+  );
+
+  // Convert all sources into base64 data URLs first so we can attach them as
+  // file parts. Plain http(s) URLs get fetched server-side.
+  const normalized: string[] = [];
+  for (const source of sourceImages) {
+    if (source.startsWith("data:image")) {
+      normalized.push(source);
+    } else if (source.startsWith("http")) {
+      normalized.push(await urlToBase64(source));
+    } else {
+      // Treat anything else as raw base64 (legacy behaviour)
+      normalized.push(`data:image/png;base64,${source}`);
+    }
+  }
+
+  const formData = new FormData();
+  formData.append("model", input.model.id);
+  formData.append("prompt", input.prompt);
+
+  // Forward known params as form fields
+  if (input.parameters) {
+    for (const [key, rawValue] of Object.entries(input.parameters)) {
+      if (!GPT_IMAGE_2_FORWARDED_PARAMS.has(key)) continue;
+      if (rawValue === null || rawValue === undefined || rawValue === "") continue;
+      formData.append(key, String(coerceNumericIfNeeded(key, rawValue)));
+    }
+  }
+
+  // Attach source images. gpt-image-2 accepts the same field name repeated.
+  normalized.forEach((dataUrl, idx) => {
+    const { blob, filename } = base64ToBlob(dataUrl, idx);
+    formData.append("image", blob, filename);
+  });
+
+  const response = await fetch(OPENAI_EDITS_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      // NOTE: do NOT set Content-Type; the runtime fills in the multipart boundary.
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    return { success: false, error: await readOpenAIError(response, input.model.name) };
+  }
+
+  const json = (await response.json()) as OpenAIImagesResponse;
+  const dataUrl = extractFirstImageDataUrl(json, inferOutputMimeType(input.parameters));
+  if (!dataUrl) {
+    return { success: false, error: `${input.model.name}: No image data in OpenAI edits response` };
+  }
+
+  console.log(`[API:${requestId}] SUCCESS - Returning OpenAI edited image`);
+  return {
+    success: true,
+    outputs: [{ type: "image", data: dataUrl }],
+  };
+}
+
+/**
+ * Public entry point used by the generate route.
+ *
+ * Routes to the edits endpoint if any image input was provided, otherwise
+ * falls through to text-to-image generation.
+ */
+export async function generateWithOpenAI(
+  requestId: string,
+  apiKey: string,
+  input: GenerationInput
+): Promise<GenerationOutput> {
+  try {
+    if (isEditRequest(input)) {
+      return await generateOpenAIImageEdit(requestId, apiKey, input);
+    }
+    return await generateOpenAITextToImage(requestId, apiKey, input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "OpenAI image generation failed";
+    console.error(`[API:${requestId}] OpenAI generation error: ${message}`);
+    return { success: false, error: `${input.model.name}: ${message}` };
+  }
+}

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -17,6 +17,7 @@ import { generateWithGemini, generateWithGeminiVideo } from "./providers/gemini"
 import { generateWithReplicate } from "./providers/replicate";
 import { clearFalInputMappingCache as _clearFalInputMappingCache, generateWithFalQueue } from "./providers/fal";
 import { submitKieTask } from "./providers/kie";
+import { generateWithOpenAI } from "./providers/openai";
 import { generateWithWaveSpeed } from "./providers/wavespeed";
 
 // Re-export for backward compatibility (test file imports from route)
@@ -362,6 +363,76 @@ export async function POST(request: NextRequest) {
           { status: 500 }
         );
       }
+    }
+
+    if (provider === "openai") {
+      if (!selectedModel?.modelId || !selectedModel?.displayName) {
+        return NextResponse.json<GenerateResponse>(
+          { success: false, error: "selectedModel with modelId and displayName is required for OpenAI" },
+          { status: 400 }
+        );
+      }
+
+      // User-provided key (from settings) takes precedence over env variable
+      const openaiApiKey = request.headers.get("X-OpenAI-API-Key") || process.env.OPENAI_API_KEY;
+      if (!openaiApiKey) {
+        return NextResponse.json<GenerateResponse>(
+          {
+            success: false,
+            error: "OpenAI API key not configured. Add OPENAI_API_KEY to .env.local or configure in Settings.",
+          },
+          { status: 401 }
+        );
+      }
+
+      // Keep Data URIs as-is; the OpenAI provider converts them to multipart parts.
+      const processedImages: string[] = images ? [...images] : [];
+
+      // Process dynamicInputs: drop empty values, keep everything else verbatim.
+      let processedDynamicInputs: Record<string, string | string[]> | undefined = undefined;
+      if (dynamicInputs) {
+        processedDynamicInputs = {};
+        for (const key of Object.keys(dynamicInputs)) {
+          const value = dynamicInputs[key];
+          if (value === null || value === undefined || value === "") {
+            continue;
+          }
+          processedDynamicInputs[key] = value;
+        }
+      }
+
+      const genInput: GenerationInput = {
+        model: {
+          id: selectedModel.modelId,
+          name: selectedModel.displayName,
+          provider: "openai",
+          capabilities: capabilitiesForMediaType(mediaType),
+          description: null,
+        },
+        prompt: prompt || "",
+        images: processedImages,
+        parameters,
+        dynamicInputs: processedDynamicInputs,
+      };
+
+      const result = await generateWithOpenAI(requestId, openaiApiKey, genInput);
+
+      if (!result.success) {
+        return NextResponse.json<GenerateResponse>(
+          { success: false, error: result.error || "Generation failed" },
+          { status: 500 }
+        );
+      }
+
+      const output = result.outputs?.[0];
+      if (!output?.data && !output?.url) {
+        return NextResponse.json<GenerateResponse>(
+          { success: false, error: "No output in generation result" },
+          { status: 500 }
+        );
+      }
+
+      return buildMediaResponse(output);
     }
 
     if (provider === "wavespeed") {

--- a/src/app/api/models/[modelId]/route.ts
+++ b/src/app/api/models/[modelId]/route.ts
@@ -699,6 +699,23 @@ function getKieSchema(modelId: string): ExtractedSchema {
         { name: "input_urls", type: "image", required: true, label: "Image", isArray: true },
       ],
     },
+    "gpt-image-2/text-to-image": {
+      parameters: [
+        { name: "aspect_ratio", type: "string", description: "Output aspect ratio", enum: ["1:1", "2:3", "3:2", "4:3", "3:4", "16:9", "9:16"], default: "1:1" },
+        { name: "quality", type: "string", description: "Output quality tier", enum: ["low", "medium", "high"], default: "medium" },
+      ],
+      inputs: [{ name: "prompt", type: "text", required: true, label: "Prompt" }],
+    },
+    "gpt-image-2/image-to-image": {
+      parameters: [
+        { name: "aspect_ratio", type: "string", description: "Output aspect ratio", enum: ["1:1", "2:3", "3:2", "4:3", "3:4", "16:9", "9:16"], default: "1:1" },
+        { name: "quality", type: "string", description: "Output quality tier", enum: ["low", "medium", "high"], default: "medium" },
+      ],
+      inputs: [
+        { name: "prompt", type: "text", required: true, label: "Prompt" },
+        { name: "input_urls", type: "image", required: true, label: "Source Images", isArray: true },
+      ],
+    },
     "flux-2/pro-text-to-image": {
       parameters: [
         { name: "aspect_ratio", type: "string", description: "Output aspect ratio", enum: flux2AspectRatios, default: "1:1" },
@@ -1140,6 +1157,109 @@ function getKieSchema(modelId: string): ExtractedSchema {
 }
 
 /**
+ * Get hardcoded schema for OpenAI image models.
+ *
+ * OpenAI doesn't expose an OpenAPI discovery endpoint for image models, so we
+ * pin the parameter set explicitly. Source:
+ * https://developers.openai.com/api/docs/models/gpt-image-2
+ *
+ * Notes:
+ * - `size` accepts "auto" plus a fixed set of square/portrait/landscape sizes.
+ *   gpt-image-2 advertises support for additional resolutions up to ~2000px;
+ *   we expose a curated enum so the UI stays usable.
+ * - `quality` ranges low → high. "auto" lets the model pick.
+ * - `n` is 1-10 (multiple images, shared style).
+ * - `output_format` controls the file type; `output_compression` (0-100) only
+ *   applies to webp/jpeg.
+ * - `background` may be "auto" or "opaque". Transparent backgrounds are NOT
+ *   supported on gpt-image-2.
+ * - `moderation` is "auto" (default) or "low".
+ * - `thinking` is the new reasoning-effort knob: off / low / medium / high.
+ */
+function getOpenAISchema(modelId: string): ExtractedSchema | null {
+  if (modelId !== "gpt-image-2") return null;
+
+  const parameters: ModelParameter[] = [
+    {
+      name: "size",
+      type: "string",
+      description: "Output image dimensions. `auto` lets the model decide based on the prompt.",
+      enum: ["auto", "1024x1024", "1536x1024", "1024x1536", "2048x2048"],
+      default: "auto",
+    },
+    {
+      name: "quality",
+      type: "string",
+      description: "Quality tier. Higher quality is slower and more expensive.",
+      enum: ["auto", "low", "medium", "high"],
+      default: "auto",
+    },
+    {
+      name: "thinking",
+      type: "string",
+      description: "Reasoning effort. Higher = better composition but slower / more expensive.",
+      enum: ["off", "low", "medium", "high"],
+      default: "low",
+    },
+    {
+      name: "n",
+      type: "integer",
+      description: "Number of images to generate (1-10). Multiple images share style.",
+      default: 1,
+      minimum: 1,
+      maximum: 10,
+    },
+    {
+      name: "output_format",
+      type: "string",
+      description: "File format of the returned image.",
+      enum: ["png", "webp", "jpeg"],
+      default: "png",
+    },
+    {
+      name: "output_compression",
+      type: "integer",
+      description: "Compression level 0-100 (webp/jpeg only).",
+      default: 100,
+      minimum: 0,
+      maximum: 100,
+    },
+    {
+      name: "background",
+      type: "string",
+      description: "Background handling. Transparent is NOT supported on gpt-image-2.",
+      enum: ["auto", "opaque"],
+      default: "auto",
+    },
+    {
+      name: "moderation",
+      type: "string",
+      description: "Moderation strictness for the generated image.",
+      enum: ["auto", "low"],
+      default: "auto",
+    },
+  ];
+
+  // Single connectable handle: prompt + (optional) image input. The image
+  // handle being `isArray: true` lets the GenerateImageNode collect multiple
+  // upstream images for composition, which routes to /v1/images/edits at
+  // generation time.
+  const inputs: ModelInput[] = [
+    { name: "prompt", type: "text", required: true, label: "Prompt" },
+    {
+      name: "image",
+      type: "image",
+      required: false,
+      label: "Source Images",
+      description: "Optional. Up to 16 source images for editing or composition.",
+      isArray: true,
+    },
+  ];
+
+  return { parameters, inputs };
+}
+
+/**
  * Get schema for Gemini video models (native Veo via Gemini API)
  * Returns null if the model is not a Gemini video model.
  */
@@ -1460,11 +1580,11 @@ export async function GET(
   const decodedModelId = decodeURIComponent(modelId);
   const provider = request.nextUrl.searchParams.get("provider") as ProviderType | null;
 
-  if (!provider || (provider !== "replicate" && provider !== "fal" && provider !== "kie" && provider !== "wavespeed" && provider !== "gemini")) {
+  if (!provider || (provider !== "replicate" && provider !== "fal" && provider !== "kie" && provider !== "wavespeed" && provider !== "gemini" && provider !== "openai")) {
     return NextResponse.json<SchemaErrorResponse>(
       {
         success: false,
-        error: "Invalid or missing provider. Use ?provider=replicate, ?provider=fal, ?provider=kie, ?provider=wavespeed, or ?provider=gemini",
+        error: "Invalid or missing provider. Use ?provider=replicate, ?provider=fal, ?provider=kie, ?provider=wavespeed, ?provider=gemini, or ?provider=openai",
       },
       { status: 400 }
     );
@@ -1512,6 +1632,16 @@ export async function GET(
     } else if (provider === "kie") {
       // Kie.ai uses hardcoded schemas (no schema discovery API)
       result = getKieSchema(decodedModelId);
+    } else if (provider === "openai") {
+      // OpenAI image models use hardcoded schemas (no schema discovery API)
+      const openaiSchema = getOpenAISchema(decodedModelId);
+      if (!openaiSchema) {
+        return NextResponse.json<SchemaErrorResponse>(
+          { success: false, error: `Unknown OpenAI image model: ${decodedModelId}` },
+          { status: 400 }
+        );
+      }
+      result = openaiSchema;
     } else if (provider === "wavespeed") {
       // WaveSpeed uses dynamic schemas from API, with static fallback
       const apiKey = request.headers.get("X-WaveSpeed-Key") || process.env.WAVESPEED_API_KEY || null;

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -111,6 +111,24 @@ const KIE_MODELS: ProviderModel[] = [
     pageUrl: "https://kie.ai/gpt-image-1",
   },
   {
+    id: "gpt-image-2/text-to-image",
+    name: "GPT Image 2",
+    description: "OpenAI's reasoning-capable text-to-image model via Kie.ai. Supports flexible aspect ratios and multiple quality tiers.",
+    provider: "kie",
+    capabilities: ["text-to-image"],
+    coverImage: undefined,
+    pageUrl: "https://docs.kie.ai/market/gpt/gpt-image-2-text-to-image",
+  },
+  {
+    id: "gpt-image-2/image-to-image",
+    name: "GPT Image 2 Edit",
+    description: "OpenAI GPT Image 2 image editing and composition (up to 16 source images) via Kie.ai.",
+    provider: "kie",
+    capabilities: ["image-to-image"],
+    coverImage: undefined,
+    pageUrl: "https://docs.kie.ai/market/gpt/gpt-image-2-image-to-image",
+  },
+  {
     id: "flux-2/pro-text-to-image",
     name: "FLUX.2 Pro",
     description: "FLUX.2 Pro text-to-image generation via Kie.ai.",
@@ -497,6 +515,21 @@ const KIE_MODELS: ProviderModel[] = [
     coverImage: undefined,
     pricing: { type: "per-run", amount: 0.02, currency: "USD" },
     pageUrl: "https://kie.ai/elevenlabs-sound-effect",
+  },
+];
+
+// OpenAI image models (hardcoded - OpenAI doesn't expose a model-discovery endpoint
+// for image models, and gpt-image-2 has a fixed parameter schema).
+const OPENAI_IMAGE_MODELS: ProviderModel[] = [
+  {
+    id: "gpt-image-2",
+    name: "GPT Image 2",
+    description:
+      "OpenAI's reasoning-capable image model. Supports text-to-image and multi-image editing/composition (up to 16 source images), with optional reasoning effort via the `thinking` parameter.",
+    provider: "openai",
+    capabilities: ["text-to-image", "image-to-image"],
+    coverImage: undefined,
+    pageUrl: "https://developers.openai.com/api/docs/models/gpt-image-2",
   },
 ];
 
@@ -1098,6 +1131,7 @@ export async function GET(
   const falKey = request.headers.get("X-Fal-Key") || process.env.FAL_API_KEY || null;
   const kieKey = request.headers.get("X-Kie-Key") || process.env.KIE_API_KEY || null;
   const wavespeedKey = request.headers.get("X-WaveSpeed-Key") || process.env.WAVESPEED_API_KEY || null;
+  const openaiKey = request.headers.get("X-OpenAI-Key") || process.env.OPENAI_API_KEY || null;
 
   // Build list of all available providers (have keys from env or client headers)
   const availableProviders: string[] = ["gemini"]; // Gemini always available
@@ -1105,11 +1139,13 @@ export async function GET(
   if (replicateKey) availableProviders.push("replicate");
   if (kieKey) availableProviders.push("kie");
   if (wavespeedKey) availableProviders.push("wavespeed");
+  if (openaiKey) availableProviders.push("openai");
 
-  // Determine which providers to fetch from (excluding gemini/kie - handled separately as hardcoded)
+  // Determine which providers to fetch from (excluding gemini/kie/openai - handled separately as hardcoded)
   const providersToFetch: ProviderType[] = [];
   let includeGemini = false;
   let includeKie = false;
+  let includeOpenAI = false;
 
   if (providerFilter) {
     if (providerFilter === "gemini") {
@@ -1124,6 +1160,19 @@ export async function GET(
           {
             success: false,
             error: "Kie API key required. Add KIE_API_KEY to .env.local or configure in Settings.",
+          },
+          { status: 400 }
+        );
+      }
+    } else if (providerFilter === "openai") {
+      // Only OpenAI requested - no external API calls needed (hardcoded models)
+      if (openaiKey) {
+        includeOpenAI = true;
+      } else {
+        return NextResponse.json<ModelsErrorResponse>(
+          {
+            success: false,
+            error: "OpenAI API key required. Add OPENAI_API_KEY to .env.local or configure in Settings.",
           },
           { status: 400 }
         );
@@ -1152,6 +1201,7 @@ export async function GET(
     // Include all providers that have keys configured
     includeGemini = true; // Gemini always available
     includeKie = kieKey ? true : false; // Kie only if API key is configured
+    includeOpenAI = openaiKey ? true : false; // OpenAI image models only if key is configured
     if (wavespeedKey) {
       providersToFetch.push("wavespeed"); // WaveSpeed if key is configured
     }
@@ -1164,12 +1214,12 @@ export async function GET(
   }
 
   // Gemini and Kie are always available (with key for Kie), so we don't fail if no external providers
-  if (providersToFetch.length === 0 && !includeGemini && !includeKie) {
+  if (providersToFetch.length === 0 && !includeGemini && !includeKie && !includeOpenAI) {
     return NextResponse.json<ModelsErrorResponse>(
       {
         success: false,
         error:
-          "No providers available. Add REPLICATE_API_KEY, FAL_API_KEY, KIE_API_KEY, or WAVESPEED_API_KEY to .env.local or configure in Settings.",
+          "No providers available. Add REPLICATE_API_KEY, FAL_API_KEY, KIE_API_KEY, OPENAI_API_KEY, or WAVESPEED_API_KEY to .env.local or configure in Settings.",
       },
       { status: 400 }
     );
@@ -1208,6 +1258,21 @@ export async function GET(
     providerResults["kie"] = {
       success: true,
       count: kieModels.length,
+      cached: true, // Hardcoded models are effectively "cached"
+    };
+    anyFromCache = true;
+  }
+
+  // Add OpenAI image models if included (hardcoded, no API call needed)
+  if (includeOpenAI) {
+    let openaiModels = OPENAI_IMAGE_MODELS;
+    if (searchQuery) {
+      openaiModels = filterModelsBySearch(openaiModels, searchQuery);
+    }
+    allModels.push(...openaiModels);
+    providerResults["openai"] = {
+      success: true,
+      count: openaiModels.length,
       cached: true, // Hardcoded models are effectively "cached"
     };
     anyFromCache = true;

--- a/src/components/nodes/GenerateImageNode.tsx
+++ b/src/components/nodes/GenerateImageNode.tsx
@@ -63,7 +63,7 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
   const updateNodeData = useWorkflowStore((state) => state.updateNodeData);
   const generationsPath = useWorkflowStore((state) => state.generationsPath);
   // Use stable selector for API keys to prevent unnecessary re-fetches
-  const { replicateApiKey, falApiKey, kieApiKey, replicateEnabled, kieEnabled } = useProviderApiKeys();
+  const { replicateApiKey, falApiKey, kieApiKey, openaiApiKey, replicateEnabled, kieEnabled, openaiEnabled } = useProviderApiKeys();
   const [isLoadingCarouselImage, setIsLoadingCarouselImage] = useState(false);
   const [externalModels, setExternalModels] = useState<ProviderModel[]>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
@@ -105,8 +105,12 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
     if (kieEnabled && kieApiKey) {
       providers.push({ id: "kie", name: "Kie.ai" });
     }
+    // Add OpenAI if configured (image gen requires OPENAI_API_KEY in Settings)
+    if (openaiEnabled && openaiApiKey) {
+      providers.push({ id: "openai", name: "OpenAI" });
+    }
     return providers;
-  }, [replicateEnabled, replicateApiKey, kieEnabled, kieApiKey]);
+  }, [replicateEnabled, replicateApiKey, kieEnabled, kieApiKey, openaiEnabled, openaiApiKey]);
 
   // Migrate legacy data: derive selectedModel from model field if missing
   useEffect(() => {
@@ -143,6 +147,9 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
       if (kieApiKey) {
         headers["X-Kie-Key"] = kieApiKey;
       }
+      if (openaiApiKey) {
+        headers["X-OpenAI-Key"] = openaiApiKey;
+      }
       const response = await deduplicatedFetch(`/api/models?provider=${currentProvider}&capabilities=${capabilities}`, { headers });
       if (response.ok) {
         const data = await response.json();
@@ -165,7 +172,7 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
     } finally {
       setIsLoadingModels(false);
     }
-  }, [currentProvider, replicateApiKey, falApiKey, kieApiKey]);
+  }, [currentProvider, replicateApiKey, falApiKey, kieApiKey, openaiApiKey]);
 
   useEffect(() => {
     fetchModels();

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -2858,9 +2858,11 @@ export function useProviderApiKeys() {
       falApiKey: state.providerSettings.providers.fal?.apiKey ?? null,
       kieApiKey: state.providerSettings.providers.kie?.apiKey ?? null,
       wavespeedApiKey: state.providerSettings.providers.wavespeed?.apiKey ?? null,
+      openaiApiKey: state.providerSettings.providers.openai?.apiKey ?? null,
       // Provider enabled states (for conditional UI)
       replicateEnabled: state.providerSettings.providers.replicate?.enabled ?? false,
       kieEnabled: state.providerSettings.providers.kie?.enabled ?? false,
+      openaiEnabled: state.providerSettings.providers.openai?.enabled ?? false,
     }))
   );
 }


### PR DESCRIPTION
- Add new providers/openai.ts that calls /v1/images/generations and /v1/images/edits (multipart, up to 16 source images for composition)
- Register OPENAI_IMAGE_MODELS and add includeOpenAI branch + X-OpenAI-Key header handling in /api/models
- Add getOpenAISchema() with size/quality/n/output_format/output_compression/ background/moderation/thinking parameters
- Wire openai branch into /api/generate alongside existing providers
- Surface OpenAI in GenerateImageNode dropdown (gated on openaiEnabled+key); add openaiApiKey/openaiEnabled to useProviderApiKeys hook
- Also add gpt-image-2/text-to-image and gpt-image-2/image-to-image to Kie.ai (KIE_MODELS, schemas, defaults, input_urls image-input mapping)

Both routes work; user can pick OpenAI direct (uses OPENAI_API_KEY) or route via Kie.ai (uses KIE_API_KEY).