### PR TITLE
Replicate video models: discoverability, video-to-video support & search perf

### DIFF
--- a/src/app/api/generate/__tests__/route.test.ts
+++ b/src/app/api/generate/__tests__/route.test.ts
@@ -711,7 +711,7 @@ describe("/api/generate route", () => {
 
       expect(response.status).toBe(400);
       expect(data.success).toBe(false);
-      expect(data.error).toBe("Prompt or image input is required");
+      expect(data.error).toBe("Prompt, image, video, or audio input is required");
     });
 
     it("should accept request with only images (image-to-image)", async () => {
@@ -808,6 +808,23 @@ describe("/api/generate route", () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
+    });
+
+    it("should reject request whose only media input is an empty value", async () => {
+      process.env.GEMINI_API_KEY = "test-gemini-key";
+
+      const request = createMockPostRequest({
+        dynamicInputs: {
+          video_url: "",
+        },
+        model: "nano-banana-pro",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
     });
 
     it("should handle multiple images in request", async () => {

--- a/src/app/api/generate/__tests__/route.test.ts
+++ b/src/app/api/generate/__tests__/route.test.ts
@@ -791,6 +791,25 @@ describe("/api/generate route", () => {
       expect(data.success).toBe(true);
     });
 
+    it("should accept request with dynamicInputs containing a video (video-to-video)", async () => {
+      process.env.GEMINI_API_KEY = "test-gemini-key";
+
+      mockGenerateContent.mockResolvedValueOnce(createGeminiImageResponse());
+
+      const request = createMockPostRequest({
+        dynamicInputs: {
+          video_url: "data:video/mp4;base64,videoData",
+        },
+        model: "nano-banana-pro",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+
     it("should handle multiple images in request", async () => {
       process.env.GEMINI_API_KEY = "test-gemini-key";
 

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -116,15 +116,19 @@ export async function POST(request: NextRequest) {
     const hasImageInputs = dynamicInputs && Object.keys(dynamicInputs).some(key =>
       key.includes('frame') || key.includes('image')
     );
-    const hasMediaInputs = dynamicInputs && Object.keys(dynamicInputs).some(key =>
-      key.includes('video') || key.includes('audio')
+    const hasMediaInputs = dynamicInputs && Object.entries(dynamicInputs).some(([key, value]) =>
+      (key.includes('video') || key.includes('audio')) &&
+      (
+        (typeof value === 'string' && value.trim().length > 0) ||
+        (Array.isArray(value) && value.some((v) => typeof v === 'string' && v.trim().length > 0))
+      )
     );
 
     if (!hasPrompt && !hasImages && !hasImageInputs && !hasMediaInputs) {
       return NextResponse.json<GenerateResponse>(
         {
           success: false,
-          error: "Prompt or image input is required",
+          error: "Prompt, image, video, or audio input is required",
         },
         { status: 400 }
       );

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -106,6 +106,7 @@ export async function POST(request: NextRequest) {
     // - Provided via dynamicInputs
     // - Images are provided (image-to-video/image-to-image models)
     // - Dynamic inputs contain image frames (first_frame, last_frame, etc.)
+    // - Dynamic inputs contain a video (video-to-video upscalers/restorers) or audio
     const hasPrompt = prompt || (dynamicInputs && (
       typeof dynamicInputs.prompt === 'string'
         ? dynamicInputs.prompt
@@ -115,8 +116,11 @@ export async function POST(request: NextRequest) {
     const hasImageInputs = dynamicInputs && Object.keys(dynamicInputs).some(key =>
       key.includes('frame') || key.includes('image')
     );
+    const hasMediaInputs = dynamicInputs && Object.keys(dynamicInputs).some(key =>
+      key.includes('video') || key.includes('audio')
+    );
 
-    if (!hasPrompt && !hasImages && !hasImageInputs) {
+    if (!hasPrompt && !hasImages && !hasImageInputs && !hasMediaInputs) {
       return NextResponse.json<GenerateResponse>(
         {
           success: false,

--- a/src/app/api/generate/schemaUtils.ts
+++ b/src/app/api/generate/schemaUtils.ts
@@ -19,8 +19,9 @@ export const INPUT_PATTERNS: Record<string, string[]> = {
 
   // Video inputs (e.g. video-to-video upscalers/restorers). The connected video
   // normally travels via dynamicInputs under its exact schema name; this is a
-  // defensive mapping for the non-dynamic fallback path.
-  videoInput: ["video_url", "video_urls", "video", "input_video", "source_video",
+  // defensive mapping for the non-dynamic fallback path. (Bare "video" is
+  // omitted — it would partial-match params like "video_length"/"video_strength".)
+  videoInput: ["video_url", "video_urls", "input_video", "source_video",
                "init_video", "reference_video", "driving_video", "control_video"],
 
   // Video/media settings

--- a/src/app/api/generate/schemaUtils.ts
+++ b/src/app/api/generate/schemaUtils.ts
@@ -17,6 +17,12 @@ export const INPUT_PATTERNS: Record<string, string[]> = {
   image: ["image_url", "image_urls", "image", "first_frame", "start_image", "init_image",
           "reference_image", "input_image", "image_input", "source_image", "img", "photo"],
 
+  // Video inputs (e.g. video-to-video upscalers/restorers). The connected video
+  // normally travels via dynamicInputs under its exact schema name; this is a
+  // defensive mapping for the non-dynamic fallback path.
+  videoInput: ["video_url", "video_urls", "video", "input_video", "source_video",
+               "init_video", "reference_video", "driving_video", "control_video"],
+
   // Video/media settings
   aspectRatio: ["aspect_ratio", "ratio", "size", "dimensions", "output_size"],
   duration: ["duration", "length", "num_frames", "seconds", "video_length"],

--- a/src/app/api/models/[modelId]/__tests__/route.test.ts
+++ b/src/app/api/models/[modelId]/__tests__/route.test.ts
@@ -842,4 +842,48 @@ describe("/api/models/[modelId] schema endpoint", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("isVideoInput classification", () => {
+    it("should classify video_url as a video input (not image)", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createReplicateModelResponse({
+          video_url: { type: "string", format: "uri", description: "URL of the input video" },
+          upscale_factor: { type: "string", enum: ["2", "4"], default: "2" },
+        }, ["video_url"])
+      );
+
+      const modelId = `topazlabs/video-upscale-${testCounter}`;
+      const request = createMockSchemaRequest(modelId, "replicate");
+      const response = await GET(request, { params: Promise.resolve({ modelId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const videoInput = data.inputs.find((i: { name: string }) => i.name === "video_url");
+      expect(videoInput).toBeDefined();
+      expect(videoInput.type).toBe("video");
+    });
+
+    it("should keep first_frame/last_frame as image inputs while bare 'video' is a video input", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createReplicateModelResponse({
+          first_frame: { type: "string", format: "uri", description: "First frame image" },
+          last_frame: { type: "string", format: "uri", description: "Last frame image" },
+          video: { type: "string", format: "uri", description: "Input video to process" },
+        })
+      );
+
+      const modelId = `test/frames-${testCounter}`;
+      const request = createMockSchemaRequest(modelId, "replicate");
+      const response = await GET(request, { params: Promise.resolve({ modelId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const byName: Record<string, string> = Object.fromEntries(
+        data.inputs.map((i: { name: string; type: string }) => [i.name, i.type])
+      );
+      expect(byName.first_frame).toBe("image");
+      expect(byName.last_frame).toBe("image");
+      expect(byName.video).toBe("video");
+    });
+  });
 });

--- a/src/app/api/models/[modelId]/route.ts
+++ b/src/app/api/models/[modelId]/route.ts
@@ -63,6 +63,21 @@ const AUDIO_INPUT_PATTERNS = [
   "audio",
 ];
 
+// Video input property patterns. Deliberately excludes first_frame/last_frame,
+// which are still images and handled by IMAGE_INPUT_PATTERNS.
+const VIDEO_INPUT_PATTERNS = [
+  "video_url",
+  "video_urls",
+  "video",
+  "videos",
+  "input_video",
+  "source_video",
+  "init_video",
+  "reference_video",
+  "driving_video",
+  "control_video",
+];
+
 // Text input properties
 const TEXT_INPUT_NAMES = ["prompt", "negative_prompt"];
 
@@ -236,6 +251,46 @@ function isAudioInput(name: string, prop: Record<string, unknown>, schemaCompone
 
   // Check name patterns
   return name.endsWith("_audio") || name.startsWith("audio_");
+}
+
+/**
+ * Check if property is a video input based on schema type and name.
+ *
+ * Video inputs are strings (URLs or base64) or arrays of strings, like images
+ * and audio. Checked BEFORE isImageInput so video params (e.g. video_url) are
+ * not swallowed by the permissive image URL/uri heuristics.
+ */
+function isVideoInput(name: string, prop: Record<string, unknown>, schemaComponents?: Record<string, unknown>): boolean {
+  const resolved = resolvePropertyType(prop, schemaComponents);
+  const propType = resolved.type;
+  if (propType !== "string" && propType !== "array") {
+    return false;
+  }
+
+  // For arrays, check if items are strings
+  if (propType === "array") {
+    const items = prop.items as Record<string, unknown> | undefined;
+    if (items && items.type && items.type !== "string") {
+      return false;
+    }
+  }
+
+  // Check explicit patterns
+  if (VIDEO_INPUT_PATTERNS.includes(name)) {
+    return true;
+  }
+
+  // Check description for video-related keywords
+  const description = (prop.description as string || "").toLowerCase();
+  if (description.includes("video url") ||
+      description.includes("video file") ||
+      description.includes("url of the video") ||
+      description.includes("input video")) {
+    return true;
+  }
+
+  // Check name patterns
+  return name.endsWith("_video") || name.startsWith("video_");
 }
 
 /**
@@ -588,6 +643,21 @@ function extractParametersFromSchema(
       continue;
     }
 
+    // Video is checked before image: image detection is permissive (URL/uri
+    // description heuristics) and would otherwise swallow video_url-style params.
+    if (isVideoInput(name, prop, schemaComponents)) {
+      const resolvedType = resolvePropertyType(prop, schemaComponents).type;
+      inputs.push({
+        name,
+        type: "video",
+        required: required.includes(name),
+        label: toLabel(name),
+        description: prop.description as string | undefined,
+        isArray: resolvedType === "array",
+      });
+      continue;
+    }
+
     if (isImageInput(name, prop, schemaComponents)) {
       const resolvedType = resolvePropertyType(prop, schemaComponents).type;
       inputs.push({
@@ -629,12 +699,12 @@ function extractParametersFromSchema(
     return a.name.localeCompare(b.name);
   });
 
-  // Sort inputs: required first, then by type (image, audio, text), then alphabetically
-  const inputTypeOrder: Record<string, number> = { image: 0, audio: 1, text: 2 };
+  // Sort inputs: required first, then by type (image, video, audio, text), then alphabetically
+  const inputTypeOrder: Record<string, number> = { image: 0, video: 1, audio: 2, text: 3 };
   inputs.sort((a, b) => {
     if (a.required !== b.required) return a.required ? -1 : 1;
-    const aOrder = inputTypeOrder[a.type] ?? 3;
-    const bOrder = inputTypeOrder[b.type] ?? 3;
+    const aOrder = inputTypeOrder[a.type] ?? 4;
+    const bOrder = inputTypeOrder[b.type] ?? 4;
     if (aOrder !== bOrder) return aOrder - bOrder;
     return a.name.localeCompare(b.name);
   });

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -775,4 +775,76 @@ describe("/api/models route", () => {
       expect(data.models[10].name).toBe("zebra");
     });
   });
+
+  describe("Replicate fetch-by-id fallback", () => {
+    it("GET: resolves an exact owner/name that isn't in the paginated catalogue", async () => {
+      process.env.REPLICATE_API_KEY = "test-key";
+
+      mockFetch.mockImplementation((url: string) => {
+        // Direct single-model lookup (checked first — more specific path)
+        if (url.includes("/models/topazlabs/video-upscale")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+              owner: "topazlabs",
+              name: "video-upscale",
+              description: "Professional-grade video upscaling powered by AI.",
+              visibility: "public",
+              run_count: 100,
+            }),
+          });
+        }
+        // Bulk catalogue list — deliberately does NOT include the topaz model
+        if (url.includes("replicate.com")) {
+          return Promise.resolve(
+            createReplicateResponse([
+              { owner: "stability-ai", name: "sdxl", description: "SDXL model" },
+            ])
+          );
+        }
+        return Promise.reject(new Error("Unknown URL"));
+      });
+
+      const request = createMockGetRequest({ provider: "replicate", search: "topazlabs/video-upscale" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      const found = data.models.find((m: { id: string }) => m.id === "topazlabs/video-upscale");
+      expect(found).toBeDefined();
+      // A video upscaler must land under a video capability (visible in the Video node)
+      expect(found.capabilities).toContain("image-to-video");
+      // The direct lookup endpoint must have been hit
+      expect(
+        mockFetch.mock.calls.some((c: unknown[]) => String(c[0]).includes("/models/topazlabs/video-upscale"))
+      ).toBe(true);
+    });
+
+    it("GET: a non-existent owner/name 404s gracefully without failing the request", async () => {
+      process.env.REPLICATE_API_KEY = "test-key";
+
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes("/models/ghost/missing-model")) {
+          return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+        }
+        if (url.includes("replicate.com")) {
+          return Promise.resolve(
+            createReplicateResponse([
+              { owner: "stability-ai", name: "sdxl", description: "SDXL model" },
+            ])
+          );
+        }
+        return Promise.reject(new Error("Unknown URL"));
+      });
+
+      const request = createMockGetRequest({ provider: "replicate", search: "ghost/missing-model" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.models.find((m: { id: string }) => m.id === "ghost/missing-model")).toBeUndefined();
+    });
+  });
 });

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -919,5 +919,39 @@ describe("/api/models route", () => {
       expect(data.success).toBe(true);
       expect(data.models.find((m: { id: string }) => m.id === "black-forest/flux")).toBeDefined();
     });
+
+    it("GET: skips the search API when the cached list already has enough matches", async () => {
+      process.env.REPLICATE_API_KEY = "test-key";
+
+      let searchApiCalled = false;
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes("/search?query=")) {
+          searchApiCalled = true;
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ results: [] }) });
+        }
+        if (url.includes("replicate.com")) {
+          // List returns more than REPLICATE_SEARCH_MIN_RESULTS matches for "flux"
+          return Promise.resolve(
+            createReplicateResponse([
+              { owner: "a", name: "flux-1", description: "flux" },
+              { owner: "b", name: "flux-2", description: "flux" },
+              { owner: "c", name: "flux-3", description: "flux" },
+              { owner: "d", name: "flux-4", description: "flux" },
+              { owner: "e", name: "flux-5", description: "flux" },
+              { owner: "f", name: "flux-6", description: "flux" },
+            ])
+          );
+        }
+        return Promise.reject(new Error("Unknown URL"));
+      });
+
+      const request = createMockGetRequest({ provider: "replicate", search: "flux" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(searchApiCalled).toBe(false);
+      expect(data.models.length).toBeGreaterThanOrEqual(5);
+    });
   });
 });

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -847,4 +847,77 @@ describe("/api/models route", () => {
       expect(data.models.find((m: { id: string }) => m.id === "ghost/missing-model")).toBeUndefined();
     });
   });
+
+  describe("Replicate server-side search", () => {
+    it("GET: finds a model by name fragment via Replicate search even when not in the paginated list", async () => {
+      process.env.REPLICATE_API_KEY = "test-key";
+
+      mockFetch.mockImplementation((url: string) => {
+        // Server-side search endpoint (/v1/search?query=...) — checked first
+        if (url.includes("/search?query=")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+              results: [
+                {
+                  model: {
+                    owner: "topazlabs",
+                    name: "video-upscale",
+                    description: "Professional-grade video upscaling powered by AI.",
+                    visibility: "public",
+                    run_count: 50,
+                  },
+                },
+              ],
+            }),
+          });
+        }
+        // Bulk catalogue list — deliberately does NOT include the topaz model
+        if (url.includes("replicate.com")) {
+          return Promise.resolve(
+            createReplicateResponse([
+              { owner: "stability-ai", name: "sdxl", description: "SDXL model" },
+            ])
+          );
+        }
+        return Promise.reject(new Error("Unknown URL"));
+      });
+
+      // A plain fragment (no "/") — only server-side search can surface it
+      const request = createMockGetRequest({ provider: "replicate", search: "topaz" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const found = data.models.find((m: { id: string }) => m.id === "topazlabs/video-upscale");
+      expect(found).toBeDefined();
+      expect(found.capabilities).toContain("image-to-video");
+    });
+
+    it("GET: a failing search is non-fatal — list results still return", async () => {
+      process.env.REPLICATE_API_KEY = "test-key";
+
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes("/search?query=")) {
+          return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
+        }
+        if (url.includes("replicate.com")) {
+          return Promise.resolve(
+            createReplicateResponse([
+              { owner: "black-forest", name: "flux", description: "Flux model" },
+            ])
+          );
+        }
+        return Promise.reject(new Error("Unknown URL"));
+      });
+
+      const request = createMockGetRequest({ provider: "replicate", search: "flux" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.models.find((m: { id: string }) => m.id === "black-forest/flux")).toBeDefined();
+    });
+  });
 });

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -704,6 +704,19 @@ function inferReplicateCapabilities(model: ReplicateModel): ModelCapability[] {
     return capabilities;
   }
 
+  // Video-processing models (upscalers, restorers, frame interpolators) often
+  // don't say "video" in their name — gate them on a processing verb paired with
+  // a video signal so they still land under the Video node instead of Image.
+  const hasVideoProcessingSignal =
+    (searchText.includes("upscale") ||
+      searchText.includes("restore") ||
+      searchText.includes("interpolat")) &&
+    (searchText.includes("video") ||
+      searchText.includes("clip") ||
+      searchText.includes("footage") ||
+      searchText.includes("fps") ||
+      searchText.includes("frames"));
+
   // Check for video-related keywords
   const isVideoModel =
     searchText.includes("video") ||
@@ -711,14 +724,17 @@ function inferReplicateCapabilities(model: ReplicateModel): ModelCapability[] {
     searchText.includes("motion") ||
     searchText.includes("luma") ||
     searchText.includes("kling") ||
-    searchText.includes("minimax");
+    searchText.includes("minimax") ||
+    hasVideoProcessingSignal;
 
   if (isVideoModel) {
-    // Video model - determine video capability type
+    // Video model - determine video capability type. Processing models consume a
+    // media (video/frame) input, so treat them as image-to-video rather than text.
     if (
       searchText.includes("img2vid") ||
       searchText.includes("image-to-video") ||
-      searchText.includes("i2v")
+      searchText.includes("i2v") ||
+      hasVideoProcessingSignal
     ) {
       capabilities.push("image-to-video");
     } else {
@@ -785,6 +801,43 @@ async function fetchReplicateModels(apiKey: string): Promise<ProviderModel[]> {
   }
 
   return allModels;
+}
+
+/**
+ * Fetch a single Replicate model by its full "owner/name" id.
+ *
+ * The bulk listing in fetchReplicateModels only covers the first ~15 pages of
+ * Replicate's catalogue, so most models (e.g. topazlabs/video-upscale) never
+ * appear there. This direct lookup is the fallback used when a user searches by
+ * an exact model id. Returns null on a malformed id or any non-OK response
+ * (including 404) so a typo never fails the whole /api/models request.
+ */
+async function fetchReplicateModelById(
+  apiKey: string,
+  modelId: string
+): Promise<ProviderModel | null> {
+  const parts = modelId.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null;
+  }
+  const [owner, name] = parts;
+
+  try {
+    const response = await fetch(`${REPLICATE_API_BASE}/models/${owner}/${name}`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const model: ReplicateModel = await response.json();
+    return mapReplicateModel(model);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -1279,6 +1332,29 @@ export async function GET(
           error: errorMessage,
         };
         continue;
+      }
+    }
+
+    // Replicate fallback: if the user searched by an exact "owner/name" id that
+    // isn't in the paginated catalogue, resolve it directly so any public model
+    // is reachable (O(1) lookup rather than unbounded extra pagination).
+    if (
+      provider === "replicate" &&
+      searchQuery &&
+      searchQuery.includes("/") &&
+      !models.some((m) => m.id.toLowerCase() === searchQuery.toLowerCase())
+    ) {
+      const byId = await fetchReplicateModelById(replicateKey!, searchQuery);
+      if (byId) {
+        models = [...models, byId];
+        // Warm the cached full list so repeat searches resolve without a refetch.
+        const cachedFull = getCachedModels(cacheKey);
+        if (
+          cachedFull &&
+          !cachedFull.some((m) => m.id.toLowerCase() === byId.id.toLowerCase())
+        ) {
+          setCachedModels(cacheKey, [...cachedFull, byId]);
+        }
       }
     }
 

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -841,6 +841,73 @@ async function fetchReplicateModelById(
 }
 
 /**
+ * Extract valid Replicate models from a search response. Handles both the
+ * /v1/search shape ({ results: [{ model: {...} }] }) and a direct-model shape
+ * ({ results: [{...model}] }), skipping non-model results (collections, docs).
+ */
+function extractReplicateSearchModels(data: unknown): ProviderModel[] {
+  const results = (data as { results?: unknown[] })?.results;
+  if (!Array.isArray(results)) return [];
+
+  const models: ProviderModel[] = [];
+  for (const result of results) {
+    const candidate = ((result as { model?: unknown })?.model ?? result) as {
+      owner?: unknown;
+      name?: unknown;
+    };
+    if (candidate && typeof candidate.owner === "string" && typeof candidate.name === "string") {
+      models.push(mapReplicateModel(candidate as ReplicateModel));
+    }
+  }
+  return models;
+}
+
+/**
+ * Search Replicate's full catalogue server-side for a text query.
+ *
+ * The bulk listing only covers the first ~15 pages, so a fragment search like
+ * "topaz" can't find models outside that window. This hits Replicate's search
+ * so any public model is discoverable by name. Tries the dedicated /v1/search
+ * endpoint first, then falls back to QUERY /v1/models. Always returns an array
+ * (never throws) so a flaky/again-unreliable search can only ADD results, never
+ * break the request — list results and the by-id fallback still apply.
+ */
+async function searchReplicateModels(apiKey: string, query: string): Promise<ProviderModel[]> {
+  // 1) GET /v1/search?query=... (searches models, collections, docs)
+  try {
+    const response = await fetch(
+      `${REPLICATE_API_BASE}/search?query=${encodeURIComponent(query)}`,
+      { headers: { Authorization: `Bearer ${apiKey}` } }
+    );
+    if (response.ok) {
+      const models = extractReplicateSearchModels(await response.json());
+      if (models.length > 0) return models;
+    }
+  } catch {
+    // fall through to the models search
+  }
+
+  // 2) QUERY /v1/models (dedicated model search; plain-text body)
+  try {
+    const response = await fetch(`${REPLICATE_API_BASE}/models`, {
+      method: "QUERY",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "text/plain",
+      },
+      body: query,
+    });
+    if (response.ok) {
+      return extractReplicateSearchModels(await response.json());
+    }
+  } catch {
+    // ignore — search is best-effort
+  }
+
+  return [];
+}
+
+/**
  * Filter models by search query (client-side filtering for Replicate)
  */
 function filterModelsBySearch(
@@ -1332,6 +1399,27 @@ export async function GET(
           error: errorMessage,
         };
         continue;
+      }
+    }
+
+    // Replicate server-side search: the bulk list only covers ~15 pages, so a
+    // fragment search (e.g. "topaz") can't find models outside that window.
+    // Query Replicate's search and merge in any models not already present.
+    if (provider === "replicate" && searchQuery) {
+      const searchModels = await searchReplicateModels(replicateKey!, searchQuery);
+      if (searchModels.length > 0) {
+        const seen = new Set(models.map((m) => m.id.toLowerCase()));
+        const fresh: ProviderModel[] = [];
+        for (const m of searchModels) {
+          const key = m.id.toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            fresh.push(m);
+          }
+        }
+        if (fresh.length > 0) {
+          models = [...models, ...fresh];
+        }
       }
     }
 

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -41,6 +41,10 @@ import {
 // API base URLs
 const REPLICATE_API_BASE = "https://api.replicate.com/v1";
 const FAL_API_BASE = "https://api.fal.ai/v1";
+
+// When the cached catalogue already yields at least this many matches for a
+// search, skip Replicate's (slower) search API — the local results are enough.
+const REPLICATE_SEARCH_MIN_RESULTS = 5;
 const WAVESPEED_API_BASE = "https://api.wavespeed.ai/api/v3";
 
 // Categories we care about for image/video/3D/audio generation (fal.ai)
@@ -1402,11 +1406,22 @@ export async function GET(
       }
     }
 
-    // Replicate server-side search: the bulk list only covers ~15 pages, so a
+    // Replicate search: the cached catalogue only covers ~15 pages, so a
     // fragment search (e.g. "topaz") can't find models outside that window.
-    // Query Replicate's search and merge in any models not already present.
-    if (provider === "replicate" && searchQuery) {
-      const searchModels = await searchReplicateModels(replicateKey!, searchQuery);
+    // Search against the cache first and only call Replicate's slower search API
+    // when the local matches are too few — then cache those results per query so
+    // repeat searches stay fast.
+    if (
+      provider === "replicate" &&
+      searchQuery &&
+      models.length < REPLICATE_SEARCH_MIN_RESULTS
+    ) {
+      const searchCacheKey = getCacheKey(provider, searchQuery);
+      let searchModels = refresh ? null : getCachedModels(searchCacheKey);
+      if (!searchModels) {
+        searchModels = await searchReplicateModels(replicateKey!, searchQuery);
+        setCachedModels(searchCacheKey, searchModels);
+      }
       if (searchModels.length > 0) {
         const seen = new Set(models.map((m) => m.id.toLowerCase()));
         const fresh: ProviderModel[] = [];

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -162,7 +162,7 @@ const getNodeHandles = (nodeType: string): { inputs: string[]; outputs: string[]
     case "nanoBanana":
       return { inputs: ["image", "text"], outputs: ["image"] };
     case "generateVideo":
-      return { inputs: ["image", "text", "audio"], outputs: ["video"] };
+      return { inputs: ["image", "video", "text", "audio"], outputs: ["video"] };
     case "generate3d":
       return { inputs: ["image", "text"], outputs: ["3d"] };
     case "generateAudio":

--- a/src/components/__tests__/GenerateVideoNode.test.tsx
+++ b/src/components/__tests__/GenerateVideoNode.test.tsx
@@ -177,10 +177,11 @@ describe("GenerateVideoNode", () => {
         </TestWrapper>
       );
 
-      // Should have Image and Prompt labels for inputs, Video for output
+      // Inputs: Image, Video, Prompt (default handles). Output: Video.
+      // "Video" appears twice — once as the default video input, once as the output.
       expect(screen.getByText("Image")).toBeInTheDocument();
       expect(screen.getByText("Prompt")).toBeInTheDocument();
-      expect(screen.getByText("Video")).toBeInTheDocument();
+      expect(screen.getAllByText("Video").length).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/src/components/nodes/GenerateVideoNode.tsx
+++ b/src/components/nodes/GenerateVideoNode.tsx
@@ -492,7 +492,8 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
             });
           }
 
-          // Add video handles from schema (no placeholder — video is not a default input)
+          // Add video handles from schema, or a placeholder if none exist, so a
+          // video source can always be attached (e.g. before model selection).
           if (hasVideoInput) {
             videoInputs.forEach((input, index) => {
               handles.push({
@@ -503,6 +504,15 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
                 description: input.description || null,
                 isPlaceholder: false,
               });
+            });
+          } else {
+            handles.push({
+              id: "video",
+              type: "video",
+              label: "Video",
+              schemaName: null,
+              description: "Not used by this model",
+              isPlaceholder: true,
             });
           }
 
@@ -657,6 +667,16 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
           />
           {/* Default image label */}
           <HandleLabel label="Image" side="target" color="var(--handle-color-image)" top="calc(35% - 18px)" visible={showLabels} />
+          <Handle
+            type="target"
+            position={Position.Left}
+            id="video"
+            style={{ top: "50%", zIndex: 10 }}
+            data-handletype="video"
+            isConnectable={true}
+          />
+          {/* Default video label */}
+          <HandleLabel label="Video" side="target" color="var(--handle-color-video)" top="calc(50% - 18px)" visible={showLabels} />
           <Handle
             type="target"
             position={Position.Left}

--- a/src/components/nodes/GenerateVideoNode.tsx
+++ b/src/components/nodes/GenerateVideoNode.tsx
@@ -449,18 +449,20 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
         // we still need the image handle to preserve connections made before model selection.
         (() => {
           const imageInputs = nodeData.inputSchema!.filter(i => i.type === "image");
+          const videoInputs = nodeData.inputSchema!.filter(i => i.type === "video");
           const audioInputs = nodeData.inputSchema!.filter(i => i.type === "audio");
           const textInputs = nodeData.inputSchema!.filter(i => i.type === "text");
 
           // Always include at least one image and one text handle for connection stability
           const hasImageInput = imageInputs.length > 0;
+          const hasVideoInput = videoInputs.length > 0;
           const hasAudioInput = audioInputs.length > 0;
           const hasTextInput = textInputs.length > 0;
 
           // Build the handles array: schema inputs + fallback defaults if missing
           const handles: Array<{
             id: string;
-            type: "image" | "text" | "audio";
+            type: "image" | "text" | "audio" | "video";
             label: string;
             schemaName: string | null;
             description: string | null;
@@ -487,6 +489,20 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
               schemaName: null,
               description: "Not used by this model",
               isPlaceholder: true,
+            });
+          }
+
+          // Add video handles from schema (no placeholder — video is not a default input)
+          if (hasVideoInput) {
+            videoInputs.forEach((input, index) => {
+              handles.push({
+                id: `video-${index}`,
+                type: "video",
+                label: input.label,
+                schemaName: input.name,
+                description: input.description || null,
+                isPlaceholder: false,
+              });
             });
           }
 
@@ -527,32 +543,40 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
             });
           }
 
-          // Calculate positions: group by type order (image, audio, text) with gaps between groups
-          const imageHandles = handles.filter(h => h.type === "image");
-          const audioHandles = handles.filter(h => h.type === "audio");
-          const textHandles = handles.filter(h => h.type === "text");
-          const groupCount = [imageHandles.length > 0, audioHandles.length > 0, textHandles.length > 0].filter(Boolean).length;
-          const totalSlots = imageHandles.length + audioHandles.length + textHandles.length + (groupCount - 1); // gaps between groups
+          // Calculate positions: group by type order (image, video, audio, text)
+          // with a one-slot gap between adjacent non-empty groups.
+          const orderedGroups = [
+            { type: "image", handles: handles.filter(h => h.type === "image") },
+            { type: "video", handles: handles.filter(h => h.type === "video") },
+            { type: "audio", handles: handles.filter(h => h.type === "audio") },
+            { type: "text", handles: handles.filter(h => h.type === "text") },
+          ].filter(g => g.handles.length > 0);
+
+          const groupCount = orderedGroups.length;
+          const totalSlots =
+            orderedGroups.reduce((sum, g) => sum + g.handles.length, 0) +
+            Math.max(0, groupCount - 1); // gaps between groups
+
+          // Assign each handle a slot index, inserting a gap between groups
+          const slotById = new Map<string, number>();
+          let slotCursor = 0;
+          orderedGroups.forEach((group, groupIndex) => {
+            if (groupIndex > 0) slotCursor += 1; // gap before this group
+            group.handles.forEach((h) => {
+              slotById.set(h.id, slotCursor);
+              slotCursor += 1;
+            });
+          });
 
           const getHandleColor = (type: string) => {
             if (type === "image") return "var(--handle-color-image)";
+            if (type === "video") return "var(--handle-color-video)";
             if (type === "audio") return "var(--handle-color-audio)";
             return "var(--handle-color-text)";
           };
 
           const renderedHandles = handles.map((handle) => {
-            // Calculate position based on type group ordering
-            let adjustedIndex: number;
-            if (handle.type === "image") {
-              adjustedIndex = imageHandles.findIndex(h => h.id === handle.id);
-            } else if (handle.type === "audio") {
-              const gapAfterImages = imageHandles.length > 0 ? 1 : 0;
-              adjustedIndex = imageHandles.length + gapAfterImages + audioHandles.findIndex(h => h.id === handle.id);
-            } else {
-              const gapAfterImages = imageHandles.length > 0 && (audioHandles.length > 0 || textHandles.length > 0) ? 1 : 0;
-              const gapAfterAudio = audioHandles.length > 0 && textHandles.length > 0 ? 1 : 0;
-              adjustedIndex = imageHandles.length + gapAfterImages + audioHandles.length + gapAfterAudio + textHandles.findIndex(h => h.id === handle.id);
-            }
+            const adjustedIndex = slotById.get(handle.id) ?? 0;
             const topPercent = ((adjustedIndex + 1) / (totalSlots + 1)) * 100;
 
             return (
@@ -587,6 +611,15 @@ export function GenerateVideoNode({ id, data, selected }: NodeProps<GenerateVide
                   position={Position.Left}
                   id="image"
                   style={{ top: "35%", opacity: 0, pointerEvents: "none" }}
+                  isConnectable={false}
+                />
+              )}
+              {hasVideoInput && (
+                <Handle
+                  type="target"
+                  position={Position.Left}
+                  id="video"
+                  style={{ top: "42%", opacity: 0, pointerEvents: "none" }}
                   isConnectable={false}
                 />
               )}

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -43,7 +43,7 @@ export interface ModelInput {
   /** Property name from schema (e.g., "image_url", "tail_image_url", "prompt") */
   name: string;
   /** Handle type for connections */
-  type: "image" | "text" | "audio";
+  type: "image" | "text" | "audio" | "video";
   /** Whether this input is required */
   required: boolean;
   /** Human-readable label for the handle */

--- a/src/store/execution/__tests__/generateVideoExecutor.test.ts
+++ b/src/store/execution/__tests__/generateVideoExecutor.test.ts
@@ -88,6 +88,29 @@ describe("executeGenerateVideo", () => {
     await expect(executeGenerateVideo(ctx)).rejects.toThrow("Missing required inputs");
   });
 
+  it("should NOT throw when only a video input is connected (video-to-video)", async () => {
+    const node = makeNode();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true, video: "data:video/mp4;base64,output" }),
+    });
+    const ctx = makeCtx(node, {
+      getConnectedInputs: vi.fn().mockReturnValue({
+        images: [],
+        videos: ["data:video/mp4;base64,input"],
+        audio: [],
+        text: null,
+        dynamicInputs: { video_url: "data:video/mp4;base64,input" },
+        easeCurve: null,
+      }),
+    });
+
+    await expect(executeGenerateVideo(ctx)).resolves.toBeUndefined();
+    // dynamicInputs (which carries the connected video) must be forwarded to /api/generate
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.dynamicInputs.video_url).toBe("data:video/mp4;base64,input");
+  });
+
   it("should throw when no model selected", async () => {
     const node = makeNode({ selectedModel: null });
     const ctx = makeCtx(node);

--- a/src/store/execution/generateVideoExecutor.ts
+++ b/src/store/execution/generateVideoExecutor.ts
@@ -35,7 +35,7 @@ export async function executeGenerateVideo(
 
   const { useStoredFallback = false } = options;
 
-  const { images: connectedImages, text: connectedText, audio: connectedAudio, dynamicInputs } = getConnectedInputs(node.id);
+  const { images: connectedImages, text: connectedText, audio: connectedAudio, videos: connectedVideos, dynamicInputs } = getConnectedInputs(node.id);
 
   // Get fresh node data from store
   const freshNode = getFreshNode(node.id);
@@ -50,7 +50,8 @@ export async function executeGenerateVideo(
     text = connectedText ?? nodeData.inputPrompt;
     const hasPrompt = text || dynamicInputs.prompt || dynamicInputs.negative_prompt;
     const hasAudio = connectedAudio.length > 0;
-    if (!hasPrompt && images.length === 0 && !hasAudio) {
+    const hasVideo = connectedVideos.length > 0;
+    if (!hasPrompt && images.length === 0 && !hasAudio && !hasVideo) {
       updateNodeData(node.id, {
         status: "error",
         error: "Missing required inputs",
@@ -62,7 +63,8 @@ export async function executeGenerateVideo(
     text = connectedText;
     const hasPrompt = text || dynamicInputs.prompt || dynamicInputs.negative_prompt;
     const hasAudio = connectedAudio.length > 0;
-    if (!hasPrompt && images.length === 0 && !hasAudio) {
+    const hasVideo = connectedVideos.length > 0;
+    if (!hasPrompt && images.length === 0 && !hasAudio && !hasVideo) {
       updateNodeData(node.id, {
         status: "error",
         error: "Missing required inputs",

--- a/src/store/utils/__tests__/connectedInputs.test.ts
+++ b/src/store/utils/__tests__/connectedInputs.test.ts
@@ -250,6 +250,25 @@ describe("getConnectedInputsPure", () => {
     expect(result.dynamicInputs).toEqual({ image_url: "data:image/png;base64,a" });
   });
 
+  it("should map a connected video into dynamicInputs and videos via schema", () => {
+    const nodes = [
+      makeNode("vid", "videoInput", { video: "data:video/mp4;base64,v" }),
+      makeNode("gen", "generateVideo", {
+        inputSchema: [{ name: "video_url", type: "video" }],
+      }),
+    ];
+    const edges = [{
+      id: "vid-gen",
+      source: "vid",
+      target: "gen",
+      sourceHandle: "video",
+      targetHandle: "video-0",
+    }] as WorkflowEdge[];
+    const result = getConnectedInputsPure("gen", nodes, edges);
+    expect(result.dynamicInputs).toEqual({ video_url: "data:video/mp4;base64,v" });
+    expect(result.videos).toEqual(["data:video/mp4;base64,v"]);
+  });
+
   it("should extract easeCurve data", () => {
     const nodes = [
       makeNode("ec", "easeCurve", {

--- a/src/store/utils/__tests__/connectedInputs.test.ts
+++ b/src/store/utils/__tests__/connectedInputs.test.ts
@@ -354,11 +354,28 @@ describe("validateWorkflowPure", () => {
     expect(result.errors[0]).toContain("missing text input");
   });
 
-  it("should detect missing text input on generateVideo", () => {
+  it("should detect missing input on generateVideo when nothing is connected", () => {
     const nodes = [makeNode("vid", "generateVideo")];
     const result = validateWorkflowPure(nodes, []);
     expect(result.valid).toBe(false);
-    expect(result.errors[0]).toContain("missing text input");
+    expect(result.errors[0]).toContain("missing input");
+  });
+
+  it("should pass generateVideo with only a video input connected (no prompt required)", () => {
+    const nodes = [
+      makeNode("src", "videoInput", { video: "data:video/mp4;base64,v" }),
+      makeNode("vid", "generateVideo"),
+    ];
+    const edges = [{
+      id: "src-vid",
+      source: "src",
+      target: "vid",
+      sourceHandle: "video",
+      targetHandle: "video-0",
+    }] as WorkflowEdge[];
+    const result = validateWorkflowPure(nodes, edges);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
   });
 
   it("should detect missing image input on annotation without manual image", () => {

--- a/src/store/utils/connectedInputs.ts
+++ b/src/store/utils/connectedInputs.ts
@@ -428,17 +428,23 @@ export function validateWorkflowPure(
       }
     });
 
-  // Check generateVideo nodes have required text input
+  // Check generateVideo nodes have at least one usable input connected.
+  // A prompt is not always required: video-to-video models (e.g. upscalers)
+  // need only a video input, image-to-video needs an image, etc. This mirrors
+  // the executor, which runs as long as any of text/image/video/audio is present.
   nodes
     .filter((n) => n.type === "generateVideo")
     .forEach((node) => {
-      const textConnected = edges.some(
+      const hasInput = edges.some(
         (e) => e.target === node.id &&
                !e.data?.isLoop &&
-               (e.targetHandle === "text" || e.targetHandle?.startsWith("text-"))
+               (e.targetHandle === "text" || e.targetHandle?.startsWith("text-") ||
+                e.targetHandle === "image" || e.targetHandle?.startsWith("image-") ||
+                e.targetHandle === "video" || e.targetHandle?.startsWith("video-") ||
+                e.targetHandle === "audio" || e.targetHandle?.startsWith("audio-"))
       );
-      if (!textConnected) {
-        errors.push(`Video node "${node.id}" missing text input`);
+      if (!hasInput) {
+        errors.push(`Video node "${node.id}" missing input`);
       }
     });
 

--- a/src/store/utils/connectedInputs.ts
+++ b/src/store/utils/connectedInputs.ts
@@ -194,11 +194,19 @@ export function getConnectedInputsPure(
     const imageInputs = inputSchema.filter(i => i.type === "image");
     const textInputs = inputSchema.filter(i => i.type === "text");
     const audioInputs = inputSchema.filter(i => i.type === "audio");
+    const videoInputs = inputSchema.filter(i => i.type === "video");
 
     imageInputs.forEach((input, index) => {
       handleToSchemaName[`image-${index}`] = input.name;
       if (index === 0) {
         handleToSchemaName["image"] = input.name;
+      }
+    });
+
+    videoInputs.forEach((input, index) => {
+      handleToSchemaName[`video-${index}`] = input.name;
+      if (index === 0) {
+        handleToSchemaName["video"] = input.name;
       }
     });
 

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -174,7 +174,7 @@ export interface CarouselVideoItem {
  */
 export interface ModelInputDef {
   name: string;
-  type: "image" | "text" | "audio";
+  type: "image" | "text" | "audio" | "video";
   required: boolean;
   label: string;
   description?: string;


### PR DESCRIPTION
## Summary
Fixes Replicate video models (e.g. `topazlabs/video-upscale`) not appearing in the model browser, and makes them usable end-to-end.

## Changes
- **Discovery by id** — resolve an exact `owner/name` directly via the Replicate API when it's outside the paginated catalogue.
- **Classification** — video-processing models (upscalers / restorers / interpolators) now classify as video, not image.
- **Video inputs end-to-end** — new `"video"` input handle type: schema parsing, node UI (default + per-model handles), connection routing, and executor support, so a video source can drive a video-to-video model.
- **Server-side search** — the model browser now searches Replicate's full catalogue, not just the first ~15 pages.
- **Search performance** — search the cache first; only hit the search API when local matches are sparse, and cache results per query (so the extra call doesn't slow every search).
- **Validation** — the Video node no longer requires a connected prompt (any of text/image/video/audio suffices); the generate API also accepts video/audio-only inputs.

## Commits
- `eb0622a` fix(replicate): resolve models by exact id and classify video processors
- `f78b770` feat(video): support video inputs end-to-end for video-to-video models
- `561baf5` fix(replicate): search the full catalogue server-side, not just 15 pages
- `08ab905` fix(video): default video input handle + don't force a prompt to run
- `3eac5c1` fix(generate): accept video/audio-only inputs in the generate API
- `aaf3730` perf(replicate): search cache first, only hit search API when sparse

## Test plan
- `npm run test:run` — all passing (2040+ tests; new cases for discovery, search, classification, video handles, and validation)
- `npm run build` — clean
- Manual: search `topaz` in the Video node's model browser → model appears → connect a video source → run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct video input support across workflows, including new compatible handle types and routing for video-to-video connections.
  * Improved model schema detection and ordering for video inputs, plus enhanced model discovery via best-effort search fallback.
* **Bug Fixes**
  * Updated request and workflow validation to treat video inputs as acceptable required inputs (including improved error messaging).
  * Added coverage ensuring video-only executions work and empty video values are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->