### PR TITLE
fix(connectedInputs): populate dynamicInputs through router/switch passthrough

### DIFF
--- a/src/store/utils/__tests__/connectedInputs.test.ts
+++ b/src/store/utils/__tests__/connectedInputs.test.ts
@@ -250,6 +250,25 @@ describe("getConnectedInputsPure", () => {
     expect(result.dynamicInputs).toEqual({ image_url: "data:image/png;base64,a" });
   });
 
+  it("should populate dynamicInputs through a router passthrough (regression: router bypassed dynamicInputs → 422)", () => {
+    const nodes = [
+      makeNode("img", "imageInput", { image: "data:image/png;base64,a" }),
+      makeNode("r", "router"),
+      makeNode("gen", "nanoBanana", {
+        inputSchema: [{ name: "image_url", type: "image" }],
+      }),
+    ];
+    const edges = [
+      makeEdge("img", "r", "image"),   // source → router
+      makeEdge("r", "gen", "image-0"), // router → generate (named schema slot)
+    ];
+    const result = getConnectedInputsPure("gen", nodes, edges);
+    // Before the fix, dynamicInputs was empty for routed inputs (router returned early) → 422
+    expect(result.dynamicInputs).toEqual({ image_url: "data:image/png;base64,a" });
+    // images[] still populated too (nanoBanana path unaffected)
+    expect(result.images).toEqual(["data:image/png;base64,a"]);
+  });
+
   it("should map a connected video into dynamicInputs and videos via schema", () => {
     const nodes = [
       makeNode("vid", "videoInput", { video: "data:video/mp4;base64,v" }),

--- a/src/store/utils/connectedInputs.ts
+++ b/src/store/utils/connectedInputs.ts
@@ -231,6 +231,27 @@ export function getConnectedInputsPure(
     });
   }
 
+  // Populate dynamicInputs for a passthrough (router/switch) edge, mirroring the direct-connection
+  // mapping further below. Those branches `return` before that block runs, so without this a routed
+  // input never reaches dynamicInputs (the named schema slots) — which breaks generateVideo
+  // multi-image slots, video inputs, and negative prompts. (Surfaced as "Failed to fetch result: 422".)
+  const addPassthroughDynamicInput = (
+    targetHandle: string | null | undefined,
+    values: Array<string | null> | string | null,
+  ): void => {
+    if (!targetHandle) return;
+    const schemaName = handleToSchemaName[targetHandle];
+    if (!schemaName) return; // node has no schema slot for this handle (e.g. nanoBanana) → no-op
+    const list = Array.isArray(values) ? values : [values];
+    for (const v of list) {
+      if (v == null) continue;
+      const existing = dynamicInputs[schemaName];
+      dynamicInputs[schemaName] = existing !== undefined
+        ? (Array.isArray(existing) ? [...existing, v] : [existing, v])
+        : v;
+    }
+  };
+
   // Cache passthrough node results so multiple edges from the same router/switch
   // all receive correct data (the _visited set prevents re-traversal, so we cache
   // the result from the first traversal and reuse it for subsequent edges).
@@ -268,16 +289,21 @@ export function getConnectedInputsPure(
 
         if (edgeType === "image" || (!edgeType && isImageHandle(edge.sourceHandle))) {
           images.push(...routerInputs.images);
+          addPassthroughDynamicInput(edge.targetHandle, routerInputs.images);
         } else if (edgeType === "text" || (!edgeType && isTextHandle(edge.sourceHandle))) {
           if (routerInputs.text) text = routerInputs.text;
+          addPassthroughDynamicInput(edge.targetHandle, routerInputs.text);
         } else if (edgeType === "video") {
           videos.push(...routerInputs.videos);
+          addPassthroughDynamicInput(edge.targetHandle, routerInputs.videos);
         } else if (edgeType === "audio") {
           audio.push(...routerInputs.audio);
+          addPassthroughDynamicInput(edge.targetHandle, routerInputs.audio);
         } else if (edgeType === "3d") {
           if (routerInputs.model3d) model3d = routerInputs.model3d;
+          addPassthroughDynamicInput(edge.targetHandle, routerInputs.model3d);
         } else if (edgeType === "easeCurve") {
-          // EaseCurve passthrough
+          // EaseCurve passthrough (not a schema-named input → no dynamicInputs mapping)
           if (routerInputs.easeCurve) easeCurve = routerInputs.easeCurve;
         }
         return; // Skip normal getSourceOutput processing for this edge
@@ -302,14 +328,19 @@ export function getConnectedInputsPure(
 
         if (edgeType === "image") {
           images.push(...switchInputs.images);
+          addPassthroughDynamicInput(edge.targetHandle, switchInputs.images);
         } else if (edgeType === "text") {
           if (switchInputs.text) text = switchInputs.text;
+          addPassthroughDynamicInput(edge.targetHandle, switchInputs.text);
         } else if (edgeType === "video") {
           videos.push(...switchInputs.videos);
+          addPassthroughDynamicInput(edge.targetHandle, switchInputs.videos);
         } else if (edgeType === "audio") {
           audio.push(...switchInputs.audio);
+          addPassthroughDynamicInput(edge.targetHandle, switchInputs.audio);
         } else if (edgeType === "3d") {
           if (switchInputs.model3d) model3d = switchInputs.model3d;
+          addPassthroughDynamicInput(edge.targetHandle, switchInputs.model3d);
         } else if (edgeType === "easeCurve") {
           if (switchInputs.easeCurve) easeCurve = switchInputs.easeCurve;
         }


### PR DESCRIPTION
## Problem

Inputs routed through a Router or Switch node never reach `dynamicInputs`
(the schema-named parameter slots). The router/switch passthrough branches in
`getConnectedInputsPure` return early — before the block that maps an edge's
`targetHandle` to its schema name — so the routed value lands in
`images[]`/`text`/`videos[]` but the named slot stays empty.

For schema-driven nodes this drops the input from the provider request
entirely, and the provider rejects it ("Failed to fetch result: 422").

**Repro:** `imageInput → router → generateVideo` (any model with a named
image slot, e.g. `image-0`). The generate request is sent without the image
parameter. Same applies to multi-image slots, video inputs, and negative
prompts routed through a Switch.

## Fix

Mirror the direct-connection `dynamicInputs` mapping when a passthrough edge
delivers its values, for all data types (image/text/video/audio/3d).
`easeCurve` is deliberately excluded (not a schema-named input), and nodes
without an input schema (e.g. nanoBanana) are a no-op, as before.

## Testing

- New regression test: routed input must appear in `dynamicInputs`
  (verified it fails on `develop` without the fix, passes with it)
- All 33 tests in `connectedInputs.test.ts` pass