### PR TITLE
fix(annotation): stop Delete in the modal from deleting the node behind it

### DIFF
--- a/src/components/AnnotationModal.tsx
+++ b/src/components/AnnotationModal.tsx
@@ -103,14 +103,24 @@ export function AnnotationModal() {
   }, [selectedShapeId, currentTool]);
 
   useEffect(() => {
+    // While the annotation modal is open, destructive shortcuts must NOT reach the canvas
+    // (React Flow) behind it — the canvas reads a different isModalOpen flag, so its
+    // deleteKeyCode/undo are still live. e.g. Delete would remove the selected NODE, making it
+    // vanish on save. Intercept in the CAPTURE phase (fires before React Flow's document handler)
+    // and stop propagation for the keys the modal owns. Text-editing keys are left alone — React
+    // Flow already ignores key events whose target is a text input.
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!isModalOpen) return;
+
       if (e.key === "Delete" || e.key === "Backspace") {
-        if (selectedShapeId && !editingTextId) {
-          deleteAnnotation(selectedShapeId);
-        }
+        if (editingTextId) return; // typing in the text input — let it handle the key
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        if (selectedShapeId) deleteAnnotation(selectedShapeId);
+        return;
       }
       if (e.key === "Escape") {
+        e.stopImmediatePropagation();
         if (editingTextId) {
           setEditingTextId(null);
           setTextInputPosition(null);
@@ -118,20 +128,20 @@ export function AnnotationModal() {
         } else {
           closeModal();
         }
+        return;
       }
-      if (e.ctrlKey || e.metaKey) {
-        if (e.key === "z") {
-          e.preventDefault();
-          if (e.shiftKey) {
-            redo();
-          } else {
-            undo();
-          }
+      if ((e.ctrlKey || e.metaKey) && e.key === "z") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        if (e.shiftKey) {
+          redo();
+        } else {
+          undo();
         }
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
   }, [isModalOpen, selectedShapeId, editingTextId, deleteAnnotation, closeModal, undo, redo]);
 
   const getRelativePointerPosition = useCallback(() => {

--- a/src/components/__tests__/AnnotationModal.test.tsx
+++ b/src/components/__tests__/AnnotationModal.test.tsx
@@ -509,4 +509,58 @@ describe("AnnotationModal", () => {
       expect(canvasContainer).toBeInTheDocument();
     });
   });
+
+  describe("Keyboard handling", () => {
+    // Simulates React Flow's document-level key handler (deleteKeyCode etc.).
+    // While the modal is open, destructive keys must never reach it — otherwise
+    // Delete removes the selected NODE on the canvas behind the modal.
+    let canvasKeyHandler: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      canvasKeyHandler = vi.fn();
+      document.addEventListener("keydown", canvasKeyHandler);
+    });
+
+    afterEach(() => {
+      document.removeEventListener("keydown", canvasKeyHandler);
+    });
+
+    it("should delete the selected annotation on Delete without reaching the canvas", () => {
+      mockAnnotationStore = createMockAnnotationStore({ selectedShapeId: "shape-1" });
+      render(<AnnotationModal />);
+
+      fireEvent.keyDown(document.body, { key: "Delete" });
+
+      expect(mockDeleteAnnotation).toHaveBeenCalledWith("shape-1");
+      expect(canvasKeyHandler).not.toHaveBeenCalled();
+    });
+
+    it("should swallow Delete even with no annotation selected (regression: node behind modal was deleted)", () => {
+      mockAnnotationStore = createMockAnnotationStore({ selectedShapeId: null });
+      render(<AnnotationModal />);
+
+      fireEvent.keyDown(document.body, { key: "Delete" });
+
+      expect(mockDeleteAnnotation).not.toHaveBeenCalled();
+      expect(canvasKeyHandler).not.toHaveBeenCalled();
+    });
+
+    it("should close the modal on Escape without reaching the canvas", () => {
+      render(<AnnotationModal />);
+
+      fireEvent.keyDown(document.body, { key: "Escape" });
+
+      expect(mockCloseModal).toHaveBeenCalled();
+      expect(canvasKeyHandler).not.toHaveBeenCalled();
+    });
+
+    it("should let keys reach the canvas when the modal is closed", () => {
+      mockAnnotationStore = createMockAnnotationStore({ isModalOpen: false });
+      render(<AnnotationModal />);
+
+      fireEvent.keyDown(document.body, { key: "Delete" });
+
+      expect(canvasKeyHandler).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Pressing Delete inside the annotation modal can delete the **node on the
canvas behind the modal** — the node then vanishes when the annotation is
saved.

The modal's keydown handler runs on `window` in the bubble phase and never
stops the event, so React Flow's document-level `deleteKeyCode` handler also
receives it and removes the currently selected node. (The canvas gates its
shortcuts on `workflowStore.isModalOpen`, which the annotation modal never
sets, so those guards stay inactive.)

**Repro:** select a node → open its annotation editor → click an annotation
shape (or nothing at all) → press Delete → close/save the modal. The node
behind it is gone.

## Fix

Intercept Delete/Backspace/Escape/Ctrl+Z in the **capture phase** and
`stopImmediatePropagation()` for the keys the modal owns, so they never reach
the canvas. Text-editing keys are untouched (`editingTextId` returns early,
and React Flow already ignores key events targeting text inputs).

## Testing

- New "Keyboard handling" tests: a simulated document-level canvas handler
  must not fire while the modal is open (Delete with/without a selected
  shape, Escape), and keys pass through again once the modal is closed
- The interception tests fail on `develop` without the fix, pass with it
- All 48 tests in `AnnotationModal.test.tsx` pass