### PR TITLE
feat: improve split-grid workflows and downstream routing

### DIFF
--- a/src/app/api/generate/__tests__/route.test.ts
+++ b/src/app/api/generate/__tests__/route.test.ts
@@ -303,6 +303,60 @@ describe("/api/generate route", () => {
       );
     });
 
+    it("should NOT apply search tools for nano-banana-2-lite model", async () => {
+      process.env.GEMINI_API_KEY = "test-gemini-key";
+
+      mockGenerateContent.mockResolvedValueOnce(createGeminiImageResponse());
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        model: "nano-banana-2-lite",
+        useGoogleSearch: true,
+        useImageSearch: true,
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      // nano-banana-2-lite has no Google Search or Image Search grounding
+      expect(mockGenerateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.not.objectContaining({
+            tools: expect.anything(),
+          }),
+        })
+      );
+    });
+
+    it("should NOT apply resolution config for nano-banana-2-lite model", async () => {
+      process.env.GEMINI_API_KEY = "test-gemini-key";
+
+      mockGenerateContent.mockResolvedValueOnce(createGeminiImageResponse());
+
+      const request = createMockPostRequest({
+        prompt: "A landscape photo",
+        model: "nano-banana-2-lite",
+        aspectRatio: "16:9",
+        resolution: "1024x1024",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      // nano-banana-2-lite is 1K only: imageSize must not be sent even if resolution is provided
+      expect(mockGenerateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            imageConfig: { aspectRatio: "16:9" },
+          }),
+        })
+      );
+    });
+
     it("should apply imageSearch searchType for nano-banana-2 with useImageSearch only", async () => {
       process.env.GEMINI_API_KEY = "test-gemini-key";
 
@@ -634,6 +688,28 @@ describe("/api/generate route", () => {
       expect(mockGenerateContent).toHaveBeenCalledWith(
         expect.objectContaining({
           model: "gemini-2.5-flash-image",
+        })
+      );
+    });
+
+    it("should use correct model mapping for nano-banana-2-lite", async () => {
+      process.env.GEMINI_API_KEY = "test-gemini-key";
+
+      mockGenerateContent.mockResolvedValueOnce(createGeminiImageResponse());
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        model: "nano-banana-2-lite",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(mockGenerateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: "gemini-3.1-flash-lite-image",
         })
       );
     });

--- a/src/app/api/generate/providers/gemini.ts
+++ b/src/app/api/generate/providers/gemini.ts
@@ -16,6 +16,7 @@ export const MODEL_MAP: Record<ModelType, string> = {
   "nano-banana": "gemini-2.5-flash-image",
   "nano-banana-pro": "gemini-3-pro-image-preview",
   "nano-banana-2": "gemini-3.1-flash-image-preview",
+  "nano-banana-2-lite": "gemini-3.1-flash-lite-image",
 };
 
 /**

--- a/src/app/api/models/[modelId]/route.ts
+++ b/src/app/api/models/[modelId]/route.ts
@@ -1313,6 +1313,12 @@ function getGeminiImageSchema(modelId: string): ExtractedSchema | null {
       ],
       inputs: commonInputs,
     },
+    "nano-banana-2-lite": {
+      parameters: [
+        { name: "aspectRatio", type: "string", description: "Output aspect ratio", enum: baseAspectRatios, default: "1:1" },
+      ],
+      inputs: commonInputs,
+    },
   };
 
   return schemas[modelId] ?? null;

--- a/src/app/api/models/__tests__/route.test.ts
+++ b/src/app/api/models/__tests__/route.test.ts
@@ -124,12 +124,12 @@ describe("/api/models route", () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      // 2 fal models + 7 gemini models (3 image + 4 video, always included)
-      expect(data.models).toHaveLength(9);
+      // 2 fal models + 8 gemini models (4 image + 4 video, always included)
+      expect(data.models).toHaveLength(10);
       expect(data.providers.fal.success).toBe(true);
       expect(data.providers.fal.count).toBe(2);
       expect(data.providers.gemini.success).toBe(true);
-      expect(data.providers.gemini.count).toBe(7);
+      expect(data.providers.gemini.count).toBe(8);
     });
 
     it("GET: should return models from both providers when both keys present", async () => {
@@ -156,8 +156,8 @@ describe("/api/models route", () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      // 1 replicate + 1 fal + 7 gemini models (always included)
-      expect(data.models).toHaveLength(9);
+      // 1 replicate + 1 fal + 8 gemini models (always included)
+      expect(data.models).toHaveLength(10);
       expect(data.providers.replicate.success).toBe(true);
       expect(data.providers.fal.success).toBe(true);
       expect(data.providers.gemini.success).toBe(true);
@@ -445,8 +445,8 @@ describe("/api/models route", () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      // 1 fal + 7 gemini models (always included)
-      expect(data.models).toHaveLength(8);
+      // 1 fal + 8 gemini models (always included)
+      expect(data.models).toHaveLength(9);
       expect(data.providers.replicate.success).toBe(false);
       expect(data.providers.fal.success).toBe(true);
       expect(data.providers.gemini.success).toBe(true);
@@ -684,8 +684,8 @@ describe("/api/models route", () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      // 4 fal models + 7 gemini models (always included)
-      expect(data.models).toHaveLength(11);
+      // 4 fal models + 8 gemini models (always included)
+      expect(data.models).toHaveLength(12);
       expect(data.models.find((m: { id: string }) => m.id === "fal-ai/flux")?.capabilities).toEqual(["text-to-image"]);
       expect(data.models.find((m: { id: string }) => m.id === "fal-ai/img2img")?.capabilities).toEqual(["image-to-image"]);
       expect(data.models.find((m: { id: string }) => m.id === "fal-ai/t2v")?.capabilities).toEqual(["text-to-video"]);
@@ -712,8 +712,8 @@ describe("/api/models route", () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      // 1 fal text-to-image + 1 fal text-to-speech (mapped to text-to-audio) + 7 gemini models (always included)
-      expect(data.models).toHaveLength(9);
+      // 1 fal text-to-image + 1 fal text-to-speech (mapped to text-to-audio) + 8 gemini models (always included)
+      expect(data.models).toHaveLength(10);
       expect(data.models.find((m: { id: string }) => m.id === "fal-ai/flux")).toBeDefined();
       expect(data.models.find((m: { id: string }) => m.id === "fal-ai/tts")?.capabilities).toEqual(["text-to-audio"]);
     });
@@ -754,25 +754,27 @@ describe("/api/models route", () => {
       expect(data.models[0].name).toBe("Alpha");
       expect(data.models[1].provider).toBe("fal");
       expect(data.models[1].name).toBe("Zebra");
-      // Gemini models: 3 image + 4 video, sorted by name
+      // Gemini models: 4 image + 4 video, sorted by name
       expect(data.models[2].provider).toBe("gemini");
       expect(data.models[2].name).toBe("Nano Banana");
       expect(data.models[3].provider).toBe("gemini");
       expect(data.models[3].name).toBe("Nano Banana 2");
       expect(data.models[4].provider).toBe("gemini");
-      expect(data.models[4].name).toBe("Nano Banana Pro");
+      expect(data.models[4].name).toBe("Nano Banana 2 Lite");
       expect(data.models[5].provider).toBe("gemini");
-      expect(data.models[5].name).toBe("Veo 3.1");
+      expect(data.models[5].name).toBe("Nano Banana Pro");
       expect(data.models[6].provider).toBe("gemini");
-      expect(data.models[6].name).toBe("Veo 3.1 Fast");
+      expect(data.models[6].name).toBe("Veo 3.1");
       expect(data.models[7].provider).toBe("gemini");
-      expect(data.models[7].name).toBe("Veo 3.1 Fast I2V");
+      expect(data.models[7].name).toBe("Veo 3.1 Fast");
       expect(data.models[8].provider).toBe("gemini");
-      expect(data.models[8].name).toBe("Veo 3.1 I2V");
-      expect(data.models[9].provider).toBe("replicate");
-      expect(data.models[9].name).toBe("alpha");
+      expect(data.models[8].name).toBe("Veo 3.1 Fast I2V");
+      expect(data.models[9].provider).toBe("gemini");
+      expect(data.models[9].name).toBe("Veo 3.1 I2V");
       expect(data.models[10].provider).toBe("replicate");
-      expect(data.models[10].name).toBe("zebra");
+      expect(data.models[10].name).toBe("alpha");
+      expect(data.models[11].provider).toBe("replicate");
+      expect(data.models[11].name).toBe("zebra");
     });
   });
 

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -522,6 +522,15 @@ const GEMINI_IMAGE_MODELS: ProviderModel[] = [
     pricing: { type: "per-run", amount: 0.067, currency: "USD" },
   },
   {
+    id: "nano-banana-2-lite",
+    name: "Nano Banana 2 Lite",
+    description: "Fast, low-cost image generation with Gemini 3.1 Flash Lite. Supports text-to-image and image-to-image with up to 10 reference images at 1K resolution.",
+    provider: "gemini",
+    capabilities: ["text-to-image", "image-to-image"],
+    coverImage: undefined,
+    pricing: { type: "per-run", amount: 0.034, currency: "USD" },
+  },
+  {
     id: "nano-banana-pro",
     name: "Nano Banana Pro",
     description: "High-quality image generation with Gemini 3 Pro. Supports text-to-image, image-to-image, resolution control (1K/2K/4K), and Google Search grounding.",

--- a/src/components/CostDialog.tsx
+++ b/src/components/CostDialog.tsx
@@ -260,7 +260,7 @@ export function CostDialog({ predictedCost, incurredCost, onClose }: CostDialogP
 
           {/* Pricing Note */}
           <div className="text-xs text-neutral-600">
-            <p>Gemini pricing: $0.039-$0.24/image. External providers not tracked.</p>
+            <p>Gemini pricing: $0.034-$0.24/image. External providers not tracked.</p>
           </div>
         </div>
       </div>

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -81,6 +81,7 @@ import { ModelSearchDialog } from "./modals/ModelSearchDialog";
 import { LLMFallbackPopover } from "./nodes/LLMFallbackPopover";
 import { browseRegistry } from "@/utils/browseRegistry";
 import { useInlineParameters } from "@/hooks/useInlineParameters";
+import { useWheelPanZoom } from "@/hooks/useWheelPanZoom";
 import { SplitGridTemplateModal } from "./splitgrid/SplitGridTemplateModal";
 import { createPortal } from "react-dom";
 import { useAnnotationStore } from "@/store/annotationStore";
@@ -249,73 +250,6 @@ interface ConnectionDropState {
 // Detect if running on macOS for platform-specific trackpad behavior
 const isMacOS = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
-// Detect if a wheel event is from a mouse (vs trackpad)
-const isMouseWheel = (event: WheelEvent): boolean => {
-  // Mouse scroll wheel typically uses deltaMode 1 (lines) or has large discrete deltas
-  // Trackpad uses deltaMode 0 (pixels) with smaller, smoother deltas
-  if (event.deltaMode === 1) return true; // DOM_DELTA_LINE = mouse
-
-  // Fallback: large delta values suggest mouse wheel
-  const threshold = 50;
-  return Math.abs(event.deltaY) >= threshold &&
-         Math.abs(event.deltaY) % 40 === 0; // Mouse deltas often in multiples
-};
-
-// Check if an element can scroll and has room to scroll in the given direction
-const canElementScroll = (element: HTMLElement, deltaX: number, deltaY: number): boolean => {
-  const style = window.getComputedStyle(element);
-  const overflowY = style.overflowY;
-  const overflowX = style.overflowX;
-
-  const canScrollY = overflowY === 'auto' || overflowY === 'scroll';
-  const canScrollX = overflowX === 'auto' || overflowX === 'scroll';
-
-  // Check if there's room to scroll in the delta direction
-  if (canScrollY && deltaY !== 0) {
-    const hasVerticalScroll = element.scrollHeight > element.clientHeight;
-    if (hasVerticalScroll) {
-      // Check if we can scroll further in the delta direction
-      if (deltaY > 0 && element.scrollTop < element.scrollHeight - element.clientHeight) {
-        return true; // Can scroll down
-      }
-      if (deltaY < 0 && element.scrollTop > 0) {
-        return true; // Can scroll up
-      }
-    }
-  }
-
-  if (canScrollX && deltaX !== 0) {
-    const hasHorizontalScroll = element.scrollWidth > element.clientWidth;
-    if (hasHorizontalScroll) {
-      if (deltaX > 0 && element.scrollLeft < element.scrollWidth - element.clientWidth) {
-        return true; // Can scroll right
-      }
-      if (deltaX < 0 && element.scrollLeft > 0) {
-        return true; // Can scroll left
-      }
-    }
-  }
-
-  return false;
-};
-
-// Find if the target element or any ancestor is scrollable
-const findScrollableAncestor = (target: HTMLElement, deltaX: number, deltaY: number): HTMLElement | null => {
-  let current: HTMLElement | null = target;
-
-  while (current && !current.classList.contains('react-flow')) {
-    // Check for nowheel class (React Flow convention for elements that should handle their own scroll)
-    if (current.classList.contains('nowheel') || current.tagName === 'TEXTAREA') {
-      if (canElementScroll(current, deltaX, deltaY)) {
-        return current;
-      }
-    }
-    current = current.parentElement;
-  }
-
-  return null;
-};
-
 /** Shared ref so child components (BaseNode) can check panning state without re-rendering */
 export const isPanningRef = { current: false };
 /** Shared ref so child components (BaseNode) can skip hover updates during node drags */
@@ -354,7 +288,7 @@ export function WorkflowCanvas() {
   const clearWorkflow = useWorkflowStore((state) => state.clearWorkflow);
   const setHoveredNodeId = useWorkflowStore((state) => state.setHoveredNodeId);
   const openAnnotationModal = useAnnotationStore((state) => state.openModal);
-  const { screenToFlowPosition, getViewport, zoomIn, zoomOut, setViewport, setCenter } = useReactFlow();
+  const { screenToFlowPosition, getViewport, setCenter } = useReactFlow();
   const { show: showToast } = useToast();
   const [isDragOver, setIsDragOver] = useState(false);
   const [dropType, setDropType] = useState<"image" | "audio" | "workflow" | "node" | null>(null);
@@ -1549,80 +1483,9 @@ export function WorkflowCanvas() {
   const undo = useWorkflowStore((state) => state.undo);
   const redo = useWorkflowStore((state) => state.redo);
 
-  // Add non-passive wheel listener to handle zoom/pan and prevent browser navigation
-  // This replaces the onWheel prop which is passive by default and can't preventDefault
-  useEffect(() => {
-    const wrapper = reactFlowWrapper.current;
-    if (!wrapper) return;
-
-    const handleWheelNonPassive = (event: WheelEvent) => {
-      // Skip if modal is open
-      if (isModalOpen) return;
-
-      // Check if scrolling over a scrollable element
-      const target = event.target as HTMLElement;
-      const scrollableElement = findScrollableAncestor(target, event.deltaX, event.deltaY);
-      if (scrollableElement) return;
-
-      const { zoomMode } = canvasNavigationSettings;
-
-      // Check if zoom should be triggered based on settings
-      const shouldZoom =
-        zoomMode === "scroll" ||
-        (zoomMode === "altScroll" && event.altKey) ||
-        (zoomMode === "ctrlScroll" && (event.ctrlKey || event.metaKey));
-
-      // Pinch gesture (ctrlKey + trackpad) always zooms regardless of settings
-      if (event.ctrlKey && !event.altKey) {
-        event.preventDefault();
-        if (event.deltaY < 0) zoomIn();
-        else zoomOut();
-        return;
-      }
-
-      // On macOS, differentiate trackpad from mouse
-      if (isMacOS) {
-        if (isMouseWheel(event)) {
-          // Mouse wheel → zoom if settings allow
-          if (shouldZoom) {
-            event.preventDefault();
-            if (event.deltaY < 0) zoomIn();
-            else zoomOut();
-          }
-        } else {
-          // Trackpad scroll
-          if (shouldZoom) {
-            // Zoom
-            event.preventDefault();
-            if (event.deltaY < 0) zoomIn();
-            else zoomOut();
-          } else {
-            // Pan (also prevent horizontal swipe navigation)
-            event.preventDefault();
-            const viewport = getViewport();
-            setViewport({
-              x: viewport.x - event.deltaX,
-              y: viewport.y - event.deltaY,
-              zoom: viewport.zoom,
-            });
-          }
-        }
-        return;
-      }
-
-      // Non-macOS
-      if (shouldZoom) {
-        event.preventDefault();
-        if (event.deltaY < 0) zoomIn();
-        else zoomOut();
-      }
-    };
-
-    wrapper.addEventListener('wheel', handleWheelNonPassive, { passive: false });
-    return () => {
-      wrapper.removeEventListener('wheel', handleWheelNonPassive);
-    };
-  }, [isModalOpen, zoomIn, zoomOut, getViewport, setViewport, canvasNavigationSettings]);
+  // Wheel-based pan/zoom, honoring the user's navigation settings. Disabled
+  // while a modal is open (the modal's mini canvas drives its own).
+  useWheelPanZoom(reactFlowWrapper, canvasNavigationSettings, !isModalOpen);
 
   // Keyboard shortcuts for copy/paste and stacking selected nodes
   const handleKeyDown = useCallback((event: KeyboardEvent) => {

--- a/src/components/__tests__/CostDialog.test.tsx
+++ b/src/components/__tests__/CostDialog.test.tsx
@@ -613,7 +613,7 @@ describe("CostDialog", () => {
         />
       );
 
-      expect(screen.getByText(/Gemini pricing: \$0\.039-\$0\.24\/image/)).toBeInTheDocument();
+      expect(screen.getByText(/Gemini pricing: \$0\.034-\$0\.24\/image/)).toBeInTheDocument();
       expect(screen.getByText(/External providers not tracked/)).toBeInTheDocument();
     });
   });

--- a/src/components/__tests__/CostIndicator.test.tsx
+++ b/src/components/__tests__/CostIndicator.test.tsx
@@ -134,6 +134,29 @@ describe("CostIndicator", () => {
       expect(screen.getByText("$0.04")).toBeInTheDocument();
     });
 
+    it("should format cost correctly for nano-banana-2-lite model", () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "node-1",
+          type: "nanoBanana",
+          position: { x: 0, y: 0 },
+          data: {
+            model: "nano-banana-2-lite",
+            resolution: "1K",
+          },
+        },
+      ];
+
+      mockUseWorkflowStore.mockImplementation((selector) => {
+        return selector(createDefaultState({ nodes }));
+      });
+
+      render(<CostIndicator />);
+
+      // nano-banana-2-lite costs $0.034/image (1K only)
+      expect(screen.getByText("$0.03")).toBeInTheDocument();
+    });
+
     it("should format cost correctly for nano-banana-pro model", () => {
       const nodes: WorkflowNode[] = [
         {

--- a/src/components/__tests__/GenerateImageNode.test.tsx
+++ b/src/components/__tests__/GenerateImageNode.test.tsx
@@ -403,6 +403,28 @@ describe("GenerateImageNode", () => {
         });
       });
     });
+
+    it("should migrate legacy nano-banana-2-lite model field to selectedModel", async () => {
+      render(
+        <TestWrapper>
+          <GenerateImageNode {...createNodeProps({
+            model: "nano-banana-2-lite",
+            selectedModel: undefined,
+          })} />
+        </TestWrapper>
+      );
+
+      // The migration effect should resolve the display name from MODEL_DISPLAY_NAMES
+      await waitFor(() => {
+        expect(mockUpdateNodeData).toHaveBeenCalledWith("test-node-1", {
+          selectedModel: {
+            provider: "gemini",
+            modelId: "nano-banana-2-lite",
+            displayName: "Nano Banana 2 Lite",
+          },
+        });
+      });
+    });
   });
 
   describe("Dynamic Input Handles (External Providers)", () => {

--- a/src/components/__tests__/SplitGridNode.test.tsx
+++ b/src/components/__tests__/SplitGridNode.test.tsx
@@ -212,8 +212,8 @@ describe("SplitGridNode", () => {
       expect(screen.getByLabelText("Decrease rows")).toBeDisabled();
     });
 
-    it("disables the increase button at the maximum of 8", () => {
-      renderNode({ gridRows: 8 });
+    it("disables the increase button at the maximum of 16", () => {
+      renderNode({ gridRows: 16 });
 
       expect(screen.getByLabelText("Increase rows")).toBeDisabled();
     });
@@ -228,14 +228,14 @@ describe("SplitGridNode", () => {
       expect(mockUpdateNodeData).toHaveBeenCalledWith(NODE_ID, { gridRows: 5 });
     });
 
-    it("clamps typed values above the maximum to 8", () => {
+    it("clamps typed values above the maximum to 16", () => {
       renderNode({ gridRows: 2 });
 
       const input = screen.getByLabelText("Rows");
       fireEvent.change(input, { target: { value: "99" } });
       fireEvent.blur(input);
 
-      expect(mockUpdateNodeData).toHaveBeenCalledWith(NODE_ID, { gridRows: 8 });
+      expect(mockUpdateNodeData).toHaveBeenCalledWith(NODE_ID, { gridRows: 16 });
     });
 
     it("clamps typed values below the minimum to 1", () => {

--- a/src/components/__tests__/SplitGridNode.test.tsx
+++ b/src/components/__tests__/SplitGridNode.test.tsx
@@ -184,6 +184,28 @@ describe("SplitGridNode", () => {
       expect(mockUpdateNodeData).toHaveBeenCalledWith(NODE_ID, { gridCols: 4 });
     });
 
+    it("clears custom column offsets when the column count changes", () => {
+      renderNode({ gridCols: 3, colOffsets: [0.2, 0.6] });
+
+      fireEvent.click(screen.getByLabelText("Increase columns"));
+
+      // Explicitly resets colOffsets so stale interior lines don't linger
+      const call = mockUpdateNodeData.mock.calls.find((c) => c[0] === NODE_ID);
+      expect(call?.[1]).toHaveProperty("gridCols", 4);
+      expect(call?.[1]).toHaveProperty("colOffsets", undefined);
+      expect("colOffsets" in (call?.[1] as object)).toBe(true);
+    });
+
+    it("clears custom row offsets when the row count changes", () => {
+      renderNode({ gridRows: 2, rowOffsets: [0.4] });
+
+      fireEvent.click(screen.getByLabelText("Increase rows"));
+
+      const call = mockUpdateNodeData.mock.calls.find((c) => c[0] === NODE_ID);
+      expect(call?.[1]).toHaveProperty("gridRows", 3);
+      expect("rowOffsets" in (call?.[1] as object)).toBe(true);
+    });
+
     it("disables the decrease button at the minimum of 1", () => {
       renderNode({ gridRows: 1 });
 
@@ -349,6 +371,38 @@ describe("SplitGridNode", () => {
 
       expect(screen.getByText("Connect image")).toBeInTheDocument();
       expect(screen.queryByAltText("Source grid")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Draggable grid lines", () => {
+    it("renders one draggable line per interior boundary (cols-1 vertical, rows-1 horizontal)", () => {
+      setStoreState(connectedImageState(SOURCE_IMAGE));
+      const { container } = renderNode({ sourceImage: SOURCE_IMAGE, gridRows: 2, gridCols: 3 });
+
+      expect(container.querySelectorAll('[style*="col-resize"]').length).toBe(2); // 3 cols → 2 lines
+      expect(container.querySelectorAll('[style*="row-resize"]').length).toBe(1); // 2 rows → 1 line
+    });
+
+    it("renders no draggable lines while a workflow is running", () => {
+      setStoreState({ ...connectedImageState(SOURCE_IMAGE), isRunning: true });
+      const { container } = renderNode({ sourceImage: SOURCE_IMAGE, gridRows: 2, gridCols: 3 });
+
+      expect(container.querySelectorAll('[style*="col-resize"]').length).toBe(0);
+      expect(container.querySelectorAll('[style*="row-resize"]').length).toBe(0);
+    });
+
+    it("positions cell outlines from custom offsets when lines have been dragged", () => {
+      setStoreState(connectedImageState(SOURCE_IMAGE));
+      const { container } = renderNode({
+        sourceImage: SOURCE_IMAGE,
+        gridRows: 1,
+        gridCols: 2,
+        colOffsets: [0.25],
+      });
+
+      const overlay = container.querySelector('[style*="grid-template-columns"]') as HTMLElement;
+      // 0.25 boundary → column fractions 0.25fr / 0.75fr (not the uniform 0.5/0.5)
+      expect(overlay.style.gridTemplateColumns).toBe("0.25fr 0.75fr");
     });
   });
 

--- a/src/components/__tests__/SplitGridTemplateModal.test.tsx
+++ b/src/components/__tests__/SplitGridTemplateModal.test.tsx
@@ -339,4 +339,52 @@ describe("SplitGridTemplateModal", () => {
       expect(screen.queryByText(GENERATE_WARNING)).not.toBeInTheDocument();
     });
   });
+
+  describe("Downstream router port", () => {
+    const wiredTemplate: SplitGridNodeData["template"] = {
+      baseNodeId: "cell-image",
+      nodes: [
+        { id: "cell-image", type: "imageInput", position: { x: 0, y: 0 } },
+        { id: "cell-prompt", type: "prompt", position: { x: 0, y: 310 } },
+        { id: "cell-generate", type: "nanoBanana", position: { x: 340, y: 0 } },
+      ],
+      edges: [
+        { id: "e1", source: "cell-image", sourceHandle: "image", target: "cell-generate", targetHandle: "image" },
+        { id: "e2", source: "cell-prompt", sourceHandle: "text", target: "cell-generate", targetHandle: "text" },
+      ],
+      router: [{ source: "cell-generate", sourceHandle: "image", targetHandle: "image" }],
+    };
+
+    it("renders the fixed downstream-router port", () => {
+      renderModal();
+
+      expect(screen.getByText("Downstream Router")).toBeInTheDocument();
+      expect(screen.getByText("shared · 1 total")).toBeInTheDocument();
+    });
+
+    it("round-trips the router wiring into the applied template", () => {
+      renderModal({ nodeData: { template: wiredTemplate } });
+
+      fireEvent.click(screen.getByRole("button", { name: "Apply to 6 cells" }));
+
+      const [, options] = mockMaterializeSplitGridCells.mock.calls[0];
+      expect(options.template.router).toEqual([
+        { source: "cell-generate", sourceHandle: "image", targetHandle: "image" },
+      ]);
+      // The port itself is never emitted as a template node
+      expect(
+        options.template.nodes.some((node: { type: string }) => node.type === "router")
+      ).toBe(false);
+    });
+
+    it("clears the router wiring when a preset resets the node set", () => {
+      renderModal({ nodeData: { template: wiredTemplate } });
+
+      fireEvent.click(screen.getByRole("button", { name: "Image only" }));
+      fireEvent.click(screen.getByRole("button", { name: "Apply to 6 cells" }));
+
+      const [, options] = mockMaterializeSplitGridCells.mock.calls[0];
+      expect(options.template.router ?? []).toHaveLength(0);
+    });
+  });
 });

--- a/src/components/__tests__/SplitGridTemplateModal.test.tsx
+++ b/src/components/__tests__/SplitGridTemplateModal.test.tsx
@@ -1,8 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import { SplitGridTemplateModal } from "@/components/splitgrid/SplitGridTemplateModal";
 import { TEMPLATE_NODE_CATALOG } from "@/components/splitgrid/templateCatalog";
 import type { SplitGridNodeData } from "@/types";
+import type { FinalConnectionState } from "@xyflow/react";
+
+const reactFlowCapture = vi.hoisted(() => ({
+  props: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@xyflow/react", async () => {
+  const actual = await vi.importActual<typeof import("@xyflow/react")>("@xyflow/react");
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    ReactFlow: (props: Record<string, unknown>) => {
+      reactFlowCapture.props = props;
+      return React.createElement(actual.ReactFlow, props);
+    },
+  };
+});
 
 // Mock the workflow store (selector-passthrough pattern)
 const mockUpdateNodeData = vi.fn();
@@ -60,6 +77,15 @@ function renderModal(
     />
   );
   return { ...result, onClose };
+}
+
+function mockCanvasSize(width = 1000, height = 600): () => void {
+  const widthSpy = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(width);
+  const heightSpy = vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(height);
+  return () => {
+    widthSpy.mockRestore();
+    heightSpy.mockRestore();
+  };
 }
 
 describe("SplitGridTemplateModal", () => {
@@ -387,6 +413,70 @@ describe("SplitGridTemplateModal", () => {
 
       const [, options] = mockMaterializeSplitGridCells.mock.calls[0];
       expect(options.template.router ?? []).toHaveLength(0);
+    });
+
+    it("adds router wiring when an output connection ends over the rail", () => {
+      const restoreCanvasSize = mockCanvasSize();
+      try {
+        renderModal();
+        const onConnectEnd = reactFlowCapture.props?.onConnectEnd as
+          | ((event: MouseEvent, state: FinalConnectionState) => void)
+          | undefined;
+        expect(onConnectEnd).toBeTypeOf("function");
+
+        act(() => {
+          onConnectEnd?.(
+            new MouseEvent("mouseup", { clientX: 950, clientY: 300 }),
+            {
+              isValid: false,
+              fromNode: { id: "cell-image" },
+              fromHandle: { id: "image", type: "source" },
+            } as unknown as FinalConnectionState
+          );
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Apply to 6 cells" }));
+
+        const [, options] = mockMaterializeSplitGridCells.mock.calls[0];
+        expect(options.template.router).toEqual([
+          { source: "cell-image", sourceHandle: "image", targetHandle: "image" },
+        ]);
+      } finally {
+        restoreCanvasSize();
+      }
+    });
+
+    it("disconnects a router type through its socket control", () => {
+      const restoreCanvasSize = mockCanvasSize();
+      try {
+        renderModal({ nodeData: { template: wiredTemplate } });
+        fireEvent.click(screen.getByTitle("Disconnect Image"));
+        fireEvent.click(screen.getByRole("button", { name: "Apply to 6 cells" }));
+
+        const [, options] = mockMaterializeSplitGridCells.mock.calls[0];
+        expect(options.template.router ?? []).toHaveLength(0);
+      } finally {
+        restoreCanvasSize();
+      }
+    });
+
+    it("disconnects one router wire through the floating delete toolbar", () => {
+      const restoreCanvasSize = mockCanvasSize();
+      try {
+        renderModal({ nodeData: { template: wiredTemplate } });
+        const wire = document.querySelector(
+          '[data-wire-source="cell-generate"][data-wire-handle="image"]'
+        );
+        expect(wire).not.toBeNull();
+
+        fireEvent.mouseDown(wire!, { clientX: 700, clientY: 250 });
+        fireEvent.click(screen.getByRole("button", { name: "Delete connection" }));
+        fireEvent.click(screen.getByRole("button", { name: "Apply to 6 cells" }));
+
+        const [, options] = mockMaterializeSplitGridCells.mock.calls[0];
+        expect(options.template.router ?? []).toHaveLength(0);
+      } finally {
+        restoreCanvasSize();
+      }
     });
   });
 });

--- a/src/components/__tests__/SplitGridTemplateModal.test.tsx
+++ b/src/components/__tests__/SplitGridTemplateModal.test.tsx
@@ -355,11 +355,13 @@ describe("SplitGridTemplateModal", () => {
       router: [{ source: "cell-generate", sourceHandle: "image", targetHandle: "image" }],
     };
 
-    it("renders the fixed downstream-router port with its empty-state label", () => {
+    it("emits no router wiring for an unwired node set", () => {
       renderModal();
 
-      // With no terminal wired, the empty gray socket shows the port's name
-      expect(screen.getByText("Downstream Router")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Apply to 6 cells" }));
+
+      const [, options] = mockMaterializeSplitGridCells.mock.calls[0];
+      expect(options.template.router ?? []).toHaveLength(0);
     });
 
     it("round-trips the router wiring into the applied template", () => {
@@ -371,7 +373,7 @@ describe("SplitGridTemplateModal", () => {
       expect(options.template.router).toEqual([
         { source: "cell-generate", sourceHandle: "image", targetHandle: "image" },
       ]);
-      // The port itself is never emitted as a template node
+      // The router is never emitted as a template node (it's a fixed overlay)
       expect(
         options.template.nodes.some((node: { type: string }) => node.type === "router")
       ).toBe(false);

--- a/src/components/__tests__/SplitGridTemplateModal.test.tsx
+++ b/src/components/__tests__/SplitGridTemplateModal.test.tsx
@@ -355,11 +355,11 @@ describe("SplitGridTemplateModal", () => {
       router: [{ source: "cell-generate", sourceHandle: "image", targetHandle: "image" }],
     };
 
-    it("renders the fixed downstream-router port", () => {
+    it("renders the fixed downstream-router port with its empty-state label", () => {
       renderModal();
 
+      // With no terminal wired, the empty gray socket shows the port's name
       expect(screen.getByText("Downstream Router")).toBeInTheDocument();
-      expect(screen.getByText("shared · 1 total")).toBeInTheDocument();
     });
 
     it("round-trips the router wiring into the applied template", () => {

--- a/src/components/nodes/ControlPanel.tsx
+++ b/src/components/nodes/ControlPanel.tsx
@@ -48,6 +48,7 @@ const RESOLUTIONS_NB2: Resolution[] = ["512", "1K", "2K", "4K"];
 const GEMINI_IMAGE_MODELS: { value: ModelType; label: string }[] = [
   { value: "nano-banana", label: "Nano Banana" },
   { value: "nano-banana-2", label: "Nano Banana 2" },
+  { value: "nano-banana-2-lite", label: "Nano Banana 2 Lite" },
   { value: "nano-banana-pro", label: "Nano Banana Pro" },
 ];
 

--- a/src/components/nodes/GenerateImageNode.tsx
+++ b/src/components/nodes/GenerateImageNode.tsx
@@ -52,6 +52,7 @@ const RESOLUTIONS_NB2: Resolution[] = ["512", "1K", "2K", "4K"];
 const GEMINI_IMAGE_MODELS: { value: ModelType; label: string }[] = [
   { value: "nano-banana", label: "Nano Banana" },
   { value: "nano-banana-2", label: "Nano Banana 2" },
+  { value: "nano-banana-2-lite", label: "Nano Banana 2 Lite" },
   { value: "nano-banana-pro", label: "Nano Banana Pro" },
 ];
 

--- a/src/components/nodes/SplitGridNode.tsx
+++ b/src/components/nodes/SplitGridNode.tsx
@@ -156,7 +156,10 @@ export function SplitGridNode({ id, data, selected }: NodeProps<SplitGridNodeTyp
   const cells = getSplitGridCells(nodeData);
   const cellsAreStale = useMemo(() => {
     const existingIds = new Set(nodes.map((node) => node.id));
-    return needsMaterialization(nodeData, existingIds);
+    const existingRouterNodeIds = new Set(
+      nodes.filter((node) => node.type === "router").map((node) => node.id)
+    );
+    return needsMaterialization(nodeData, existingIds, { existingRouterNodeIds });
   }, [nodeData, nodes]);
 
   // Custom interior line positions (from dragging); fall back to uniform.

--- a/src/components/nodes/SplitGridNode.tsx
+++ b/src/components/nodes/SplitGridNode.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, useEffect, useMemo } from "react";
+import { useCallback, useState, useEffect, useMemo, useRef } from "react";
 import { Handle, Position, NodeProps, Node } from "@xyflow/react";
 import { BaseNode } from "./BaseNode";
 import { useWorkflowStore } from "@/store/workflowStore";
@@ -11,8 +11,11 @@ import {
   getSplitGridCells,
   getSplitGridTemplate,
   needsMaterialization,
+  resolveGridOffsets,
+  gridFractions,
   MIN_GRID_DIMENSION,
   MAX_GRID_DIMENSION,
+  MIN_SLICE_GAP,
 } from "@/store/utils/splitGridTemplate";
 import { useAdaptiveImageSrc } from "@/hooks/useAdaptiveImageSrc";
 import { useShowHandleLabels } from "@/hooks/useShowHandleLabels";
@@ -99,6 +102,38 @@ export function SplitGridNode({ id, data, selected }: NodeProps<SplitGridNodeTyp
   const gridCols = clampGridDimension(nodeData.gridCols);
   const cellCount = gridRows * gridCols;
 
+  // Size the grid overlay to the image's object-contain rectangle so the grid
+  // lines track the actual image, not the letterboxed preview container.
+  const previewRef = useRef<HTMLDivElement>(null);
+  const [imageAspect, setImageAspect] = useState<number | null>(null);
+  const [fittedSize, setFittedSize] = useState<{ width: number; height: number } | null>(null);
+
+  // A new source image invalidates the measured aspect until it re-loads.
+  useEffect(() => {
+    setImageAspect(null);
+    setFittedSize(null);
+  }, [adaptiveSourceImage]);
+
+  useEffect(() => {
+    const el = previewRef.current;
+    if (!el || imageAspect == null || typeof ResizeObserver === "undefined") return;
+    const measure = () => {
+      const cw = el.clientWidth;
+      const ch = el.clientHeight;
+      if (cw === 0 || ch === 0) return;
+      const containerAspect = cw / ch;
+      const wide = imageAspect > containerAspect;
+      setFittedSize({
+        width: wide ? cw : ch * imageAspect,
+        height: wide ? cw / imageAspect : ch,
+      });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [imageAspect]);
+
   // Reactively track the connected source image
   const hasIncomingImageConnection = useMemo(() => {
     return edges.some((edge) => edge.target === id && edge.targetHandle === "image");
@@ -124,13 +159,73 @@ export function SplitGridNode({ id, data, selected }: NodeProps<SplitGridNodeTyp
     return needsMaterialization(nodeData, existingIds);
   }, [nodeData, nodes]);
 
+  // Custom interior line positions (from dragging); fall back to uniform.
+  const colOffsets = useMemo(
+    () => resolveGridOffsets(gridCols, nodeData.colOffsets),
+    [gridCols, nodeData.colOffsets]
+  );
+  const rowOffsets = useMemo(
+    () => resolveGridOffsets(gridRows, nodeData.rowOffsets),
+    [gridRows, nodeData.rowOffsets]
+  );
+
+  // Live positions while dragging a grid line (null when idle).
+  const innerRef = useRef<HTMLDivElement>(null);
+  const [drag, setDrag] = useState<{ axis: "col" | "row"; offsets: number[] } | null>(null);
+  const activeColOffsets = drag?.axis === "col" ? drag.offsets : colOffsets;
+  const activeRowOffsets = drag?.axis === "row" ? drag.offsets : rowOffsets;
+  const colFractions = gridFractions(gridCols, activeColOffsets);
+  const rowFractions = gridFractions(gridRows, activeRowOffsets);
+
+  const startLineDrag = useCallback(
+    (axis: "col" | "row", index: number, e: React.PointerEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const inner = innerRef.current;
+      if (!inner) return;
+      const base = axis === "col" ? colOffsets : rowOffsets;
+      let working = [...base];
+      setDrag({ axis, offsets: working });
+
+      const onMove = (ev: PointerEvent) => {
+        const rect = inner.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) return;
+        const norm =
+          axis === "col"
+            ? (ev.clientX - rect.left) / rect.width
+            : (ev.clientY - rect.top) / rect.height;
+        const lower = index > 0 ? working[index - 1] : 0;
+        const upper = index < working.length - 1 ? working[index + 1] : 1;
+        const clamped = Math.min(upper - MIN_SLICE_GAP, Math.max(lower + MIN_SLICE_GAP, norm));
+        working = working.map((v, i) => (i === index ? clamped : v));
+        setDrag({ axis, offsets: working });
+      };
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        setDrag(null);
+        updateNodeData(id, axis === "col" ? { colOffsets: working } : { rowOffsets: working });
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [colOffsets, rowOffsets, id, updateNodeData]
+  );
+
   const handleRowsChange = useCallback(
-    (value: number) => updateNodeData(id, { gridRows: value }),
-    [id, updateNodeData]
+    (value: number) => {
+      if (value === gridRows) return;
+      // Row count changed: custom row lines no longer fit — reset to uniform.
+      updateNodeData(id, { gridRows: value, rowOffsets: undefined });
+    },
+    [id, updateNodeData, gridRows]
   );
   const handleColsChange = useCallback(
-    (value: number) => updateNodeData(id, { gridCols: value }),
-    [id, updateNodeData]
+    (value: number) => {
+      if (value === gridCols) return;
+      updateNodeData(id, { gridCols: value, colOffsets: undefined });
+    },
+    [id, updateNodeData, gridCols]
   );
 
   const handleSplit = useCallback(() => {
@@ -199,27 +294,93 @@ export function SplitGridNode({ id, data, selected }: NodeProps<SplitGridNodeTyp
           </button>
 
           {/* Preview with grid overlay */}
-          <div className="relative flex-1 min-h-[96px] rounded-md overflow-hidden bg-neutral-900/40 border border-neutral-700/40">
+          <div
+            ref={previewRef}
+            className="relative flex-1 min-h-[96px] rounded-md overflow-hidden bg-neutral-900/40 border border-neutral-700/40 flex items-center justify-center"
+          >
             {nodeData.sourceImage ? (
-              <>
+              <div
+                ref={innerRef}
+                className="relative"
+                style={
+                  fittedSize
+                    ? { width: fittedSize.width, height: fittedSize.height }
+                    : { width: "100%", height: "100%" }
+                }
+              >
                 <img
                   src={adaptiveSourceImage ?? undefined}
                   alt="Source grid"
-                  className="w-full h-full object-contain"
+                  className="w-full h-full object-contain block select-none"
+                  draggable={false}
+                  onLoad={(e) => {
+                    const { naturalWidth, naturalHeight } = e.currentTarget;
+                    if (naturalWidth > 0 && naturalHeight > 0) {
+                      setImageAspect(naturalWidth / naturalHeight);
+                    }
+                  }}
                 />
+                {/* Cell outlines (non-uniform when lines have been dragged) */}
                 <div
                   className="absolute inset-0 pointer-events-none"
                   style={{
                     display: "grid",
-                    gridTemplateColumns: `repeat(${gridCols}, 1fr)`,
-                    gridTemplateRows: `repeat(${gridRows}, 1fr)`,
+                    gridTemplateColumns: colFractions.map((f) => `${f}fr`).join(" "),
+                    gridTemplateRows: rowFractions.map((f) => `${f}fr`).join(" "),
                   }}
                 >
                   {Array.from({ length: cellCount }).map((_, index) => (
                     <div key={index} className="border border-blue-400/50" />
                   ))}
                 </div>
-              </>
+                {/* Draggable interior grid lines */}
+                {!isRunning && (
+                  <>
+                    {activeColOffsets.map((offset, index) => (
+                      <div
+                        key={`v-${index}`}
+                        className="nodrag nopan group absolute top-0 bottom-0"
+                        style={{
+                          left: `${offset * 100}%`,
+                          width: 12,
+                          transform: "translateX(-50%)",
+                          cursor: "col-resize",
+                        }}
+                        onPointerDown={(e) => startLineDrag("col", index, e)}
+                      >
+                        <div
+                          className={`absolute inset-y-0 left-1/2 -translate-x-1/2 transition-all ${
+                            drag?.axis === "col"
+                              ? "w-[2px] bg-blue-300"
+                              : "w-px bg-blue-400/70 group-hover:w-[2px] group-hover:bg-blue-300"
+                          }`}
+                        />
+                      </div>
+                    ))}
+                    {activeRowOffsets.map((offset, index) => (
+                      <div
+                        key={`h-${index}`}
+                        className="nodrag nopan group absolute left-0 right-0"
+                        style={{
+                          top: `${offset * 100}%`,
+                          height: 12,
+                          transform: "translateY(-50%)",
+                          cursor: "row-resize",
+                        }}
+                        onPointerDown={(e) => startLineDrag("row", index, e)}
+                      >
+                        <div
+                          className={`absolute inset-x-0 top-1/2 -translate-y-1/2 transition-all ${
+                            drag?.axis === "row"
+                              ? "h-[2px] bg-blue-300"
+                              : "h-px bg-blue-400/70 group-hover:h-[2px] group-hover:bg-blue-300"
+                          }`}
+                        />
+                      </div>
+                    ))}
+                  </>
+                )}
+              </div>
             ) : (
               <div className="w-full h-full flex flex-col items-center justify-center gap-1">
                 <svg className="w-5 h-5 text-neutral-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>

--- a/src/components/splitgrid/RouterRail.tsx
+++ b/src/components/splitgrid/RouterRail.tsx
@@ -45,9 +45,10 @@ const TYPE_LABELS: Record<string, string> = {
 const EMPTY_COLOR = "#6b7280";
 
 const ROW_H = 28;
-const LABEL_H = 20;
-const RAIL_RIGHT = 24; // distance from the wrapper's right edge
-const CONTENT_W = 128;
+const LABEL_H = 28; // room for the "Router" caption + its top gap
+const CAPTION_GAP = 10; // vertical gap between the sockets and the "Router" caption
+const RAIL_RIGHT = 12; // distance from the wrapper's right edge
+const CONTENT_W = 72;
 const SOCKET_LEFT = 26; // socket center, measured from the rail content's left
 
 /** Distinct wired types, in a stable order (one socket row per type). */
@@ -245,7 +246,7 @@ export function RouterRail({
         {/* "Router" caption beneath the connector */}
         <span
           className="absolute text-[11px] font-semibold text-neutral-300 whitespace-nowrap select-none"
-          style={{ top: railH + 3, left: SOCKET_LEFT, transform: "translateX(-50%)" }}
+          style={{ top: railH + CAPTION_GAP, left: SOCKET_LEFT, transform: "translateX(-50%)" }}
         >
           Router
         </span>

--- a/src/components/splitgrid/RouterRail.tsx
+++ b/src/components/splitgrid/RouterRail.tsx
@@ -212,20 +212,18 @@ export function RouterRail({
   nodes,
   size,
   onDisconnectType,
-  onDisconnectWire,
 }: {
   wires: RouterWire[];
   nodes: TemplateRFNode[];
   size: RailSize;
   onDisconnectType: (type: string) => void;
-  onDisconnectWire: (source: string, sourceHandle: string) => void;
 }) {
   const viewport = useViewport();
   const { types, railH, blockTop, contentLeft } = useMemo(
     () => railMetrics(wires, size),
     [wires, size]
   );
-  // Wire midpoints for the delete buttons (same geometry as the stroke layer)
+  // Wire geometry for the invisible click targets (same paths as the strokes)
   const geoms = useMemo(
     () => routerWireGeoms(wires, nodes, size, viewport),
     [wires, nodes, size, viewport]
@@ -237,29 +235,27 @@ export function RouterRail({
 
   return (
     <>
-      {/* Per-wire delete buttons at each wire's midpoint (revealed on hover) */}
-      {geoms.map((geom, i) => (
-        <div
-          key={`del-${geom.wire.source}-${geom.wire.sourceHandle}-${i}`}
-          className="absolute z-[21]"
-          style={{ left: geom.mid.x, top: geom.mid.y, transform: "translate(-50%, -50%)" }}
-        >
-          <button
-            type="button"
-            onClick={() => onDisconnectWire(geom.wire.source, geom.wire.sourceHandle)}
-            title="Delete router connection"
-            aria-label="Delete router connection"
-            className="group grid place-items-center"
-            style={{ width: 28, height: 28, background: "transparent", pointerEvents: "auto" }}
-          >
-            <span className="flex items-center justify-center w-5 h-5 rounded-full bg-neutral-800 border border-neutral-600 text-neutral-400 shadow-md opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 group-hover:text-red-400 group-hover:border-red-500 group-hover:bg-red-500/20">
-              <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </span>
-          </button>
-        </div>
-      ))}
+      {/* Invisible click targets tracing each wire. Only the stroke band is
+          interactive (pointer-events: stroke), so empty space still passes
+          through to the canvas. The modal turns a click here into the same
+          floating delete toolbar you get clicking a main-canvas noodle. */}
+      <svg
+        className="absolute inset-0 z-[21]"
+        style={{ overflow: "visible", pointerEvents: "none" }}
+      >
+        {geoms.map((geom, i) => (
+          <path
+            key={`hit-${geom.wire.source}-${geom.wire.sourceHandle}-${i}`}
+            d={geom.path}
+            fill="none"
+            stroke="transparent"
+            strokeWidth={14}
+            data-wire-source={geom.wire.source}
+            data-wire-handle={geom.wire.sourceHandle}
+            style={{ pointerEvents: "stroke", cursor: "pointer" }}
+          />
+        ))}
+      </svg>
 
       {/* The fixed rail */}
       <div

--- a/src/components/splitgrid/RouterRail.tsx
+++ b/src/components/splitgrid/RouterRail.tsx
@@ -47,8 +47,8 @@ const EMPTY_COLOR = "#6b7280";
 const ROW_H = 28;
 const LABEL_H = 28; // room for the "Router" caption + its top gap
 const CAPTION_GAP = 10; // vertical gap between the sockets and the "Router" caption
-const RAIL_RIGHT = 12; // distance from the wrapper's right edge
-const CONTENT_W = 72;
+const RAIL_RIGHT = 14; // distance from the wrapper's right edge
+const CONTENT_W = 42; // no per-type labels, so the socket can hug the edge
 const SOCKET_LEFT = 26; // socket center, measured from the rail content's left
 
 /** Distinct wired types, in a stable order (one socket row per type). */
@@ -75,7 +75,7 @@ export function isInRailDropZone(
   if (size.width === 0) return false;
   const { blockTop, blockH, contentLeft } = railMetrics(wires, size);
   return (
-    point.x >= contentLeft - 16 &&
+    point.x >= contentLeft - 56 &&
     point.x <= size.width &&
     point.y >= blockTop - 24 &&
     point.y <= blockTop + blockH + 24
@@ -201,17 +201,18 @@ export function RouterRail({
           const top = i * ROW_H + ROW_H / 2;
           const label = type ? TYPE_LABELS[type] ?? type : null;
           const color = type ? TYPE_COLORS[type] ?? EMPTY_COLOR : EMPTY_COLOR;
+          // Type is conveyed by socket color (matching the main-canvas handles);
+          // the label lives in the hover tooltip so the rail can hug the edge.
           return (
             <div key={type ?? "empty"} className="group">
-              {/* Clickable row (typed sockets only) to disconnect that type */}
               {type && (
                 <div
                   className="absolute cursor-pointer"
                   style={{
-                    top: top - ROW_H / 2,
-                    left: 0,
-                    width: CONTENT_W,
-                    height: ROW_H,
+                    top: top - 12,
+                    left: SOCKET_LEFT - 12,
+                    width: 24,
+                    height: 24,
                     pointerEvents: "auto",
                   }}
                   title={`Disconnect ${label}`}
@@ -219,7 +220,7 @@ export function RouterRail({
                 />
               )}
               <div
-                className="absolute rounded-full"
+                className="absolute rounded-full transition-shadow group-hover:ring-2 group-hover:ring-white/30"
                 style={{
                   top,
                   left: SOCKET_LEFT,
@@ -231,14 +232,6 @@ export function RouterRail({
                   boxShadow: "0 0 0 1px rgba(0,0,0,.35)",
                 }}
               />
-              {label && (
-                <span
-                  className="absolute text-[11px] font-medium leading-none whitespace-nowrap select-none group-hover:line-through"
-                  style={{ top, left: SOCKET_LEFT + 12, transform: "translateY(-50%)", color }}
-                >
-                  {label}
-                </span>
-              )}
             </div>
           );
         })}

--- a/src/components/splitgrid/RouterRail.tsx
+++ b/src/components/splitgrid/RouterRail.tsx
@@ -64,7 +64,8 @@ const EMPTY_COLOR = "#6b7280";
 const ROW_H = 28;
 const LABEL_H = 28; // room for the "Router" caption + its top gap
 const CAPTION_GAP = 10; // vertical gap between the sockets and the "Router" caption
-const RAIL_RIGHT = 14; // distance from the wrapper's right edge
+const RAIL_RIGHT = 44; // distance from the wrapper's right edge (kept off the
+// edge so dragging a noodle onto the socket doesn't graze the pane edge)
 const CONTENT_W = 42; // no per-type labels, so the socket can hug the edge
 const SOCKET_LEFT = 26; // socket center, measured from the rail content's left
 

--- a/src/components/splitgrid/RouterRail.tsx
+++ b/src/components/splitgrid/RouterRail.tsx
@@ -10,6 +10,11 @@
  * The rail is NOT a React Flow node, so its edges are drawn here: each wire runs
  * from the terminal's output handle (converted from flow to pane coordinates via
  * the live viewport) to its type socket (fixed pane coordinates).
+ *
+ * Rendering is split across two layers so the wires read like normal edges:
+ * `RouterWires` draws just the strokes and is mounted BEHIND the React Flow
+ * canvas (so opaque nodes occlude it); `RouterRail` draws the fixed rail plus
+ * the per-wire delete buttons ON TOP.
  */
 
 import { useMemo } from "react";
@@ -24,6 +29,18 @@ export interface RouterWire {
 export interface RailSize {
   width: number;
   height: number;
+}
+
+interface RouterViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+export interface RouterWireGeom {
+  wire: RouterWire;
+  path: string;
+  mid: { x: number; y: number };
 }
 
 const TYPE_COLORS: Record<string, string> = {
@@ -82,6 +99,98 @@ export function isInRailDropZone(
   );
 }
 
+/** Terminal output-handle position in pane coordinates (follows pan + zoom). */
+function terminalPos(
+  wire: RouterWire,
+  nodes: TemplateRFNode[],
+  viewport: RouterViewport
+): { x: number; y: number } | null {
+  const node = nodes.find((n) => n.id === wire.source);
+  if (!node) return null;
+  const width =
+    node.measured?.width ??
+    (node.width as number | undefined) ??
+    (node.style?.width as number | undefined) ??
+    300;
+  const height =
+    node.measured?.height ??
+    (node.height as number | undefined) ??
+    (node.style?.height as number | undefined) ??
+    200;
+  const flowX = node.position.x + width;
+  const flowY = node.position.y + height / 2;
+  return { x: flowX * viewport.zoom + viewport.x, y: flowY * viewport.zoom + viewport.y };
+}
+
+/**
+ * Per-wire geometry (path + midpoint), shared by the stroke layer and the
+ * delete-button layer so both agree exactly. Midpoint is the cubic bezier
+ * evaluated at t=0.5.
+ */
+export function routerWireGeoms(
+  wires: RouterWire[],
+  nodes: TemplateRFNode[],
+  size: RailSize,
+  viewport: RouterViewport
+): RouterWireGeom[] {
+  const { types, blockTop, contentLeft } = railMetrics(wires, size);
+  const typeIndex = new Map(types.map((type, i) => [type, i]));
+  const socketX = contentLeft + SOCKET_LEFT;
+  const socketY = (rowIndex: number) => blockTop + rowIndex * ROW_H + ROW_H / 2;
+
+  const geoms: RouterWireGeom[] = [];
+  for (const wire of wires) {
+    const from = terminalPos(wire, nodes, viewport);
+    if (!from) continue;
+    const to = { x: socketX, y: socketY(typeIndex.get(wire.sourceHandle) ?? 0) };
+    const dx = Math.max(40, (to.x - from.x) * 0.5);
+    const c1 = { x: from.x + dx, y: from.y };
+    const c2 = { x: to.x - dx, y: to.y };
+    const path = `M ${from.x} ${from.y} C ${c1.x} ${c1.y} ${c2.x} ${c2.y} ${to.x} ${to.y}`;
+    const mid = {
+      x: 0.125 * from.x + 0.375 * c1.x + 0.375 * c2.x + 0.125 * to.x,
+      y: 0.125 * from.y + 0.375 * c1.y + 0.375 * c2.y + 0.125 * to.y,
+    };
+    geoms.push({ wire, path, mid });
+  }
+  return geoms;
+}
+
+/**
+ * Just the wire strokes — mounted BEHIND the React Flow canvas so nodes occlude
+ * them (the pane is transparent, so the wires show through the gaps).
+ */
+export function RouterWires({
+  wires,
+  nodes,
+  size,
+}: {
+  wires: RouterWire[];
+  nodes: TemplateRFNode[];
+  size: RailSize;
+}) {
+  const viewport = useViewport();
+  const geoms = useMemo(
+    () => routerWireGeoms(wires, nodes, size, viewport),
+    [wires, nodes, size, viewport]
+  );
+  if (size.width === 0 || size.height === 0) return null;
+  return (
+    <svg className="absolute inset-0" style={{ overflow: "visible", pointerEvents: "none" }}>
+      {geoms.map((geom, i) => (
+        <path
+          key={`${geom.wire.source}-${geom.wire.sourceHandle}-${i}`}
+          d={geom.path}
+          stroke={TYPE_COLORS[geom.wire.sourceHandle] ?? "#888888"}
+          strokeWidth={2}
+          fill="none"
+          opacity={0.9}
+        />
+      ))}
+    </svg>
+  );
+}
+
 /** A rounded curly brace opening toward the sockets on its right. */
 function bracePath(height: number): string {
   const h = Math.max(height, 30);
@@ -103,71 +212,54 @@ export function RouterRail({
   nodes,
   size,
   onDisconnectType,
+  onDisconnectWire,
 }: {
   wires: RouterWire[];
   nodes: TemplateRFNode[];
   size: RailSize;
   onDisconnectType: (type: string) => void;
+  onDisconnectWire: (source: string, sourceHandle: string) => void;
 }) {
   const viewport = useViewport();
   const { types, railH, blockTop, contentLeft } = useMemo(
     () => railMetrics(wires, size),
     [wires, size]
   );
-  const typeIndex = useMemo(() => new Map(types.map((type, i) => [type, i])), [types]);
+  // Wire midpoints for the delete buttons (same geometry as the stroke layer)
+  const geoms = useMemo(
+    () => routerWireGeoms(wires, nodes, size, viewport),
+    [wires, nodes, size, viewport]
+  );
 
   if (size.width === 0 || size.height === 0) return null;
-
-  const socketX = contentLeft + SOCKET_LEFT;
-  const socketY = (rowIndex: number) => blockTop + rowIndex * ROW_H + ROW_H / 2;
-
-  // Terminal output-handle position in pane coordinates (follows pan + zoom).
-  const terminalPos = (wire: RouterWire): { x: number; y: number } | null => {
-    const node = nodes.find((n) => n.id === wire.source);
-    if (!node) return null;
-    const width =
-      node.measured?.width ??
-      (node.width as number | undefined) ??
-      (node.style?.width as number | undefined) ??
-      300;
-    const height =
-      node.measured?.height ??
-      (node.height as number | undefined) ??
-      (node.style?.height as number | undefined) ??
-      200;
-    const flowX = node.position.x + width;
-    const flowY = node.position.y + height / 2;
-    return { x: flowX * viewport.zoom + viewport.x, y: flowY * viewport.zoom + viewport.y };
-  };
 
   const rows: (string | null)[] = [...types, null];
 
   return (
     <>
-      {/* Wire edges: terminal output → its type socket (purely visual) */}
-      <svg
-        className="absolute inset-0 z-10"
-        style={{ overflow: "visible", pointerEvents: "none" }}
-      >
-        {wires.map((wire, i) => {
-          const from = terminalPos(wire);
-          if (!from) return null;
-          const to = { x: socketX, y: socketY(typeIndex.get(wire.sourceHandle) ?? 0) };
-          const dx = Math.max(40, (to.x - from.x) * 0.5);
-          const d = `M ${from.x} ${from.y} C ${from.x + dx} ${from.y} ${to.x - dx} ${to.y} ${to.x} ${to.y}`;
-          const color = TYPE_COLORS[wire.sourceHandle] ?? "#888888";
-          return (
-            <path
-              key={`${wire.source}-${wire.sourceHandle}-${i}`}
-              d={d}
-              stroke={color}
-              strokeWidth={2}
-              fill="none"
-              opacity={0.9}
-            />
-          );
-        })}
-      </svg>
+      {/* Per-wire delete buttons at each wire's midpoint (revealed on hover) */}
+      {geoms.map((geom, i) => (
+        <div
+          key={`del-${geom.wire.source}-${geom.wire.sourceHandle}-${i}`}
+          className="absolute z-[21]"
+          style={{ left: geom.mid.x, top: geom.mid.y, transform: "translate(-50%, -50%)" }}
+        >
+          <button
+            type="button"
+            onClick={() => onDisconnectWire(geom.wire.source, geom.wire.sourceHandle)}
+            title="Delete router connection"
+            aria-label="Delete router connection"
+            className="group grid place-items-center"
+            style={{ width: 28, height: 28, background: "transparent", pointerEvents: "auto" }}
+          >
+            <span className="flex items-center justify-center w-5 h-5 rounded-full bg-neutral-800 border border-neutral-600 text-neutral-400 shadow-md opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 group-hover:text-red-400 group-hover:border-red-500 group-hover:bg-red-500/20">
+              <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </span>
+          </button>
+        </div>
+      ))}
 
       {/* The fixed rail */}
       <div

--- a/src/components/splitgrid/RouterRail.tsx
+++ b/src/components/splitgrid/RouterRail.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+/**
+ * Downstream-router rail — a fixed overlay pinned to the right edge of the cell
+ * node set editor (it does not pan or zoom with the canvas). Users drag any
+ * terminal's output onto it; each wired type grows a colored socket with a
+ * label, and a rounded bracket groups them with a "Router" caption beneath. An
+ * empty gray socket at the bottom is the persistent drop target.
+ *
+ * The rail is NOT a React Flow node, so its edges are drawn here: each wire runs
+ * from the terminal's output handle (converted from flow to pane coordinates via
+ * the live viewport) to its type socket (fixed pane coordinates).
+ */
+
+import { useMemo } from "react";
+import { useViewport } from "@xyflow/react";
+import type { TemplateRFNode } from "./TemplateNodes";
+
+export interface RouterWire {
+  source: string;
+  sourceHandle: string;
+}
+
+export interface RailSize {
+  width: number;
+  height: number;
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  image: "#10b981",
+  text: "#3b82f6",
+  video: "#ec4899",
+  audio: "rgb(167, 139, 250)",
+  "3d": "#f97316",
+  easeCurve: "#ffffff",
+};
+const TYPE_LABELS: Record<string, string> = {
+  image: "Image",
+  text: "Text",
+  video: "Video",
+  audio: "Audio",
+  "3d": "3D",
+  easeCurve: "Curve",
+};
+const EMPTY_COLOR = "#6b7280";
+
+const ROW_H = 28;
+const LABEL_H = 20;
+const RAIL_RIGHT = 24; // distance from the wrapper's right edge
+const CONTENT_W = 128;
+const SOCKET_LEFT = 26; // socket center, measured from the rail content's left
+
+/** Distinct wired types, in a stable order (one socket row per type). */
+export function railTypes(wires: RouterWire[]): string[] {
+  return Array.from(new Set(wires.map((wire) => wire.sourceHandle))).sort();
+}
+
+function railMetrics(wires: RouterWire[], size: RailSize) {
+  const types = railTypes(wires);
+  const rowCount = types.length + 1; // + the empty drop socket
+  const railH = rowCount * ROW_H;
+  const blockH = railH + LABEL_H;
+  const blockTop = size.height / 2 - blockH / 2;
+  const contentLeft = size.width - RAIL_RIGHT - CONTENT_W;
+  return { types, railH, blockH, blockTop, contentLeft };
+}
+
+/** True when a wrapper-relative point is over the rail's drop zone. */
+export function isInRailDropZone(
+  point: { x: number; y: number },
+  size: RailSize,
+  wires: RouterWire[]
+): boolean {
+  if (size.width === 0) return false;
+  const { blockTop, blockH, contentLeft } = railMetrics(wires, size);
+  return (
+    point.x >= contentLeft - 16 &&
+    point.x <= size.width &&
+    point.y >= blockTop - 24 &&
+    point.y <= blockTop + blockH + 24
+  );
+}
+
+/** A rounded curly brace opening toward the sockets on its right. */
+function bracePath(height: number): string {
+  const h = Math.max(height, 30);
+  const mid = h / 2;
+  const arm = Math.min(9, mid - 6);
+  return [
+    `M 11 2`,
+    `Q 6 2 6 8`,
+    `L 6 ${mid - arm}`,
+    `Q 6 ${mid} 1 ${mid}`,
+    `Q 6 ${mid} 6 ${mid + arm}`,
+    `L 6 ${h - 8}`,
+    `Q 6 ${h - 2} 11 ${h - 2}`,
+  ].join(" ");
+}
+
+export function RouterRail({
+  wires,
+  nodes,
+  size,
+  onDisconnectType,
+}: {
+  wires: RouterWire[];
+  nodes: TemplateRFNode[];
+  size: RailSize;
+  onDisconnectType: (type: string) => void;
+}) {
+  const viewport = useViewport();
+  const { types, railH, blockTop, contentLeft } = useMemo(
+    () => railMetrics(wires, size),
+    [wires, size]
+  );
+  const typeIndex = useMemo(() => new Map(types.map((type, i) => [type, i])), [types]);
+
+  if (size.width === 0 || size.height === 0) return null;
+
+  const socketX = contentLeft + SOCKET_LEFT;
+  const socketY = (rowIndex: number) => blockTop + rowIndex * ROW_H + ROW_H / 2;
+
+  // Terminal output-handle position in pane coordinates (follows pan + zoom).
+  const terminalPos = (wire: RouterWire): { x: number; y: number } | null => {
+    const node = nodes.find((n) => n.id === wire.source);
+    if (!node) return null;
+    const width =
+      node.measured?.width ??
+      (node.width as number | undefined) ??
+      (node.style?.width as number | undefined) ??
+      300;
+    const height =
+      node.measured?.height ??
+      (node.height as number | undefined) ??
+      (node.style?.height as number | undefined) ??
+      200;
+    const flowX = node.position.x + width;
+    const flowY = node.position.y + height / 2;
+    return { x: flowX * viewport.zoom + viewport.x, y: flowY * viewport.zoom + viewport.y };
+  };
+
+  const rows: (string | null)[] = [...types, null];
+
+  return (
+    <>
+      {/* Wire edges: terminal output → its type socket (purely visual) */}
+      <svg
+        className="absolute inset-0 z-10"
+        style={{ overflow: "visible", pointerEvents: "none" }}
+      >
+        {wires.map((wire, i) => {
+          const from = terminalPos(wire);
+          if (!from) return null;
+          const to = { x: socketX, y: socketY(typeIndex.get(wire.sourceHandle) ?? 0) };
+          const dx = Math.max(40, (to.x - from.x) * 0.5);
+          const d = `M ${from.x} ${from.y} C ${from.x + dx} ${from.y} ${to.x - dx} ${to.y} ${to.x} ${to.y}`;
+          const color = TYPE_COLORS[wire.sourceHandle] ?? "#888888";
+          return (
+            <path
+              key={`${wire.source}-${wire.sourceHandle}-${i}`}
+              d={d}
+              stroke={color}
+              strokeWidth={2}
+              fill="none"
+              opacity={0.9}
+            />
+          );
+        })}
+      </svg>
+
+      {/* The fixed rail */}
+      <div
+        className="absolute z-20"
+        style={{
+          top: blockTop,
+          right: RAIL_RIGHT,
+          width: CONTENT_W,
+          height: railH + LABEL_H,
+          pointerEvents: "none",
+        }}
+      >
+        <svg
+          width="12"
+          height={railH}
+          viewBox={`0 0 12 ${railH}`}
+          className="absolute left-0 top-0"
+          style={{ overflow: "visible" }}
+          fill="none"
+        >
+          <path
+            d={bracePath(railH)}
+            stroke="#9a9a9a"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+
+        {rows.map((type, i) => {
+          const top = i * ROW_H + ROW_H / 2;
+          const label = type ? TYPE_LABELS[type] ?? type : null;
+          const color = type ? TYPE_COLORS[type] ?? EMPTY_COLOR : EMPTY_COLOR;
+          return (
+            <div key={type ?? "empty"} className="group">
+              {/* Clickable row (typed sockets only) to disconnect that type */}
+              {type && (
+                <div
+                  className="absolute cursor-pointer"
+                  style={{
+                    top: top - ROW_H / 2,
+                    left: 0,
+                    width: CONTENT_W,
+                    height: ROW_H,
+                    pointerEvents: "auto",
+                  }}
+                  title={`Disconnect ${label}`}
+                  onClick={() => onDisconnectType(type)}
+                />
+              )}
+              <div
+                className="absolute rounded-full"
+                style={{
+                  top,
+                  left: SOCKET_LEFT,
+                  width: 11,
+                  height: 11,
+                  transform: "translate(-50%, -50%)",
+                  backgroundColor: color,
+                  border: "2px solid #1e1e1e",
+                  boxShadow: "0 0 0 1px rgba(0,0,0,.35)",
+                }}
+              />
+              {label && (
+                <span
+                  className="absolute text-[11px] font-medium leading-none whitespace-nowrap select-none group-hover:line-through"
+                  style={{ top, left: SOCKET_LEFT + 12, transform: "translateY(-50%)", color }}
+                >
+                  {label}
+                </span>
+              )}
+            </div>
+          );
+        })}
+
+        {/* "Router" caption beneath the connector */}
+        <span
+          className="absolute text-[11px] font-semibold text-neutral-300 whitespace-nowrap select-none"
+          style={{ top: railH + 3, left: SOCKET_LEFT, transform: "translateX(-50%)" }}
+        >
+          Router
+        </span>
+      </div>
+    </>
+  );
+}

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -858,6 +858,9 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
               maxZoom={1.5}
               zoomOnScroll={false}
               panOnDrag={!isMacOS}
+              // The router is a fixed, always-visible overlay on the right, so
+              // panning toward it mid-connection only jostles the graph.
+              autoPanOnConnect={false}
               deleteKeyCode={["Backspace", "Delete"]}
               defaultEdgeOptions={{ type: TEMPLATE_EDGE_TYPE, animated: false }}
               proOptions={{ hideAttribution: true }}

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -44,7 +44,13 @@ import {
   createDefaultSplitGridTemplate,
   getSplitGridTemplate,
 } from "@/store/utils/splitGridTemplate";
-import { RouterRail, isInRailDropZone, type RouterWire, type RailSize } from "./RouterRail";
+import {
+  RouterRail,
+  RouterWires,
+  isInRailDropZone,
+  type RouterWire,
+  type RailSize,
+} from "./RouterRail";
 import {
   getTemplateEntry,
   getTemplateNodeIcon,
@@ -414,6 +420,13 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     setRouterWires((prev) => prev.filter((w) => w.sourceHandle !== type));
   }, []);
 
+  // Delete one specific router wire (its midpoint × button)
+  const disconnectRouterWire = useCallback((source: string, sourceHandle: string) => {
+    setRouterWires((prev) =>
+      prev.filter((w) => !(w.source === source && w.sourceHandle === sourceHandle))
+    );
+  }, []);
+
   // Each connection carries its own midpoint delete button (TemplateEditableEdge)
   // that calls this through the editor context.
   const deleteEdge = useCallback(
@@ -756,6 +769,11 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
 
         {/* Mini canvas */}
         <div ref={canvasWrapperRef} className="flex-1 min-h-0 relative bg-neutral-900">
+          {/* Router wires render BEHIND the canvas so nodes occlude them, like
+              normal edges (the pane is transparent, so they show in the gaps) */}
+          <RouterWires wires={routerWires} nodes={rfNodes} size={wrapperSize} />
+
+          <div className="absolute inset-0">
           <TemplateEditorContext.Provider value={editorContext}>
             <ReactFlow
               nodes={rfNodes}
@@ -781,13 +799,15 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
               <Controls showInteractive={false} className="!bg-neutral-800 !border-neutral-700 !shadow-none [&>button]:!bg-neutral-800 [&>button]:!border-neutral-700 [&>button]:!text-neutral-300 [&>button:hover]:!bg-neutral-700" />
             </ReactFlow>
           </TemplateEditorContext.Provider>
+          </div>
 
-          {/* Fixed downstream-router rail (pinned to the right edge) */}
+          {/* Fixed downstream-router rail + wire delete buttons (on top) */}
           <RouterRail
             wires={routerWires}
             nodes={rfNodes}
             size={wrapperSize}
             onDisconnectType={disconnectRouterType}
+            onDisconnectWire={disconnectRouterWire}
           />
 
           {/* Connection drop menu */}

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -120,8 +120,8 @@ function editorNodeDimensions(type: NodeType): { width: number; height: number }
   return defaultNodeDimensions[type] ?? { width: 300, height: 280 };
 }
 
-const PORT_WIDTH = 200;
-const PORT_HEIGHT = 80;
+const PORT_WIDTH = 130;
+const PORT_HEIGHT = 60; // initial; RouterPortBody resizes to fit its sockets
 const PORT_GAP = 140;
 
 /**

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -28,6 +28,7 @@ import {
   type NodeTypes,
 } from "@xyflow/react";
 import { useWorkflowStore } from "@/store/workflowStore";
+import { useWheelPanZoom } from "@/hooks/useWheelPanZoom";
 import type {
   LLMGenerateNodeData,
   NanoBananaNodeData,
@@ -302,6 +303,12 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   const isRunning = useWorkflowStore((state) => state.isRunning);
   const incrementModalCount = useWorkflowStore((state) => state.incrementModalCount);
   const decrementModalCount = useWorkflowStore((state) => state.decrementModalCount);
+  const canvasNavigationSettings = useWorkflowStore((state) => state.canvasNavigationSettings);
+
+  // Match the main canvas's wheel navigation (scroll-to-pan when zoomMode is
+  // altScroll/ctrlScroll) instead of React Flow's default scroll-to-zoom.
+  const canvasWrapperRef = useRef<HTMLDivElement>(null);
+  useWheelPanZoom(canvasWrapperRef, canvasNavigationSettings, true);
 
   const initialTemplate = useMemo(() => getSplitGridTemplate(nodeData), [nodeData]);
   const [rfNodes, setRfNodes, onNodesChange] = useNodesState<TemplateRFNode>(
@@ -637,7 +644,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
         </div>
 
         {/* Mini canvas */}
-        <div className="flex-1 min-h-0 relative bg-neutral-900">
+        <div ref={canvasWrapperRef} className="flex-1 min-h-0 relative bg-neutral-900">
           <TemplateEditorContext.Provider value={editorContext}>
             <ReactFlow
               nodes={rfNodes}
@@ -652,6 +659,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
               fitViewOptions={{ padding: 0.25, maxZoom: 1 }}
               minZoom={0.2}
               maxZoom={1.5}
+              zoomOnScroll={false}
               deleteKeyCode={["Backspace", "Delete"]}
               defaultEdgeOptions={{ animated: false }}
               proOptions={{ hideAttribution: true }}

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -42,8 +42,8 @@ import {
   createClassicSplitGridTemplate,
   createDefaultSplitGridTemplate,
   getSplitGridTemplate,
-  SPLIT_GRID_ROUTER_PORT_ID,
 } from "@/store/utils/splitGridTemplate";
+import { RouterRail, isInRailDropZone, type RouterWire, type RailSize } from "./RouterRail";
 import {
   getTemplateEntry,
   getTemplateNodeIcon,
@@ -120,59 +120,11 @@ function editorNodeDimensions(type: NodeType): { width: number; height: number }
   return defaultNodeDimensions[type] ?? { width: 300, height: 280 };
 }
 
-const PORT_WIDTH = 130;
-const PORT_HEIGHT = 60; // initial; RouterPortBody resizes to fit its sockets
-const PORT_GAP = 140;
-
-/**
- * The fixed downstream-router port: pinned to the right of the node-set
- * bounding box, vertically centered. It is a UI fixture (non-draggable,
- * non-deletable) whose incoming edges serialize into `template.router` — it is
- * never emitted as a template node, so it is never replicated per cell.
- */
-function routerPortRfNode(template: SplitGridTemplate): TemplateRFNode {
-  let maxX = 0;
-  let minY = 0;
-  let maxY = 0;
-  let seen = false;
-  for (const node of template.nodes) {
-    const dims = node.size ?? editorNodeDimensions(node.type);
-    const right = node.position.x + dims.width;
-    const bottom = node.position.y + dims.height;
-    if (!seen) {
-      maxX = right;
-      minY = node.position.y;
-      maxY = bottom;
-      seen = true;
-    } else {
-      maxX = Math.max(maxX, right);
-      minY = Math.min(minY, node.position.y);
-      maxY = Math.max(maxY, bottom);
-    }
-  }
-  const centerY = seen ? (minY + maxY) / 2 : 0;
-  return {
-    id: SPLIT_GRID_ROUTER_PORT_ID,
-    type: "splitGridTemplateNode",
-    position: { x: (seen ? maxX : 0) + PORT_GAP, y: centerY - PORT_HEIGHT / 2 },
-    deletable: false,
-    draggable: false,
-    selectable: false,
-    style: { width: PORT_WIDTH, height: PORT_HEIGHT },
-    data: {
-      nodeType: "router",
-      overrides: {},
-      isBase: false,
-      isRouterPort: true,
-    } satisfies TemplateNodeData,
-  };
-}
-
 function templateToRfNodes(
   template: SplitGridTemplate,
   sourceImage: string | null
 ): TemplateRFNode[] {
-  const cellNodes: TemplateRFNode[] = template.nodes.map((templateNode) => {
+  return template.nodes.map((templateNode) => {
     // Nodes with an in-flow settings panel auto-grow to fit it on mount
     const dims = templateNode.size ?? editorNodeDimensions(templateNode.type);
     const isBase = templateNode.id === template.baseNodeId;
@@ -195,11 +147,18 @@ function templateToRfNodes(
       } satisfies TemplateNodeData,
     };
   });
-  return [...cellNodes, routerPortRfNode(template)];
+}
+
+/** The downstream-router wiring stored on the template, as editor wire records. */
+function templateToRouterWires(template: SplitGridTemplate): RouterWire[] {
+  return (template.router ?? []).map((connection) => ({
+    source: connection.source,
+    sourceHandle: connection.sourceHandle,
+  }));
 }
 
 function templateToRfEdges(template: SplitGridTemplate): Edge[] {
-  const edges: Edge[] = template.edges.map((templateEdge) => ({
+  return template.edges.map((templateEdge) => ({
     id: templateEdge.id,
     source: templateEdge.source,
     sourceHandle: templateEdge.sourceHandle,
@@ -207,37 +166,22 @@ function templateToRfEdges(template: SplitGridTemplate): Edge[] {
     targetHandle: templateEdge.targetHandle,
     style: edgeStyleFor(templateEdge.sourceHandle),
   }));
-  // Reconstruct the fixed port's incoming edges so the wiring is visible + round-trips
-  for (const conn of template.router ?? []) {
-    edges.push({
-      id: `port-${conn.source}-${conn.sourceHandle}`,
-      source: conn.source,
-      sourceHandle: conn.sourceHandle,
-      target: SPLIT_GRID_ROUTER_PORT_ID,
-      targetHandle: conn.targetHandle,
-      style: edgeStyleFor(conn.sourceHandle),
-    });
-  }
-  return edges;
 }
 
 /** Serialize editor state back into a template (also used for dirty checks) */
 function serializeTemplate(
   baseNodeId: string,
   rfNodes: TemplateRFNode[],
-  rfEdges: Edge[]
+  rfEdges: Edge[],
+  routerWires: RouterWire[]
 ): SplitGridTemplate {
-  // Port-targeted edges become the router wiring (sorted for a stable, non-dirty
-  // baseline); the port node itself never enters template.nodes.
-  const router = rfEdges
-    .filter(
-      (edge) =>
-        edge.target === SPLIT_GRID_ROUTER_PORT_ID && edge.sourceHandle && edge.targetHandle
-    )
-    .map((edge) => ({
-      source: edge.source,
-      sourceHandle: edge.sourceHandle!,
-      targetHandle: edge.targetHandle!,
+  // The fixed rail's wires become the router wiring (sorted for a stable,
+  // non-dirty baseline); targetHandle equals the source handle's type.
+  const router = routerWires
+    .map((wire) => ({
+      source: wire.source,
+      sourceHandle: wire.sourceHandle,
+      targetHandle: wire.sourceHandle,
     }))
     .sort(
       (a, b) =>
@@ -247,7 +191,7 @@ function serializeTemplate(
     );
   return {
     baseNodeId,
-    nodes: rfNodes.filter((node) => !node.data.isRouterPort).map((node) => {
+    nodes: rfNodes.map((node) => {
       // Persist the node's real size, minus the editor-only settings panel
       // (real nodes grow their own panel at runtime, like the main canvas)
       const width =
@@ -268,10 +212,7 @@ function serializeTemplate(
       };
     }),
     edges: rfEdges
-      .filter(
-        (edge) =>
-          edge.sourceHandle && edge.targetHandle && edge.target !== SPLIT_GRID_ROUTER_PORT_ID
-      )
+      .filter((edge) => edge.sourceHandle && edge.targetHandle)
       .map((edge) => ({
         id: edge.id,
         source: edge.source,
@@ -401,6 +342,11 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState<Edge>(
     templateToRfEdges(initialTemplate)
   );
+  // Downstream-router wires live outside the flow (the rail is a fixed overlay)
+  const [routerWires, setRouterWires] = useState<RouterWire[]>(() =>
+    templateToRouterWires(initialTemplate)
+  );
+  const [wrapperSize, setWrapperSize] = useState<RailSize>({ width: 0, height: 0 });
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const [dropMenu, setDropMenu] = useState<TemplateDropMenuState | null>(null);
   // Drags that end over the backdrop synthesize a click on it — only treat a
@@ -422,6 +368,38 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     return () => decrementModalCount();
   }, [incrementModalCount, decrementModalCount]);
 
+  // Track the canvas wrapper size so the fixed rail can be placed + hit-tested
+  useEffect(() => {
+    const el = canvasWrapperRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const measure = () => setWrapperSize({ width: el.clientWidth, height: el.clientHeight });
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Drop router wires whose terminal node was deleted from the set
+  useEffect(() => {
+    setRouterWires((prev) => {
+      const ids = new Set(rfNodes.map((node) => node.id));
+      const next = prev.filter((wire) => ids.has(wire.source));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [rfNodes]);
+
+  const addRouterWire = useCallback((source: string, sourceHandle: string) => {
+    setRouterWires((prev) =>
+      prev.some((w) => w.source === source && w.sourceHandle === sourceHandle)
+        ? prev
+        : [...prev, { source, sourceHandle }]
+    );
+  }, []);
+
+  const disconnectRouterType = useCallback((type: string) => {
+    setRouterWires((prev) => prev.filter((w) => w.sourceHandle !== type));
+  }, []);
+
   // Dirty check: compare against the initial template mapped through the same
   // serializer, so an untouched editor is never considered dirty
   const initialSerializedRef = useRef<string | null>(null);
@@ -430,15 +408,16 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
       serializeTemplate(
         baseNodeId,
         templateToRfNodes(initialTemplate, nodeData.sourceImage),
-        templateToRfEdges(initialTemplate)
+        templateToRfEdges(initialTemplate),
+        templateToRouterWires(initialTemplate)
       )
     );
   }
   const isDirty = useCallback(
     () =>
-      JSON.stringify(serializeTemplate(baseNodeId, rfNodes, rfEdges)) !==
+      JSON.stringify(serializeTemplate(baseNodeId, rfNodes, rfEdges, routerWires)) !==
       initialSerializedRef.current,
-    [baseNodeId, rfNodes, rfEdges]
+    [baseNodeId, rfNodes, rfEdges, routerWires]
   );
 
   const requestClose = useCallback(() => {
@@ -491,6 +470,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     (template: SplitGridTemplate) => {
       setRfNodes(templateToRfNodes(template, nodeData.sourceImage));
       setRfEdges(templateToRfEdges(template));
+      setRouterWires([]); // presets carry no router wiring
       idCounterRef.current = 0;
       refitSoon();
     },
@@ -523,15 +503,6 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
       const sourceNode = rfNodes.find((node) => node.id === source);
       const targetNode = rfNodes.find((node) => node.id === target);
       if (!sourceNode || !targetNode) return false;
-      // The downstream-router port is a type-agnostic sink (never a source):
-      // accept any real output handle the source owns, no cycle check needed.
-      if (sourceNode.data.isRouterPort) return false;
-      if (targetNode.data.isRouterPort) {
-        if (!sourceHandle) return false;
-        return getTemplateEntry(sourceNode.data.nodeType).outputs.some(
-          (handle) => handle.id === sourceHandle
-        );
-      }
       const sourceEntry = getTemplateEntry(sourceNode.data.nodeType);
       const targetEntry = getTemplateEntry(targetNode.data.nodeType);
       const output = sourceEntry.outputs.find((handle) => handle.id === sourceHandle);
@@ -546,12 +517,8 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     (connection: Connection) => {
       setRfEdges((edges) => {
         let next = edges;
-        // Text inputs accept a single connection — replace the existing one. The
-        // router port is multi-input, so it is exempt from the replacement.
-        if (
-          connection.targetHandle === "text" &&
-          connection.target !== SPLIT_GRID_ROUTER_PORT_ID
-        ) {
+        // Text inputs accept a single connection — replace the existing one
+        if (connection.targetHandle === "text") {
           next = next.filter(
             (edge) =>
               !(edge.target === connection.target && edge.targetHandle === connection.targetHandle)
@@ -566,30 +533,33 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   const handleConnect = useCallback(
     (connection: Connection) => {
       if (!isValidConnection(connection)) return;
-      // Any drop onto the port resolves to the source's typed handle. This
-      // covers the generic drop target AND prevents landing on a mismatched
-      // typed handle (e.g. a text output onto an existing "image" handle), which
-      // would otherwise store a type-corrupted connection (mirrors WorkflowCanvas
-      // resolveRouterHandle).
-      let resolved = connection;
-      if (connection.target === SPLIT_GRID_ROUTER_PORT_ID) {
-        resolved = { ...connection, targetHandle: connection.sourceHandle };
-      }
-      addConnectedEdge(resolved);
+      addConnectedEdge(connection);
     },
     [isValidConnection, addConnectedEdge]
   );
 
-  // Dropping a connection in empty space opens the add-node menu, main-canvas style
+  // Dropping a connection over the fixed rail wires it to the router; dropping
+  // in empty space opens the add-node menu (main-canvas style).
   const handleConnectEnd = useCallback(
     (event: MouseEvent | TouchEvent, connectionState: FinalConnectionState) => {
       if (connectionState.isValid) return;
       const fromHandle = connectionState.fromHandle;
       const fromNode = connectionState.fromNode;
       if (!fromHandle?.id || !fromNode) return;
+      const point = "changedTouches" in event ? event.changedTouches[0] : event;
+
+      // Drop an output onto the router rail → wire it to the shared router
+      const rect = canvasWrapperRef.current?.getBoundingClientRect();
+      if (rect && fromHandle.type === "source") {
+        const wrapperPoint = { x: point.clientX - rect.left, y: point.clientY - rect.top };
+        if (isInRailDropZone(wrapperPoint, wrapperSize, routerWires)) {
+          addRouterWire(fromNode.id, fromHandle.id);
+          return;
+        }
+      }
+
       const targetElement = event.target as HTMLElement | null;
       if (!targetElement?.closest(".react-flow__pane")) return;
-      const point = "changedTouches" in event ? event.changedTouches[0] : event;
       setDropMenu({
         screen: { x: point.clientX, y: point.clientY },
         flow: screenToFlowPosition({ x: point.clientX, y: point.clientY }),
@@ -598,7 +568,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
         fromHandleType: fromHandle.type,
       });
     },
-    [screenToFlowPosition]
+    [screenToFlowPosition, wrapperSize, routerWires, addRouterWire]
   );
 
   const dropMenuOptions = useMemo(() => {
@@ -632,14 +602,8 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
         connection = { source: newId, sourceHandle: kind, target: dropMenu.fromNodeId, targetHandle: kind };
       }
 
-      const newNodeRight = position.x + dims.width;
       setRfNodes((nodes) => [
-        // Keep the fixed port clear of a node added to its left/over it
-        ...nodes.map((node) =>
-          node.data.isRouterPort && newNodeRight + PORT_GAP > node.position.x
-            ? { ...node, position: { ...node.position, x: newNodeRight + PORT_GAP } }
-            : node
-        ),
+        ...nodes,
         {
           id: newId,
           type: "splitGridTemplateNode" as const,
@@ -661,8 +625,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
 
   const cellCount =
     clampGridDimension(nodeData.gridRows) * clampGridDimension(nodeData.gridCols);
-  // The router port is shared (1 total), not part of the per-cell node count
-  const perCellNodeCount = rfNodes.filter((node) => !node.data.isRouterPort).length;
+  const perCellNodeCount = rfNodes.length;
 
   // Advisory warnings for templates that would materialize un-runnable cells
   const warnings = useMemo(() => {
@@ -678,7 +641,6 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     // Image-processing/output nodes are dead (or fail validation) without an image
     const IMAGE_OPTIONAL = new Set(["nanoBanana", "llmGenerate"]);
     const unwired = rfNodes.filter((node) => {
-      if (node.data.isRouterPort) return false;
       if (node.data.isBase || IMAGE_OPTIONAL.has(node.data.nodeType)) return false;
       const entry = getTemplateEntry(node.data.nodeType);
       if (!entry.inputs.some((handle) => handle.id === "image")) return false;
@@ -690,17 +652,11 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     }
     // Text terminals collapse to a single cell through the shared router (only
     // image outputs aggregate), so flag it rather than silently dropping cells.
-    const routerHasNonImage = rfEdges.some(
-      (edge) =>
-        edge.target === SPLIT_GRID_ROUTER_PORT_ID &&
-        edge.sourceHandle &&
-        edge.sourceHandle !== "image"
-    );
-    if (routerHasNonImage) {
-      list.push("Only image terminals aggregate through the Downstream Router — text collapses to one cell");
+    if (routerWires.some((wire) => wire.sourceHandle !== "image")) {
+      list.push("Only image terminals aggregate through the Router — text collapses to one cell");
     }
     return list;
-  }, [rfNodes, rfEdges]);
+  }, [rfNodes, rfEdges, routerWires]);
 
   const handleApply = useCallback(() => {
     if (isRunning) return;
@@ -708,10 +664,10 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     // one undo checkpoint, so one Cmd+Z reverts the whole apply
     materializeSplitGridCells(nodeId, {
       force: true,
-      template: serializeTemplate(baseNodeId, rfNodes, rfEdges),
+      template: serializeTemplate(baseNodeId, rfNodes, rfEdges, routerWires),
     });
     onClose();
-  }, [isRunning, baseNodeId, rfNodes, rfEdges, nodeId, materializeSplitGridCells, onClose]);
+  }, [isRunning, baseNodeId, rfNodes, rfEdges, routerWires, nodeId, materializeSplitGridCells, onClose]);
 
   return createPortal(
     <div
@@ -794,6 +750,14 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
               <Controls showInteractive={false} className="!bg-neutral-800 !border-neutral-700 !shadow-none [&>button]:!bg-neutral-800 [&>button]:!border-neutral-700 [&>button]:!text-neutral-300 [&>button:hover]:!bg-neutral-700" />
             </ReactFlow>
           </TemplateEditorContext.Provider>
+
+          {/* Fixed downstream-router rail (pinned to the right edge) */}
+          <RouterRail
+            wires={routerWires}
+            nodes={rfNodes}
+            size={wrapperSize}
+            onDisconnectType={disconnectRouterType}
+          />
 
           {/* Connection drop menu */}
           {dropMenu && (

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -24,6 +24,7 @@ import {
   useReactFlow,
   type Connection,
   type Edge,
+  type EdgeTypes,
   type FinalConnectionState,
   type NodeTypes,
 } from "@xyflow/react";
@@ -54,6 +55,7 @@ import {
 import {
   GEMINI_IMAGE_MODELS,
   SplitGridTemplateNode,
+  TemplateEditableEdge,
   TemplateEditorContext,
   type TemplateNodeData,
   type TemplateRFNode,
@@ -62,6 +64,17 @@ import {
 const nodeTypes: NodeTypes = {
   splitGridTemplateNode: SplitGridTemplateNode,
 };
+
+const edgeTypes: EdgeTypes = {
+  templateEditable: TemplateEditableEdge,
+};
+
+const TEMPLATE_EDGE_TYPE = "templateEditable";
+
+// Match the main canvas: on macOS a left-drag must not pan (that reads as
+// "dragging a connection moved everything"); panning is via the trackpad.
+const isMacOS =
+  typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
 const EDGE_COLOR: Record<TemplateHandleKind, string> = {
   image: "#0d9668",
@@ -160,6 +173,7 @@ function templateToRouterWires(template: SplitGridTemplate): RouterWire[] {
 function templateToRfEdges(template: SplitGridTemplate): Edge[] {
   return template.edges.map((templateEdge) => ({
     id: templateEdge.id,
+    type: TEMPLATE_EDGE_TYPE,
     source: templateEdge.source,
     sourceHandle: templateEdge.sourceHandle,
     target: templateEdge.target,
@@ -400,6 +414,15 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     setRouterWires((prev) => prev.filter((w) => w.sourceHandle !== type));
   }, []);
 
+  // Each connection carries its own midpoint delete button (TemplateEditableEdge)
+  // that calls this through the editor context.
+  const deleteEdge = useCallback(
+    (id: string) => {
+      setRfEdges((edges) => edges.filter((edge) => edge.id !== id));
+    },
+    [setRfEdges]
+  );
+
   // Dirty check: compare against the initial template mapped through the same
   // serializer, so an untouched editor is never considered dirty
   const initialSerializedRef = useRef<string | null>(null);
@@ -452,7 +475,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     },
     [setRfNodes]
   );
-  const editorContext = useMemo(() => ({ setOverrides }), [setOverrides]);
+  const editorContext = useMemo(() => ({ setOverrides, deleteEdge }), [setOverrides, deleteEdge]);
 
   const makeTemplateNodeId = useCallback(
     (type: NodeType, existing: TemplateRFNode[]): string => {
@@ -524,7 +547,10 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
               !(edge.target === connection.target && edge.targetHandle === connection.targetHandle)
           );
         }
-        return addEdge({ ...connection, style: edgeStyleFor(connection.sourceHandle) }, next);
+        return addEdge(
+          { ...connection, type: TEMPLATE_EDGE_TYPE, style: edgeStyleFor(connection.sourceHandle) },
+          next
+        );
       });
     },
     [setRfEdges]
@@ -672,7 +698,10 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   return createPortal(
     <div
       className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
-      onWheelCapture={(event) => event.stopPropagation()}
+      // Bubble-phase (not capture): the mini-canvas's native wheel-to-pan
+      // listener on the wrapper must run first; we still stop the wheel from
+      // leaking to the frozen main canvas behind the modal.
+      onWheel={(event) => event.stopPropagation()}
       onPointerDown={(event) => {
         backdropPointerDownRef.current = event.target === event.currentTarget;
       }}
@@ -737,13 +766,15 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
               onConnectEnd={handleConnectEnd}
               isValidConnection={isValidConnection}
               nodeTypes={nodeTypes}
+              edgeTypes={edgeTypes}
               fitView
               fitViewOptions={{ padding: 0.25, maxZoom: 1 }}
               minZoom={0.2}
               maxZoom={1.5}
               zoomOnScroll={false}
+              panOnDrag={!isMacOS}
               deleteKeyCode={["Backspace", "Delete"]}
-              defaultEdgeOptions={{ animated: false }}
+              defaultEdgeOptions={{ type: TEMPLATE_EDGE_TYPE, animated: false }}
               proOptions={{ hideAttribution: true }}
             >
               <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#404040" />

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -566,14 +566,13 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   const handleConnect = useCallback(
     (connection: Connection) => {
       if (!isValidConnection(connection)) return;
-      // Dropping onto the port's generic handle: resolve it to the source's
-      // typed handle so the port renders the right handle and the wiring
-      // serializes as a concrete type (mirrors WorkflowCanvas resolveRouterHandle).
+      // Any drop onto the port resolves to the source's typed handle. This
+      // covers the generic drop target AND prevents landing on a mismatched
+      // typed handle (e.g. a text output onto an existing "image" handle), which
+      // would otherwise store a type-corrupted connection (mirrors WorkflowCanvas
+      // resolveRouterHandle).
       let resolved = connection;
-      if (
-        connection.target === SPLIT_GRID_ROUTER_PORT_ID &&
-        (connection.targetHandle === "generic-input" || !connection.targetHandle)
-      ) {
+      if (connection.target === SPLIT_GRID_ROUTER_PORT_ID) {
         resolved = { ...connection, targetHandle: connection.sourceHandle };
       }
       addConnectedEdge(resolved);
@@ -633,8 +632,14 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
         connection = { source: newId, sourceHandle: kind, target: dropMenu.fromNodeId, targetHandle: kind };
       }
 
+      const newNodeRight = position.x + dims.width;
       setRfNodes((nodes) => [
-        ...nodes,
+        // Keep the fixed port clear of a node added to its left/over it
+        ...nodes.map((node) =>
+          node.data.isRouterPort && newNodeRight + PORT_GAP > node.position.x
+            ? { ...node, position: { ...node.position, x: newNodeRight + PORT_GAP } }
+            : node
+        ),
         {
           id: newId,
           type: "splitGridTemplateNode" as const,
@@ -682,6 +687,17 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     if (unwired.length > 0) {
       const labels = [...new Set(unwired.map((node) => getTemplateEntry(node.data.nodeType).label))];
       list.push(`${labels.join(", ")} node${unwired.length === 1 ? " is" : "s are"} missing an image input`);
+    }
+    // Text terminals collapse to a single cell through the shared router (only
+    // image outputs aggregate), so flag it rather than silently dropping cells.
+    const routerHasNonImage = rfEdges.some(
+      (edge) =>
+        edge.target === SPLIT_GRID_ROUTER_PORT_ID &&
+        edge.sourceHandle &&
+        edge.sourceHandle !== "image"
+    );
+    if (routerHasNonImage) {
+      list.push("Only image terminals aggregate through the Downstream Router — text collapses to one cell");
     }
     return list;
   }, [rfNodes, rfEdges]);

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -369,6 +369,13 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   const [wrapperSize, setWrapperSize] = useState<RailSize>({ width: 0, height: 0 });
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const [dropMenu, setDropMenu] = useState<TemplateDropMenuState | null>(null);
+  // Floating delete toolbar — same interaction as the main canvas: click a
+  // noodle (or a router wire) and a toolbar appears just above the cursor.
+  const [edgeToolbar, setEdgeToolbar] = useState<
+    | { x: number; y: number; target: { kind: "edge"; id: string } }
+    | { x: number; y: number; target: { kind: "wire"; source: string; sourceHandle: string } }
+    | null
+  >(null);
   // Drags that end over the backdrop synthesize a click on it — only treat a
   // click as backdrop-close when the pointer also went DOWN on the backdrop
   const backdropPointerDownRef = useRef(false);
@@ -427,14 +434,72 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     );
   }, []);
 
-  // Each connection carries its own midpoint delete button (TemplateEditableEdge)
-  // that calls this through the editor context.
   const deleteEdge = useCallback(
     (id: string) => {
       setRfEdges((edges) => edges.filter((edge) => edge.id !== id));
     },
     [setRfEdges]
   );
+
+  const handleToolbarDelete = useCallback(() => {
+    setEdgeToolbar((current) => {
+      if (!current) return null;
+      if (current.target.kind === "edge") deleteEdge(current.target.id);
+      else disconnectRouterWire(current.target.source, current.target.sourceHandle);
+      return null;
+    });
+  }, [deleteEdge, disconnectRouterWire]);
+
+  // Click a noodle or a router wire → show the delete toolbar just above the
+  // cursor; a click anywhere else dismisses it (but not clicks on the toolbar
+  // itself). Mirrors the main-canvas EdgeToolbar, which also detects edge
+  // clicks via a native mousedown listener.
+  useEffect(() => {
+    const wrapper = canvasWrapperRef.current;
+    if (!wrapper) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Element | null;
+      if (!target || target.closest("[data-edge-toolbar]")) return;
+      const above = { x: event.clientX, y: event.clientY - 40 };
+      const edgeEl = target.closest(".react-flow__edge");
+      if (edgeEl) {
+        const id =
+          edgeEl.getAttribute("data-id") ??
+          edgeEl.getAttribute("data-testid")?.replace(/^rf__edge-/, "") ??
+          null;
+        if (id) setEdgeToolbar({ ...above, target: { kind: "edge", id } });
+        return;
+      }
+      const wireEl = target.closest("[data-wire-source]");
+      if (wireEl) {
+        const source = wireEl.getAttribute("data-wire-source");
+        const sourceHandle = wireEl.getAttribute("data-wire-handle");
+        if (source && sourceHandle) {
+          setEdgeToolbar({ ...above, target: { kind: "wire", source, sourceHandle } });
+        }
+        return;
+      }
+      setEdgeToolbar(null);
+    };
+    wrapper.addEventListener("mousedown", handlePointerDown);
+    return () => wrapper.removeEventListener("mousedown", handlePointerDown);
+  }, []);
+
+  // Dismiss the toolbar if its target disappears (its node/edge/wire is removed)
+  useEffect(() => {
+    setEdgeToolbar((current) => {
+      if (!current) return current;
+      const target = current.target;
+      if (target.kind === "edge") {
+        return rfEdges.some((edge) => edge.id === target.id) ? current : null;
+      }
+      return routerWires.some(
+        (w) => w.source === target.source && w.sourceHandle === target.sourceHandle
+      )
+        ? current
+        : null;
+    });
+  }, [rfEdges, routerWires]);
 
   // Dirty check: compare against the initial template mapped through the same
   // serializer, so an untouched editor is never considered dirty
@@ -468,7 +533,9 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
-      if (dropMenu) {
+      if (edgeToolbar) {
+        setEdgeToolbar(null);
+      } else if (dropMenu) {
         setDropMenu(null);
       } else if (showDiscardConfirm) {
         setShowDiscardConfirm(false);
@@ -478,7 +545,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [dropMenu, showDiscardConfirm, requestClose]);
+  }, [edgeToolbar, dropMenu, showDiscardConfirm, requestClose]);
 
   const setOverrides = useCallback(
     (id: string, overrides: Record<string, unknown>) => {
@@ -488,7 +555,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     },
     [setRfNodes]
   );
-  const editorContext = useMemo(() => ({ setOverrides, deleteEdge }), [setOverrides, deleteEdge]);
+  const editorContext = useMemo(() => ({ setOverrides }), [setOverrides]);
 
   const makeTemplateNodeId = useCallback(
     (type: NodeType, existing: TemplateRFNode[]): string => {
@@ -801,13 +868,12 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
           </TemplateEditorContext.Provider>
           </div>
 
-          {/* Fixed downstream-router rail + wire delete buttons (on top) */}
+          {/* Fixed downstream-router rail + invisible wire click targets (on top) */}
           <RouterRail
             wires={routerWires}
             nodes={rfNodes}
             size={wrapperSize}
             onDisconnectType={disconnectRouterType}
-            onDisconnectWire={disconnectRouterWire}
           />
 
           {/* Connection drop menu */}
@@ -818,6 +884,31 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
               onSelect={handleDropMenuSelect}
               onClose={() => setDropMenu(null)}
             />
+          )}
+
+          {/* Floating delete toolbar — same look/behavior as the main canvas
+              EdgeToolbar, minus pause (cells run in one shot) */}
+          {edgeToolbar && (
+            <div
+              data-edge-toolbar
+              className="fixed z-[110] flex items-center gap-1 bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl p-1"
+              style={{ left: edgeToolbar.x, top: edgeToolbar.y, transform: "translateX(-50%)" }}
+            >
+              <button
+                onClick={handleToolbarDelete}
+                className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-red-400 transition-colors"
+                title="Delete"
+                aria-label="Delete connection"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                  />
+                </svg>
+              </button>
+            </div>
           )}
         </div>
 

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -42,6 +42,7 @@ import {
   createClassicSplitGridTemplate,
   createDefaultSplitGridTemplate,
   getSplitGridTemplate,
+  SPLIT_GRID_ROUTER_PORT_ID,
 } from "@/store/utils/splitGridTemplate";
 import {
   getTemplateEntry,
@@ -119,11 +120,59 @@ function editorNodeDimensions(type: NodeType): { width: number; height: number }
   return defaultNodeDimensions[type] ?? { width: 300, height: 280 };
 }
 
+const PORT_WIDTH = 200;
+const PORT_HEIGHT = 80;
+const PORT_GAP = 140;
+
+/**
+ * The fixed downstream-router port: pinned to the right of the node-set
+ * bounding box, vertically centered. It is a UI fixture (non-draggable,
+ * non-deletable) whose incoming edges serialize into `template.router` — it is
+ * never emitted as a template node, so it is never replicated per cell.
+ */
+function routerPortRfNode(template: SplitGridTemplate): TemplateRFNode {
+  let maxX = 0;
+  let minY = 0;
+  let maxY = 0;
+  let seen = false;
+  for (const node of template.nodes) {
+    const dims = node.size ?? editorNodeDimensions(node.type);
+    const right = node.position.x + dims.width;
+    const bottom = node.position.y + dims.height;
+    if (!seen) {
+      maxX = right;
+      minY = node.position.y;
+      maxY = bottom;
+      seen = true;
+    } else {
+      maxX = Math.max(maxX, right);
+      minY = Math.min(minY, node.position.y);
+      maxY = Math.max(maxY, bottom);
+    }
+  }
+  const centerY = seen ? (minY + maxY) / 2 : 0;
+  return {
+    id: SPLIT_GRID_ROUTER_PORT_ID,
+    type: "splitGridTemplateNode",
+    position: { x: (seen ? maxX : 0) + PORT_GAP, y: centerY - PORT_HEIGHT / 2 },
+    deletable: false,
+    draggable: false,
+    selectable: false,
+    style: { width: PORT_WIDTH, height: PORT_HEIGHT },
+    data: {
+      nodeType: "router",
+      overrides: {},
+      isBase: false,
+      isRouterPort: true,
+    } satisfies TemplateNodeData,
+  };
+}
+
 function templateToRfNodes(
   template: SplitGridTemplate,
   sourceImage: string | null
 ): TemplateRFNode[] {
-  return template.nodes.map((templateNode) => {
+  const cellNodes: TemplateRFNode[] = template.nodes.map((templateNode) => {
     // Nodes with an in-flow settings panel auto-grow to fit it on mount
     const dims = templateNode.size ?? editorNodeDimensions(templateNode.type);
     const isBase = templateNode.id === template.baseNodeId;
@@ -146,10 +195,11 @@ function templateToRfNodes(
       } satisfies TemplateNodeData,
     };
   });
+  return [...cellNodes, routerPortRfNode(template)];
 }
 
 function templateToRfEdges(template: SplitGridTemplate): Edge[] {
-  return template.edges.map((templateEdge) => ({
+  const edges: Edge[] = template.edges.map((templateEdge) => ({
     id: templateEdge.id,
     source: templateEdge.source,
     sourceHandle: templateEdge.sourceHandle,
@@ -157,6 +207,18 @@ function templateToRfEdges(template: SplitGridTemplate): Edge[] {
     targetHandle: templateEdge.targetHandle,
     style: edgeStyleFor(templateEdge.sourceHandle),
   }));
+  // Reconstruct the fixed port's incoming edges so the wiring is visible + round-trips
+  for (const conn of template.router ?? []) {
+    edges.push({
+      id: `port-${conn.source}-${conn.sourceHandle}`,
+      source: conn.source,
+      sourceHandle: conn.sourceHandle,
+      target: SPLIT_GRID_ROUTER_PORT_ID,
+      targetHandle: conn.targetHandle,
+      style: edgeStyleFor(conn.sourceHandle),
+    });
+  }
+  return edges;
 }
 
 /** Serialize editor state back into a template (also used for dirty checks) */
@@ -165,9 +227,27 @@ function serializeTemplate(
   rfNodes: TemplateRFNode[],
   rfEdges: Edge[]
 ): SplitGridTemplate {
+  // Port-targeted edges become the router wiring (sorted for a stable, non-dirty
+  // baseline); the port node itself never enters template.nodes.
+  const router = rfEdges
+    .filter(
+      (edge) =>
+        edge.target === SPLIT_GRID_ROUTER_PORT_ID && edge.sourceHandle && edge.targetHandle
+    )
+    .map((edge) => ({
+      source: edge.source,
+      sourceHandle: edge.sourceHandle!,
+      targetHandle: edge.targetHandle!,
+    }))
+    .sort(
+      (a, b) =>
+        a.source.localeCompare(b.source) ||
+        a.sourceHandle.localeCompare(b.sourceHandle) ||
+        a.targetHandle.localeCompare(b.targetHandle)
+    );
   return {
     baseNodeId,
-    nodes: rfNodes.map((node) => {
+    nodes: rfNodes.filter((node) => !node.data.isRouterPort).map((node) => {
       // Persist the node's real size, minus the editor-only settings panel
       // (real nodes grow their own panel at runtime, like the main canvas)
       const width =
@@ -188,7 +268,10 @@ function serializeTemplate(
       };
     }),
     edges: rfEdges
-      .filter((edge) => edge.sourceHandle && edge.targetHandle)
+      .filter(
+        (edge) =>
+          edge.sourceHandle && edge.targetHandle && edge.target !== SPLIT_GRID_ROUTER_PORT_ID
+      )
       .map((edge) => ({
         id: edge.id,
         source: edge.source,
@@ -196,6 +279,7 @@ function serializeTemplate(
         target: edge.target,
         targetHandle: edge.targetHandle!,
       })),
+    ...(router.length ? { router } : {}),
   };
 }
 
@@ -439,6 +523,15 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
       const sourceNode = rfNodes.find((node) => node.id === source);
       const targetNode = rfNodes.find((node) => node.id === target);
       if (!sourceNode || !targetNode) return false;
+      // The downstream-router port is a type-agnostic sink (never a source):
+      // accept any real output handle the source owns, no cycle check needed.
+      if (sourceNode.data.isRouterPort) return false;
+      if (targetNode.data.isRouterPort) {
+        if (!sourceHandle) return false;
+        return getTemplateEntry(sourceNode.data.nodeType).outputs.some(
+          (handle) => handle.id === sourceHandle
+        );
+      }
       const sourceEntry = getTemplateEntry(sourceNode.data.nodeType);
       const targetEntry = getTemplateEntry(targetNode.data.nodeType);
       const output = sourceEntry.outputs.find((handle) => handle.id === sourceHandle);
@@ -453,8 +546,12 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     (connection: Connection) => {
       setRfEdges((edges) => {
         let next = edges;
-        // Text inputs accept a single connection — replace the existing one
-        if (connection.targetHandle === "text") {
+        // Text inputs accept a single connection — replace the existing one. The
+        // router port is multi-input, so it is exempt from the replacement.
+        if (
+          connection.targetHandle === "text" &&
+          connection.target !== SPLIT_GRID_ROUTER_PORT_ID
+        ) {
           next = next.filter(
             (edge) =>
               !(edge.target === connection.target && edge.targetHandle === connection.targetHandle)
@@ -469,7 +566,17 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   const handleConnect = useCallback(
     (connection: Connection) => {
       if (!isValidConnection(connection)) return;
-      addConnectedEdge(connection);
+      // Dropping onto the port's generic handle: resolve it to the source's
+      // typed handle so the port renders the right handle and the wiring
+      // serializes as a concrete type (mirrors WorkflowCanvas resolveRouterHandle).
+      let resolved = connection;
+      if (
+        connection.target === SPLIT_GRID_ROUTER_PORT_ID &&
+        (connection.targetHandle === "generic-input" || !connection.targetHandle)
+      ) {
+        resolved = { ...connection, targetHandle: connection.sourceHandle };
+      }
+      addConnectedEdge(resolved);
     },
     [isValidConnection, addConnectedEdge]
   );
@@ -549,6 +656,8 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
 
   const cellCount =
     clampGridDimension(nodeData.gridRows) * clampGridDimension(nodeData.gridCols);
+  // The router port is shared (1 total), not part of the per-cell node count
+  const perCellNodeCount = rfNodes.filter((node) => !node.data.isRouterPort).length;
 
   // Advisory warnings for templates that would materialize un-runnable cells
   const warnings = useMemo(() => {
@@ -564,6 +673,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     // Image-processing/output nodes are dead (or fail validation) without an image
     const IMAGE_OPTIONAL = new Set(["nanoBanana", "llmGenerate"]);
     const unwired = rfNodes.filter((node) => {
+      if (node.data.isRouterPort) return false;
       if (node.data.isBase || IMAGE_OPTIONAL.has(node.data.nodeType)) return false;
       const entry = getTemplateEntry(node.data.nodeType);
       if (!entry.inputs.some((handle) => handle.id === "image")) return false;
@@ -684,7 +794,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
         <div className="flex items-center justify-between gap-4 px-5 py-3.5 border-t border-neutral-700/50 shrink-0">
           <div className="text-xs text-neutral-500 min-w-0">
             <span>
-              {rfNodes.length} node{rfNodes.length === 1 ? "" : "s"} per cell · {nodeData.gridRows}×{nodeData.gridCols} grid → {cellCount} group{cellCount === 1 ? "" : "s"}
+              {perCellNodeCount} node{perCellNodeCount === 1 ? "" : "s"} per cell · {nodeData.gridRows}×{nodeData.gridCols} grid → {cellCount} group{cellCount === 1 ? "" : "s"}
             </span>
             {warnings.map((warning) => (
               <span key={warning} className="ml-3 text-amber-400">

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -11,10 +11,15 @@
 
 import { createContext, memo, useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getBezierPath,
   Handle,
   NodeResizer,
   Position,
   useReactFlow,
+  useStore,
+  type EdgeProps,
   type NodeProps,
   type Node,
 } from "@xyflow/react";
@@ -47,11 +52,90 @@ export type TemplateRFNode = Node<TemplateNodeData, "splitGridTemplateNode">;
 
 interface TemplateEditorContextValue {
   setOverrides: (nodeId: string, overrides: Record<string, unknown>) => void;
+  deleteEdge: (edgeId: string) => void;
 }
 
 export const TemplateEditorContext = createContext<TemplateEditorContextValue>({
   setOverrides: () => {},
+  deleteEdge: () => {},
 });
+
+/**
+ * Editor edge with an always-present delete control at its midpoint. Clicking
+ * the thin connection line to select-then-delete is fiddly (and easy to miss,
+ * which lands on the pane and pans instead), so every connection carries a real
+ * button — rendered in the EdgeLabelRenderer layer so it tracks pan/zoom and is
+ * clickable regardless of how the SVG path hit-tests.
+ */
+export function TemplateEditableEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+}: EdgeProps) {
+  const { deleteEdge } = useContext(TemplateEditorContext);
+  // The EdgeLabelRenderer layer is zoom-scaled; counter-scale so the button
+  // stays a constant, comfortably-clickable screen size at any zoom.
+  const zoom = useStore((state) => state.transform[2]);
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+      {/* Wide invisible hit path — keeps hover/selection forgiving */}
+      <path d={edgePath} fill="none" strokeWidth={16} stroke="transparent" className="react-flow__edge-interaction" />
+      <EdgeLabelRenderer>
+        {/* Zero-size anchor pinned to the edge midpoint; grid-centers the button
+            on the point so the counter-scale stays centered. */}
+        <div
+          className="nodrag nopan"
+          style={{
+            position: "absolute",
+            transform: `translate(${labelX}px, ${labelY}px)`,
+            display: "grid",
+            placeItems: "center",
+            width: 0,
+            height: 0,
+            pointerEvents: "none",
+          }}
+        >
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              deleteEdge(id);
+            }}
+            title="Delete connection"
+            aria-label="Delete connection"
+            className="flex items-center justify-center rounded-full bg-neutral-800 border border-neutral-600 text-neutral-400 shadow-md transition-colors hover:bg-red-500/20 hover:border-red-500 hover:text-red-400"
+            style={{
+              width: 20,
+              height: 20,
+              pointerEvents: "all",
+              transform: `scale(${1 / zoom})`,
+            }}
+          >
+            <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}
 
 // Mirrors GenerateImageNode's gemini constants
 export const GEMINI_IMAGE_MODELS: { value: ModelType; label: string }[] = [

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -9,14 +9,12 @@
  * browser for the full multi-provider model catalog.
  */
 
-import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, memo, useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
   Handle,
   NodeResizer,
   Position,
-  useNodeConnections,
   useReactFlow,
-  useUpdateNodeInternals,
   type NodeProps,
   type Node,
 } from "@xyflow/react";
@@ -40,8 +38,6 @@ export interface TemplateNodeData extends Record<string, unknown> {
   nodeType: NodeType;
   overrides: Record<string, unknown>;
   isBase: boolean;
-  /** The fixed, non-replicated downstream-router port (1 total, not 1 per cell) */
-  isRouterPort?: boolean;
   sourceImage?: string | null;
   /** Measured settings-panel height, subtracted when persisting node size */
   _editorPanelHeight?: number;
@@ -560,148 +556,6 @@ function LlmBody({ nodeId, overrides }: { nodeId: string; overrides: Record<stri
   );
 }
 
-/** Socket colors + labels for the router port, mirroring the main-canvas handles */
-const PORT_HANDLE_COLORS: Record<string, string> = {
-  image: "#10b981",
-  text: "#3b82f6",
-  video: "#ec4899",
-  audio: "rgb(167, 139, 250)",
-  "3d": "#f97316",
-  easeCurve: "#ffffff",
-};
-const PORT_TYPE_LABELS: Record<string, string> = {
-  image: "Image",
-  text: "Text",
-  video: "Video",
-  audio: "Audio",
-  "3d": "3D",
-  easeCurve: "Curve",
-};
-const PORT_EMPTY_COLOR = "#6b7280";
-const PORT_ROW_H = 26;
-const PORT_TOP_PAD = 8;
-const PORT_SOCKET_LEFT = 18; // socket center, inset right of the brace
-
-/** A rounded curly brace embracing the sockets from their left (opening right). */
-function PortBrace({ height }: { height: number }) {
-  const h = Math.max(height, 28);
-  const mid = h / 2;
-  const curl = Math.min(9, mid - 5);
-  const d = [
-    `M 9 3`,
-    `C 5 3 5 4 5 8`,
-    `L 5 ${mid - curl}`,
-    `C 5 ${mid - 3} 5 ${mid - 3} 1 ${mid}`,
-    `C 5 ${mid + 3} 5 ${mid + 3} 5 ${mid + curl}`,
-    `L 5 ${h - 8}`,
-    `C 5 ${h - 4} 5 ${h - 3} 9 ${h - 3}`,
-  ].join(" ");
-  return (
-    <svg
-      width="10"
-      height={h}
-      viewBox={`0 0 10 ${h}`}
-      className="absolute overflow-visible pointer-events-none"
-      style={{ left: 2, top: PORT_TOP_PAD }}
-      fill="none"
-    >
-      <path
-        d={d}
-        stroke="#8a8a8a"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-/**
- * The fixed "downstream router" port — a ComfyUI-style rounded bracket pinned to
- * the right of the cell node set. Each terminal wired in grows a typed, colored
- * socket labelled with its type; a persistent empty gray socket at the bottom is
- * the drop target for the next connection. Input-only in the editor; the real
- * Router's onward wiring happens on the main canvas after materialization.
- */
-function RouterPortBody({ nodeId }: { nodeId: string }) {
-  const connections = useNodeConnections({ id: nodeId, handleType: "target" });
-  const updateNodeInternals = useUpdateNodeInternals();
-  const { setNodes } = useReactFlow();
-
-  const activeTypes = useMemo(() => {
-    const set = new Set<string>();
-    for (const connection of connections) {
-      const handle = connection.targetHandle;
-      if (handle && handle !== "generic-input") set.add(handle);
-    }
-    return Array.from(set).sort();
-  }, [connections]);
-
-  // One row per wired type, then the always-present empty drop socket.
-  const rows: (string | null)[] = [...activeTypes, null];
-  const braceHeight = rows.length * PORT_ROW_H;
-  const nodeHeight = PORT_TOP_PAD * 2 + braceHeight;
-
-  // Keep the node box sized to its sockets and re-register handles on change.
-  useEffect(() => {
-    setNodes((nodes) =>
-      nodes.map((node) => {
-        if (node.id !== nodeId) return node;
-        const current = (node.style?.height as number | undefined) ?? 0;
-        if (current === nodeHeight) return node;
-        return { ...node, style: { ...node.style, height: nodeHeight } };
-      })
-    );
-    updateNodeInternals(nodeId);
-  }, [nodeId, nodeHeight, setNodes, updateNodeInternals]);
-
-  return (
-    <div className="relative h-full w-full overflow-visible">
-      <PortBrace height={braceHeight} />
-      {rows.map((type, index) => {
-        const top = PORT_TOP_PAD + index * PORT_ROW_H + PORT_ROW_H / 2;
-        const label = type ? PORT_TYPE_LABELS[type] ?? type : null;
-        const color = type ? PORT_HANDLE_COLORS[type] ?? PORT_EMPTY_COLOR : PORT_EMPTY_COLOR;
-        return (
-          <div key={type ?? "generic-input"}>
-            <Handle
-              type="target"
-              position={Position.Left}
-              id={type ?? "generic-input"}
-              data-handletype={type ?? undefined}
-              title={label ?? "Drag a terminal's output here"}
-              style={{
-                top,
-                left: PORT_SOCKET_LEFT,
-                transform: "translate(-50%, -50%)",
-                backgroundColor: color,
-                width: 11,
-                height: 11,
-                border: "2px solid #1e1e1e",
-              }}
-            />
-            {label ? (
-              <span
-                className="absolute text-[11px] font-medium leading-none -translate-y-1/2 whitespace-nowrap pointer-events-none select-none"
-                style={{ top, left: PORT_SOCKET_LEFT + 13, color }}
-              >
-                {label}
-              </span>
-            ) : activeTypes.length === 0 ? (
-              <span
-                className="absolute text-[11px] font-medium leading-none -translate-y-1/2 whitespace-nowrap text-neutral-500 pointer-events-none select-none"
-                style={{ top, left: PORT_SOCKET_LEFT + 13 }}
-              >
-                Downstream Router
-              </span>
-            ) : null}
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
 function GenericBody({ nodeType, description }: { nodeType: NodeType; description: string }) {
   const icon = getTemplateNodeIcon(nodeType);
   return (
@@ -713,12 +567,6 @@ function GenericBody({ nodeType, description }: { nodeType: NodeType; descriptio
 }
 
 function TemplateNodeComponent({ id, data, selected }: NodeProps<TemplateRFNode>) {
-  // The fixed downstream-router port: a chrome-less rounded bracket + typed
-  // sockets pinned to the right of the node set. It is never replicated per cell.
-  if (data.isRouterPort) {
-    return <RouterPortBody nodeId={id} />;
-  }
-
   const entry = getTemplateEntry(data.nodeType);
   const isGenerate = data.nodeType === "nanoBanana";
   const selectedModel = data.overrides.selectedModel as SelectedModel | undefined;

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -9,8 +9,17 @@
  * browser for the full multi-provider model catalog.
  */
 
-import { createContext, memo, useCallback, useContext, useEffect, useRef, useState } from "react";
-import { Handle, NodeResizer, Position, useReactFlow, type NodeProps, type Node } from "@xyflow/react";
+import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Handle,
+  NodeResizer,
+  Position,
+  useNodeConnections,
+  useReactFlow,
+  useUpdateNodeInternals,
+  type NodeProps,
+  type Node,
+} from "@xyflow/react";
 import type {
   AspectRatio,
   LLMModelType,
@@ -31,6 +40,8 @@ export interface TemplateNodeData extends Record<string, unknown> {
   nodeType: NodeType;
   overrides: Record<string, unknown>;
   isBase: boolean;
+  /** The fixed, non-replicated downstream-router port (1 total, not 1 per cell) */
+  isRouterPort?: boolean;
   sourceImage?: string | null;
   /** Measured settings-panel height, subtracted when persisting node size */
   _editorPanelHeight?: number;
@@ -549,6 +560,85 @@ function LlmBody({ nodeId, overrides }: { nodeId: string; overrides: Record<stri
   );
 }
 
+/** Handle colors for the router port, mirroring RouterNode.tsx on the main canvas */
+const PORT_HANDLE_COLORS: Record<string, string> = {
+  image: "#10b981",
+  text: "#3b82f6",
+  video: "#ec4899",
+  audio: "rgb(167, 139, 250)",
+  "3d": "#f97316",
+  easeCurve: "#ffffff",
+};
+
+/**
+ * The fixed "downstream router" port — a router-style sink pinned to the right
+ * of the cell node set. Mirrors RouterNode: it grows a typed input handle for
+ * each terminal type wired into it, plus a persistent gray generic drop target.
+ * Input-only in the editor; the real Router's onward wiring happens on the main
+ * canvas after materialization.
+ */
+function RouterPortBody({ nodeId }: { nodeId: string }) {
+  const connections = useNodeConnections({ id: nodeId, handleType: "target" });
+  const updateNodeInternals = useUpdateNodeInternals();
+
+  const activeTypes = useMemo(() => {
+    const set = new Set<string>();
+    for (const connection of connections) {
+      const handle = connection.targetHandle;
+      if (handle && handle !== "generic-input") set.add(handle);
+    }
+    return Array.from(set).sort();
+  }, [connections]);
+
+  // Re-register handles when a new type is wired so edges attach cleanly
+  useEffect(() => {
+    updateNodeInternals(nodeId);
+  }, [activeTypes.length, nodeId, updateNodeInternals]);
+
+  const spacing = 22;
+  const baseTop = 16;
+  return (
+    <>
+      {activeTypes.map((type, index) => (
+        <Handle
+          key={`in-${type}`}
+          type="target"
+          position={Position.Left}
+          id={type}
+          data-handletype={type}
+          style={{
+            top: baseTop + index * spacing,
+            backgroundColor: PORT_HANDLE_COLORS[type] ?? "#6b7280",
+            width: 12,
+            height: 12,
+            border: "2px solid #1e1e1e",
+          }}
+        />
+      ))}
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="generic-input"
+        style={{
+          top: baseTop + activeTypes.length * spacing,
+          backgroundColor: "#6b7280",
+          width: 12,
+          height: 12,
+          border: "2px solid #1e1e1e",
+        }}
+      />
+      <div className="w-full h-full rounded-lg bg-neutral-800/60 border border-neutral-600 flex flex-col items-center justify-center gap-1 px-3">
+        <span className="text-neutral-500 [&>svg]:w-6 [&>svg]:h-6">{getTemplateNodeIcon("router")}</span>
+        <span className="text-[10px] text-neutral-400 text-center leading-tight">
+          {activeTypes.length
+            ? `Routes ${activeTypes.length} type${activeTypes.length > 1 ? "s" : ""} into one shared Router`
+            : "Drag a terminal's output here"}
+        </span>
+      </div>
+    </>
+  );
+}
+
 function GenericBody({ nodeType, description }: { nodeType: NodeType; description: string }) {
   const icon = getTemplateNodeIcon(nodeType);
   return (
@@ -560,6 +650,26 @@ function GenericBody({ nodeType, description }: { nodeType: NodeType; descriptio
 }
 
 function TemplateNodeComponent({ id, data, selected }: NodeProps<TemplateRFNode>) {
+  // The fixed downstream-router port: no resizer (fixed size), a shared badge,
+  // and a router-style body. It is never replicated per cell.
+  if (data.isRouterPort) {
+    return (
+      <div className="relative h-full w-full">
+        <MiniFloatingHeader
+          title="Downstream Router"
+          right={
+            <span className="text-[9px] px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-300 border border-violet-500/25">
+              shared · 1 total
+            </span>
+          }
+        />
+        <MiniCard selected={selected}>
+          <RouterPortBody nodeId={id} />
+        </MiniCard>
+      </div>
+    );
+  }
+
   const entry = getTemplateEntry(data.nodeType);
   const isGenerate = data.nodeType === "nanoBanana";
   const selectedModel = data.overrides.selectedModel as SelectedModel | undefined;

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -50,6 +50,7 @@ export const TemplateEditorContext = createContext<TemplateEditorContextValue>({
 export const GEMINI_IMAGE_MODELS: { value: ModelType; label: string }[] = [
   { value: "nano-banana", label: "Nano Banana" },
   { value: "nano-banana-2", label: "Nano Banana 2" },
+  { value: "nano-banana-2-lite", label: "Nano Banana 2 Lite" },
   { value: "nano-banana-pro", label: "Nano Banana Pro" },
 ];
 const BASE_ASPECT_RATIOS: AspectRatio[] = ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"];

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -119,17 +119,21 @@ export function TemplateEditableEdge({
             }}
             title="Delete connection"
             aria-label="Delete connection"
-            className="flex items-center justify-center rounded-full bg-neutral-800 border border-neutral-600 text-neutral-400 shadow-md transition-colors hover:bg-red-500/20 hover:border-red-500 hover:text-red-400"
+            className="group grid place-items-center"
             style={{
-              width: 20,
-              height: 20,
+              width: 28,
+              height: 28,
+              background: "transparent",
               pointerEvents: "all",
               transform: `scale(${1 / zoom})`,
             }}
           >
-            <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            {/* Hidden until the midpoint is hovered, so connections stay clean */}
+            <span className="flex items-center justify-center w-5 h-5 rounded-full bg-neutral-800 border border-neutral-600 text-neutral-400 shadow-md opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 group-hover:text-red-400 group-hover:border-red-500 group-hover:bg-red-500/20">
+              <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </span>
           </button>
         </div>
       </EdgeLabelRenderer>

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -169,9 +169,12 @@ function MiniFloatingHeader({
 }) {
   return (
     <div className="absolute left-0 right-0 -top-[26px] px-1 py-1 flex items-center justify-between pointer-events-none">
-      <div className="flex-1 min-w-0 flex items-center gap-1.5 pl-2">
+      {/* Title strip doubles as a drag handle (bodies are nodrag). No `nodrag`
+          class + pointer-events-auto lets React Flow start a node drag here,
+          mirroring the main-canvas FloatingNodeHeader. */}
+      <div className="flex-1 min-w-0 flex items-center gap-1.5 pl-2 pointer-events-auto cursor-grab active:cursor-grabbing">
         {provider && <ProviderBadge provider={provider} />}
-        <span className="text-xs font-semibold uppercase tracking-wide text-neutral-400 truncate">
+        <span className="text-xs font-semibold uppercase tracking-wide text-neutral-400 truncate select-none">
           {title}
         </span>
       </div>

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -560,7 +560,7 @@ function LlmBody({ nodeId, overrides }: { nodeId: string; overrides: Record<stri
   );
 }
 
-/** Handle colors for the router port, mirroring RouterNode.tsx on the main canvas */
+/** Socket colors + labels for the router port, mirroring the main-canvas handles */
 const PORT_HANDLE_COLORS: Record<string, string> = {
   image: "#10b981",
   text: "#3b82f6",
@@ -569,17 +569,64 @@ const PORT_HANDLE_COLORS: Record<string, string> = {
   "3d": "#f97316",
   easeCurve: "#ffffff",
 };
+const PORT_TYPE_LABELS: Record<string, string> = {
+  image: "Image",
+  text: "Text",
+  video: "Video",
+  audio: "Audio",
+  "3d": "3D",
+  easeCurve: "Curve",
+};
+const PORT_EMPTY_COLOR = "#6b7280";
+const PORT_ROW_H = 26;
+const PORT_TOP_PAD = 8;
+const PORT_SOCKET_LEFT = 18; // socket center, inset right of the brace
+
+/** A rounded curly brace embracing the sockets from their left (opening right). */
+function PortBrace({ height }: { height: number }) {
+  const h = Math.max(height, 28);
+  const mid = h / 2;
+  const curl = Math.min(9, mid - 5);
+  const d = [
+    `M 9 3`,
+    `C 5 3 5 4 5 8`,
+    `L 5 ${mid - curl}`,
+    `C 5 ${mid - 3} 5 ${mid - 3} 1 ${mid}`,
+    `C 5 ${mid + 3} 5 ${mid + 3} 5 ${mid + curl}`,
+    `L 5 ${h - 8}`,
+    `C 5 ${h - 4} 5 ${h - 3} 9 ${h - 3}`,
+  ].join(" ");
+  return (
+    <svg
+      width="10"
+      height={h}
+      viewBox={`0 0 10 ${h}`}
+      className="absolute overflow-visible pointer-events-none"
+      style={{ left: 2, top: PORT_TOP_PAD }}
+      fill="none"
+    >
+      <path
+        d={d}
+        stroke="#8a8a8a"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
 
 /**
- * The fixed "downstream router" port — a router-style sink pinned to the right
- * of the cell node set. Mirrors RouterNode: it grows a typed input handle for
- * each terminal type wired into it, plus a persistent gray generic drop target.
- * Input-only in the editor; the real Router's onward wiring happens on the main
- * canvas after materialization.
+ * The fixed "downstream router" port — a ComfyUI-style rounded bracket pinned to
+ * the right of the cell node set. Each terminal wired in grows a typed, colored
+ * socket labelled with its type; a persistent empty gray socket at the bottom is
+ * the drop target for the next connection. Input-only in the editor; the real
+ * Router's onward wiring happens on the main canvas after materialization.
  */
 function RouterPortBody({ nodeId }: { nodeId: string }) {
   const connections = useNodeConnections({ id: nodeId, handleType: "target" });
   const updateNodeInternals = useUpdateNodeInternals();
+  const { setNodes } = useReactFlow();
 
   const activeTypes = useMemo(() => {
     const set = new Set<string>();
@@ -590,52 +637,68 @@ function RouterPortBody({ nodeId }: { nodeId: string }) {
     return Array.from(set).sort();
   }, [connections]);
 
-  // Re-register handles when a new type is wired so edges attach cleanly
-  useEffect(() => {
-    updateNodeInternals(nodeId);
-  }, [activeTypes.length, nodeId, updateNodeInternals]);
+  // One row per wired type, then the always-present empty drop socket.
+  const rows: (string | null)[] = [...activeTypes, null];
+  const braceHeight = rows.length * PORT_ROW_H;
+  const nodeHeight = PORT_TOP_PAD * 2 + braceHeight;
 
-  const spacing = 22;
-  const baseTop = 16;
+  // Keep the node box sized to its sockets and re-register handles on change.
+  useEffect(() => {
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id !== nodeId) return node;
+        const current = (node.style?.height as number | undefined) ?? 0;
+        if (current === nodeHeight) return node;
+        return { ...node, style: { ...node.style, height: nodeHeight } };
+      })
+    );
+    updateNodeInternals(nodeId);
+  }, [nodeId, nodeHeight, setNodes, updateNodeInternals]);
+
   return (
-    <>
-      {activeTypes.map((type, index) => (
-        <Handle
-          key={`in-${type}`}
-          type="target"
-          position={Position.Left}
-          id={type}
-          data-handletype={type}
-          style={{
-            top: baseTop + index * spacing,
-            backgroundColor: PORT_HANDLE_COLORS[type] ?? "#6b7280",
-            width: 12,
-            height: 12,
-            border: "2px solid #1e1e1e",
-          }}
-        />
-      ))}
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="generic-input"
-        style={{
-          top: baseTop + activeTypes.length * spacing,
-          backgroundColor: "#6b7280",
-          width: 12,
-          height: 12,
-          border: "2px solid #1e1e1e",
-        }}
-      />
-      <div className="w-full h-full rounded-lg bg-neutral-800/60 border border-neutral-600 flex flex-col items-center justify-center gap-1 px-3">
-        <span className="text-neutral-500 [&>svg]:w-6 [&>svg]:h-6">{getTemplateNodeIcon("router")}</span>
-        <span className="text-[10px] text-neutral-400 text-center leading-tight">
-          {activeTypes.length
-            ? `Routes ${activeTypes.length} type${activeTypes.length > 1 ? "s" : ""} into one shared Router`
-            : "Drag a terminal's output here"}
-        </span>
-      </div>
-    </>
+    <div className="relative h-full w-full overflow-visible">
+      <PortBrace height={braceHeight} />
+      {rows.map((type, index) => {
+        const top = PORT_TOP_PAD + index * PORT_ROW_H + PORT_ROW_H / 2;
+        const label = type ? PORT_TYPE_LABELS[type] ?? type : null;
+        const color = type ? PORT_HANDLE_COLORS[type] ?? PORT_EMPTY_COLOR : PORT_EMPTY_COLOR;
+        return (
+          <div key={type ?? "generic-input"}>
+            <Handle
+              type="target"
+              position={Position.Left}
+              id={type ?? "generic-input"}
+              data-handletype={type ?? undefined}
+              title={label ?? "Drag a terminal's output here"}
+              style={{
+                top,
+                left: PORT_SOCKET_LEFT,
+                transform: "translate(-50%, -50%)",
+                backgroundColor: color,
+                width: 11,
+                height: 11,
+                border: "2px solid #1e1e1e",
+              }}
+            />
+            {label ? (
+              <span
+                className="absolute text-[11px] font-medium leading-none -translate-y-1/2 whitespace-nowrap pointer-events-none select-none"
+                style={{ top, left: PORT_SOCKET_LEFT + 13, color }}
+              >
+                {label}
+              </span>
+            ) : activeTypes.length === 0 ? (
+              <span
+                className="absolute text-[11px] font-medium leading-none -translate-y-1/2 whitespace-nowrap text-neutral-500 pointer-events-none select-none"
+                style={{ top, left: PORT_SOCKET_LEFT + 13 }}
+              >
+                Downstream Router
+              </span>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -650,24 +713,10 @@ function GenericBody({ nodeType, description }: { nodeType: NodeType; descriptio
 }
 
 function TemplateNodeComponent({ id, data, selected }: NodeProps<TemplateRFNode>) {
-  // The fixed downstream-router port: no resizer (fixed size), a shared badge,
-  // and a router-style body. It is never replicated per cell.
+  // The fixed downstream-router port: a chrome-less rounded bracket + typed
+  // sockets pinned to the right of the node set. It is never replicated per cell.
   if (data.isRouterPort) {
-    return (
-      <div className="relative h-full w-full">
-        <MiniFloatingHeader
-          title="Downstream Router"
-          right={
-            <span className="text-[9px] px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-300 border border-violet-500/25">
-              shared · 1 total
-            </span>
-          }
-        />
-        <MiniCard selected={selected}>
-          <RouterPortBody nodeId={id} />
-        </MiniCard>
-      </div>
-    );
+    return <RouterPortBody nodeId={id} />;
   }
 
   const entry = getTemplateEntry(data.nodeType);

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -12,13 +12,11 @@
 import { createContext, memo, useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
   BaseEdge,
-  EdgeLabelRenderer,
   getBezierPath,
   Handle,
   NodeResizer,
   Position,
   useReactFlow,
-  useStore,
   type EdgeProps,
   type NodeProps,
   type Node,
@@ -52,20 +50,17 @@ export type TemplateRFNode = Node<TemplateNodeData, "splitGridTemplateNode">;
 
 interface TemplateEditorContextValue {
   setOverrides: (nodeId: string, overrides: Record<string, unknown>) => void;
-  deleteEdge: (edgeId: string) => void;
 }
 
 export const TemplateEditorContext = createContext<TemplateEditorContextValue>({
   setOverrides: () => {},
-  deleteEdge: () => {},
 });
 
 /**
- * Editor edge with an always-present delete control at its midpoint. Clicking
- * the thin connection line to select-then-delete is fiddly (and easy to miss,
- * which lands on the pane and pans instead), so every connection carries a real
- * button — rendered in the EdgeLabelRenderer layer so it tracks pan/zoom and is
- * clickable regardless of how the SVG path hit-tests.
+ * Editor connection ("noodle") — a curved bezier with a wide invisible hit
+ * path, exactly like the main canvas. Deletion is handled the same way too: the
+ * modal shows a floating toolbar above the cursor when a noodle is clicked (see
+ * SplitGridTemplateModal), so the edge itself carries no inline control.
  */
 export function TemplateEditableEdge({
   id,
@@ -78,11 +73,7 @@ export function TemplateEditableEdge({
   style,
   markerEnd,
 }: EdgeProps) {
-  const { deleteEdge } = useContext(TemplateEditorContext);
-  // The EdgeLabelRenderer layer is zoom-scaled; counter-scale so the button
-  // stays a constant, comfortably-clickable screen size at any zoom.
-  const zoom = useStore((state) => state.transform[2]);
-  const [edgePath, labelX, labelY] = getBezierPath({
+  const [edgePath] = getBezierPath({
     sourceX,
     sourceY,
     sourcePosition,
@@ -94,49 +85,8 @@ export function TemplateEditableEdge({
   return (
     <>
       <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
-      {/* Wide invisible hit path — keeps hover/selection forgiving */}
+      {/* Wide invisible hit path — makes the noodle easy to click */}
       <path d={edgePath} fill="none" strokeWidth={16} stroke="transparent" className="react-flow__edge-interaction" />
-      <EdgeLabelRenderer>
-        {/* Zero-size anchor pinned to the edge midpoint; grid-centers the button
-            on the point so the counter-scale stays centered. */}
-        <div
-          className="nodrag nopan"
-          style={{
-            position: "absolute",
-            transform: `translate(${labelX}px, ${labelY}px)`,
-            display: "grid",
-            placeItems: "center",
-            width: 0,
-            height: 0,
-            pointerEvents: "none",
-          }}
-        >
-          <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              deleteEdge(id);
-            }}
-            title="Delete connection"
-            aria-label="Delete connection"
-            className="group grid place-items-center"
-            style={{
-              width: 28,
-              height: 28,
-              background: "transparent",
-              pointerEvents: "all",
-              transform: `scale(${1 / zoom})`,
-            }}
-          >
-            {/* Hidden until the midpoint is hovered, so connections stay clean */}
-            <span className="flex items-center justify-center w-5 h-5 rounded-full bg-neutral-800 border border-neutral-600 text-neutral-400 shadow-md opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 group-hover:text-red-400 group-hover:border-red-500 group-hover:bg-red-500/20">
-              <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </span>
-          </button>
-        </div>
-      </EdgeLabelRenderer>
     </>
   );
 }

--- a/src/hooks/useWheelPanZoom.ts
+++ b/src/hooks/useWheelPanZoom.ts
@@ -1,0 +1,129 @@
+import { useEffect, type RefObject } from "react";
+import { useReactFlow } from "@xyflow/react";
+import type { CanvasNavigationSettings } from "@/types/canvas";
+
+/**
+ * Wheel-based pan/zoom for a React Flow canvas, honoring the user's
+ * CanvasNavigationSettings. Shared by the main canvas and the split-grid cell
+ * editor's mini canvas so both navigate identically (e.g. trackpad scroll pans
+ * when zoomMode is altScroll/ctrlScroll).
+ *
+ * Uses a non-passive wheel listener so it can preventDefault (blocking browser
+ * back/forward swipe and React Flow's built-in scroll zoom). The React Flow
+ * instance it drives is the nearest ReactFlowProvider's — call this inside the
+ * provider whose viewport you want to control. Set `zoomOnScroll={false}` on
+ * that ReactFlow so it doesn't also zoom on scroll.
+ */
+
+const isMacOS =
+  typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+// Detect if a wheel event is from a mouse (vs trackpad).
+function isMouseWheel(event: WheelEvent): boolean {
+  // Mouse wheels typically use deltaMode 1 (lines); trackpads use deltaMode 0
+  // (pixels) with smaller, smoother deltas.
+  if (event.deltaMode === 1) return true;
+  const threshold = 50;
+  return Math.abs(event.deltaY) >= threshold && Math.abs(event.deltaY) % 40 === 0;
+}
+
+// Whether an element can scroll further in the wheel's direction.
+function canElementScroll(element: HTMLElement, deltaX: number, deltaY: number): boolean {
+  const style = window.getComputedStyle(element);
+  const canScrollY = style.overflowY === "auto" || style.overflowY === "scroll";
+  const canScrollX = style.overflowX === "auto" || style.overflowX === "scroll";
+
+  if (canScrollY && deltaY !== 0 && element.scrollHeight > element.clientHeight) {
+    if (deltaY > 0 && element.scrollTop < element.scrollHeight - element.clientHeight) return true;
+    if (deltaY < 0 && element.scrollTop > 0) return true;
+  }
+  if (canScrollX && deltaX !== 0 && element.scrollWidth > element.clientWidth) {
+    if (deltaX > 0 && element.scrollLeft < element.scrollWidth - element.clientWidth) return true;
+    if (deltaX < 0 && element.scrollLeft > 0) return true;
+  }
+  return false;
+}
+
+// Nearest scrollable ancestor (nowheel/textarea) that can consume the wheel,
+// so inner scroll areas keep their own scrolling instead of panning the canvas.
+function findScrollableAncestor(
+  target: HTMLElement,
+  deltaX: number,
+  deltaY: number
+): HTMLElement | null {
+  let current: HTMLElement | null = target;
+  while (current && !current.classList.contains("react-flow")) {
+    if (current.classList.contains("nowheel") || current.tagName === "TEXTAREA") {
+      if (canElementScroll(current, deltaX, deltaY)) return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+export function useWheelPanZoom(
+  wrapperRef: RefObject<HTMLElement | null>,
+  settings: CanvasNavigationSettings,
+  enabled = true
+): void {
+  const { getViewport, setViewport, zoomIn, zoomOut } = useReactFlow();
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper || !enabled) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      // Let inner scroll areas (nowheel/textarea) keep their own scrolling.
+      const target = event.target as HTMLElement;
+      if (findScrollableAncestor(target, event.deltaX, event.deltaY)) return;
+
+      const { zoomMode } = settings;
+      const shouldZoom =
+        zoomMode === "scroll" ||
+        (zoomMode === "altScroll" && event.altKey) ||
+        (zoomMode === "ctrlScroll" && (event.ctrlKey || event.metaKey));
+
+      // Pinch gesture (ctrl + trackpad) always zooms.
+      if (event.ctrlKey && !event.altKey) {
+        event.preventDefault();
+        if (event.deltaY < 0) zoomIn();
+        else zoomOut();
+        return;
+      }
+
+      if (isMacOS) {
+        if (isMouseWheel(event)) {
+          if (shouldZoom) {
+            event.preventDefault();
+            if (event.deltaY < 0) zoomIn();
+            else zoomOut();
+          }
+        } else if (shouldZoom) {
+          event.preventDefault();
+          if (event.deltaY < 0) zoomIn();
+          else zoomOut();
+        } else {
+          // Trackpad pan (also blocks horizontal swipe navigation).
+          event.preventDefault();
+          const viewport = getViewport();
+          setViewport({
+            x: viewport.x - event.deltaX,
+            y: viewport.y - event.deltaY,
+            zoom: viewport.zoom,
+          });
+        }
+        return;
+      }
+
+      // Non-macOS: scroll zooms only when settings ask for it.
+      if (shouldZoom) {
+        event.preventDefault();
+        if (event.deltaY < 0) zoomIn();
+        else zoomOut();
+      }
+    };
+
+    wrapper.addEventListener("wheel", handleWheel, { passive: false });
+    return () => wrapper.removeEventListener("wheel", handleWheel);
+  }, [wrapperRef, enabled, settings, getViewport, setViewport, zoomIn, zoomOut]);
+}

--- a/src/store/__tests__/materializeSplitGridCells.test.ts
+++ b/src/store/__tests__/materializeSplitGridCells.test.ts
@@ -467,4 +467,244 @@ describe("materializeSplitGridCells", () => {
       expect(data.materializedKey).toBeNull();
     });
   });
+
+  describe("shared downstream router", () => {
+    // Classic template with its generate node wired to the fixed router port.
+    function routerWiredTemplate() {
+      const t = createClassicSplitGridTemplate();
+      return {
+        ...t,
+        router: [{ source: "cell-generate", sourceHandle: "image", targetHandle: "image" }],
+      };
+    }
+
+    it("creates exactly one shared router right of the grid with a terminal->router edge per cell", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+
+      const state = useWorkflowStore.getState();
+      const routers = state.nodes.filter((n) => n.type === "router");
+      expect(routers).toHaveLength(1);
+      const router = routers[0];
+
+      // Tracked on the split node, shared (no group), grid groups unchanged
+      expect(getSplitData().routerNodeId).toBe(router.id);
+      expect(router.groupId).toBeUndefined();
+      expect(Object.keys(state.groups)).toHaveLength(4);
+
+      // One typed edge per cell, from each cell's generate node into the router
+      const routerEdges = state.edges.filter((e) => e.target === router.id);
+      expect(routerEdges).toHaveLength(4);
+      const generateIds = new Set(
+        state.nodes.filter((n) => n.type === "nanoBanana").map((n) => n.id)
+      );
+      for (const e of routerEdges) {
+        expect(generateIds.has(e.source)).toBe(true);
+        expect(e.targetHandle).toBe("image");
+        expect(e.type).not.toBe("reference");
+      }
+
+      // Positioned to the right of every cell node
+      const cellRightEdges = state.nodes
+        .filter((n) => n.groupId)
+        .map((n) => n.position.x + ((n.style?.width as number) ?? 300));
+      expect(router.position.x).toBeGreaterThan(Math.max(...cellRightEdges));
+
+      // split + 12 cell nodes + 1 router; 4 ref + 8 intra + 4 router edges
+      expect(state.nodes).toHaveLength(14);
+      expect(state.edges).toHaveLength(16);
+    });
+
+    it("creates no router when the template port is unwired", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: createClassicSplitGridTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      const state = useWorkflowStore.getState();
+      expect(state.nodes.filter((n) => n.type === "router")).toHaveLength(0);
+      expect(getSplitData().routerNodeId ?? null).toBeNull();
+    });
+
+    it("reuses the router id and preserves onward wiring across a grid resize", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      const routerId = getSplitData().routerNodeId!;
+      expect(routerId).toBeTruthy();
+
+      // User wires the router onward to an output node on the main canvas
+      act(() => {
+        useWorkflowStore.setState((s) => ({
+          nodes: [...s.nodes, makeNode("out-1", "output")],
+          edges: [
+            ...s.edges,
+            {
+              id: "edge-router-out",
+              source: routerId,
+              sourceHandle: "image",
+              target: "out-1",
+              targetHandle: "image",
+            },
+          ],
+        }));
+      });
+
+      // Resize 2x2 -> 3x2 and rematerialize
+      act(() => {
+        useWorkflowStore.getState().updateNodeData(SPLIT_ID, { gridRows: 3 });
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+
+      const state = useWorkflowStore.getState();
+      expect(getSplitData().routerNodeId).toBe(routerId); // id stable
+      expect(state.nodes.filter((n) => n.type === "router")).toHaveLength(1);
+      expect(state.edges.filter((e) => e.target === routerId)).toHaveLength(6); // rewired to 6 cells
+      // Onward wiring survives
+      expect(
+        state.edges.some((e) => e.id === "edge-router-out" && e.source === routerId)
+      ).toBe(true);
+    });
+
+    it("removes the shared router and its edges when the port is unwired on re-apply", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      const routerId = getSplitData().routerNodeId!;
+      act(() => {
+        useWorkflowStore.setState((s) => ({
+          nodes: [...s.nodes, makeNode("out-1", "output")],
+          edges: [
+            ...s.edges,
+            {
+              id: "edge-router-out",
+              source: routerId,
+              sourceHandle: "image",
+              target: "out-1",
+              targetHandle: "image",
+            },
+          ],
+        }));
+      });
+
+      // Re-apply with a port-less template (user disconnected the port)
+      act(() => {
+        useWorkflowStore
+          .getState()
+          .materializeSplitGridCells(SPLIT_ID, {
+            force: true,
+            template: createClassicSplitGridTemplate(),
+          });
+      });
+
+      const state = useWorkflowStore.getState();
+      expect(state.nodes.filter((n) => n.type === "router")).toHaveLength(0);
+      expect(state.edges.some((e) => e.source === routerId || e.target === routerId)).toBe(false);
+      expect(getSplitData().routerNodeId).toBeNull();
+    });
+
+    it("restores the pre-router state on a single undo", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      expect(useWorkflowStore.getState().nodes.filter((n) => n.type === "router")).toHaveLength(1);
+
+      act(() => {
+        useWorkflowStore.getState().undo();
+      });
+      const state = useWorkflowStore.getState();
+      expect(state.nodes).toHaveLength(1);
+      expect(state.nodes[0].id).toBe(SPLIT_ID);
+      expect(state.nodes.filter((n) => n.type === "router")).toHaveLength(0);
+      expect(getSplitData().routerNodeId ?? null).toBeNull();
+    });
+
+    it("remaps routerNodeId when the router is copied with the split node", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate(), gridRows: 1, gridCols: 1 })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+
+      const before = useWorkflowStore.getState();
+      const split = before.nodes.find((n) => n.id === SPLIT_ID)!;
+      const routerId = (split.data as SplitGridNodeData).routerNodeId!;
+      const cellNodeIds = (split.data as SplitGridNodeData).cells!.flatMap((c) => c.nodeIds);
+      const clipboardNodes = [
+        split,
+        ...before.nodes.filter((n) => cellNodeIds.includes(n.id) || n.id === routerId),
+      ];
+
+      act(() => {
+        useWorkflowStore.setState({
+          clipboard: { nodes: clipboardNodes, edges: before.edges },
+        });
+        useWorkflowStore.getState().pasteNodes({ x: 800, y: 0 });
+      });
+
+      const after = useWorkflowStore.getState();
+      const pastedSplit = after.nodes.find((n) => n.type === "splitGrid" && n.id !== SPLIT_ID)!;
+      const newRouterId = (pastedSplit.data as SplitGridNodeData).routerNodeId!;
+      expect(newRouterId).toBeTruthy();
+      expect(newRouterId).not.toBe(routerId); // its OWN router, not the original's
+      expect(after.nodes.some((n) => n.id === newRouterId && n.type === "router")).toBe(true);
+      expect(after.edges.some((e) => e.target === newRouterId)).toBe(true);
+    });
+
+    it("detaches routerNodeId when the split is pasted without its router", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate(), gridRows: 1, gridCols: 1 })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+
+      const before = useWorkflowStore.getState();
+      const split = before.nodes.find((n) => n.id === SPLIT_ID)!;
+      const routerId = (split.data as SplitGridNodeData).routerNodeId!;
+      const cellNodeIds = (split.data as SplitGridNodeData).cells!.flatMap((c) => c.nodeIds);
+      // Clipboard WITHOUT the router node (and without router edges)
+      const clipboardNodes = [split, ...before.nodes.filter((n) => cellNodeIds.includes(n.id))];
+      const clipboardEdges = before.edges.filter(
+        (e) => e.source !== routerId && e.target !== routerId
+      );
+
+      act(() => {
+        useWorkflowStore.setState({
+          clipboard: { nodes: clipboardNodes, edges: clipboardEdges },
+        });
+        useWorkflowStore.getState().pasteNodes({ x: 800, y: 0 });
+      });
+
+      const after = useWorkflowStore.getState();
+      const pastedSplit = after.nodes.find((n) => n.type === "splitGrid" && n.id !== SPLIT_ID)!;
+      // Detached: the paste rebuilds its own cells + router on next split/apply
+      expect((pastedSplit.data as SplitGridNodeData).routerNodeId ?? null).toBeNull();
+      expect((pastedSplit.data as SplitGridNodeData).cells ?? []).toHaveLength(0);
+    });
+  });
 });

--- a/src/store/__tests__/materializeSplitGridCells.test.ts
+++ b/src/store/__tests__/materializeSplitGridCells.test.ts
@@ -579,6 +579,105 @@ describe("materializeSplitGridCells", () => {
       ).toBe(true);
     });
 
+    it("removes onward edges whose router output type is no longer active", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      const routerId = getSplitData().routerNodeId!;
+      act(() => {
+        useWorkflowStore.setState((state) => ({
+          nodes: [...state.nodes, makeNode("out-1", "output")],
+          edges: [
+            ...state.edges,
+            {
+              id: "edge-router-out",
+              source: routerId,
+              sourceHandle: "image",
+              target: "out-1",
+              targetHandle: "image",
+            },
+          ],
+        }));
+      });
+
+      const textRouterTemplate = {
+        ...createClassicSplitGridTemplate(),
+        router: [{ source: "cell-prompt", sourceHandle: "text", targetHandle: "text" }],
+      };
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID, {
+          force: true,
+          template: textRouterTemplate,
+        });
+      });
+
+      const state = useWorkflowStore.getState();
+      expect(getSplitData().routerNodeId).toBe(routerId);
+      expect(state.edges.some((edge) => edge.id === "edge-router-out")).toBe(false);
+      expect(state.edges.filter((edge) => edge.target === routerId)).toHaveLength(4);
+      expect(
+        state.edges
+          .filter((edge) => edge.target === routerId)
+          .every((edge) => edge.targetHandle === "text")
+      ).toBe(true);
+    });
+
+    it("does not reuse a non-router node referenced by corrupt router metadata", () => {
+      const victim = { ...makeNode("victim-1", "output"), position: { x: 50, y: 75 } };
+      useWorkflowStore.setState({
+        nodes: [
+          makeSplitGridNode({
+            template: routerWiredTemplate(),
+            routerNodeId: victim.id,
+          }),
+          victim,
+        ],
+        edges: [],
+      });
+
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+
+      const state = useWorkflowStore.getState();
+      expect(state.nodes.find((node) => node.id === victim.id)).toMatchObject({
+        type: "output",
+        position: victim.position,
+      });
+      expect(getSplitData().routerNodeId).not.toBe(victim.id);
+      expect(state.nodes.filter((node) => node.type === "router")).toHaveLength(1);
+      expect(state.edges.some((edge) => edge.target === victim.id)).toBe(false);
+    });
+
+    it("does not delete a non-router node when corrupt router metadata is cleared", () => {
+      const victim = makeNode("victim-1", "output");
+      useWorkflowStore.setState({
+        nodes: [
+          makeSplitGridNode({
+            template: createClassicSplitGridTemplate(),
+            routerNodeId: victim.id,
+          }),
+          victim,
+        ],
+        edges: [],
+      });
+
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID, {
+          force: true,
+          template: createClassicSplitGridTemplate(),
+        });
+      });
+
+      const state = useWorkflowStore.getState();
+      expect(state.nodes.some((node) => node.id === victim.id && node.type === "output")).toBe(true);
+      expect(getSplitData().routerNodeId).toBeNull();
+    });
+
     it("removes the shared router and its edges when the port is unwired on re-apply", () => {
       useWorkflowStore.setState({
         nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],

--- a/src/store/__tests__/materializeSplitGridCells.test.ts
+++ b/src/store/__tests__/materializeSplitGridCells.test.ts
@@ -706,5 +706,119 @@ describe("materializeSplitGridCells", () => {
       expect((pastedSplit.data as SplitGridNodeData).routerNodeId ?? null).toBeNull();
       expect((pastedSplit.data as SplitGridNodeData).cells ?? []).toHaveLength(0);
     });
+
+    it("nulls routerNodeId and rebuilds the router after it is manually deleted", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      const routerId = getSplitData().routerNodeId!;
+
+      // Delete the shared router on the canvas
+      act(() => {
+        useWorkflowStore.getState().onNodesChange([{ type: "remove" as const, id: routerId }]);
+      });
+      expect(getSplitData().routerNodeId ?? null).toBeNull(); // self-heal
+      expect(useWorkflowStore.getState().nodes.filter((n) => n.type === "router")).toHaveLength(0);
+
+      // On the next run/materialize the router is rebuilt (was previously stuck)
+      let rebuilt = false;
+      act(() => {
+        rebuilt = useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      expect(rebuilt).toBe(true);
+      const state = useWorkflowStore.getState();
+      expect(state.nodes.filter((n) => n.type === "router")).toHaveLength(1);
+      expect(getSplitData().routerNodeId).toBeTruthy();
+      expect(state.edges.filter((e) => e.target === getSplitData().routerNodeId)).toHaveLength(4);
+    });
+
+    it("recreates the router on re-apply after a manual delete", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      const routerId = getSplitData().routerNodeId!;
+      act(() => {
+        useWorkflowStore.getState().onNodesChange([{ type: "remove" as const, id: routerId }]);
+      });
+      expect(useWorkflowStore.getState().nodes.filter((n) => n.type === "router")).toHaveLength(0);
+
+      // Re-apply the identical template (as the modal's Apply does)
+      act(() => {
+        useWorkflowStore
+          .getState()
+          .materializeSplitGridCells(SPLIT_ID, { force: true, template: routerWiredTemplate() });
+      });
+      expect(useWorkflowStore.getState().nodes.filter((n) => n.type === "router")).toHaveLength(1);
+      expect(getSplitData().routerNodeId).toBeTruthy();
+    });
+
+    it("repositions a reused router to the right when the grid widens", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate(), gridRows: 2, gridCols: 2 })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      const routerId = getSplitData().routerNodeId!;
+      const beforeX = useWorkflowStore.getState().nodes.find((n) => n.id === routerId)!.position.x;
+
+      // Widen 2x2 -> 2x3 (more columns extends the grid rightward)
+      act(() => {
+        useWorkflowStore.getState().updateNodeData(SPLIT_ID, { gridCols: 3 });
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+
+      const state = useWorkflowStore.getState();
+      const router = state.nodes.find((n) => n.id === routerId)!;
+      const cellRight = Math.max(
+        ...state.nodes
+          .filter((n) => n.groupId)
+          .map((n) => n.position.x + ((n.style?.width as number) ?? 300))
+      );
+      expect(router.position.x).toBeGreaterThan(beforeX);
+      expect(router.position.x).toBeGreaterThan(cellRight);
+    });
+
+    it("keeps a user-moved router position when the grid does not grow into it", () => {
+      useWorkflowStore.setState({
+        nodes: [makeSplitGridNode({ template: routerWiredTemplate() })],
+        edges: [],
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+      const routerId = getSplitData().routerNodeId!;
+
+      // User parks the router far to the right
+      act(() => {
+        useWorkflowStore.setState((s) => ({
+          nodes: s.nodes.map((n) =>
+            n.id === routerId ? { ...n, position: { x: 5000, y: 1234 } } : n
+          ),
+        }));
+      });
+
+      // A rows-only resize does not extend the grid past x=5000
+      act(() => {
+        useWorkflowStore.getState().updateNodeData(SPLIT_ID, { gridRows: 3 });
+      });
+      act(() => {
+        useWorkflowStore.getState().materializeSplitGridCells(SPLIT_ID);
+      });
+
+      const router = useWorkflowStore.getState().nodes.find((n) => n.id === routerId)!;
+      expect(router.position).toEqual({ x: 5000, y: 1234 }); // preserved
+    });
   });
 });

--- a/src/store/execution/__tests__/splitGridExecutor.test.ts
+++ b/src/store/execution/__tests__/splitGridExecutor.test.ts
@@ -238,7 +238,27 @@ describe("executeSplitGrid", () => {
 
       await executeSplitGrid(ctx);
 
-      expect(mockSplitWithDimensions).toHaveBeenCalledWith(SOURCE_IMAGE, 2, 2);
+      expect(mockSplitWithDimensions).toHaveBeenCalledWith(SOURCE_IMAGE, 2, 2, {
+        colOffsets: undefined,
+        rowOffsets: undefined,
+      });
+    });
+
+    it("forwards custom interior line offsets to the splitter", async () => {
+      const node = makeNode({
+        gridRows: 2,
+        gridCols: 2,
+        colOffsets: [0.3],
+        rowOffsets: [0.7],
+      });
+      const ctx = makeCtx(node);
+
+      await executeSplitGrid(ctx);
+
+      expect(mockSplitWithDimensions).toHaveBeenCalledWith(SOURCE_IMAGE, 2, 2, {
+        colOffsets: [0.3],
+        rowOffsets: [0.7],
+      });
     });
 
     it("populates each cell's base image node with its slice, filename, and dimensions", async () => {

--- a/src/store/execution/splitGridExecutor.ts
+++ b/src/store/execution/splitGridExecutor.ts
@@ -44,7 +44,10 @@ export async function executeSplitGrid(ctx: NodeExecutionContext): Promise<void>
     const cells = getSplitGridCells(freshData);
 
     const { splitWithDimensions } = await import("@/utils/gridSplitter");
-    const { images: splitImages } = await splitWithDimensions(sourceImage, rows, cols);
+    const { images: splitImages } = await splitWithDimensions(sourceImage, rows, cols, {
+      colOffsets: freshData.colOffsets,
+      rowOffsets: freshData.rowOffsets,
+    });
 
     // Populate each cell's base image node with its slice
     for (let index = 0; index < cells.length; index++) {

--- a/src/store/utils/__tests__/splitGridTemplate.test.ts
+++ b/src/store/utils/__tests__/splitGridTemplate.test.ts
@@ -16,6 +16,7 @@ import {
   hasLegacyCellsOnly,
   needsMaterialization,
   buildCellInstances,
+  getRouterConnections,
   sanitizeGridOffsets,
   resolveGridOffsets,
   gridBoundaries,
@@ -733,6 +734,38 @@ describe("splitGridTemplate utilities", () => {
 
       expect(result.routerEdges).toHaveLength(0);
       expect(result.routerPosition).toBeNull();
+    });
+
+    it("normalizes malformed, mismatched, and duplicate router connections", () => {
+      const template: SplitGridTemplate = {
+        ...createClassicSplitGridTemplate(),
+        router: [
+          { source: "cell-generate", sourceHandle: "image", targetHandle: "image" },
+          { source: "cell-generate", sourceHandle: "image", targetHandle: "image" },
+          { source: "cell-generate", sourceHandle: "bogus", targetHandle: "image" },
+          { source: "cell-prompt", sourceHandle: "text", targetHandle: "image" },
+        ],
+      };
+
+      expect(getRouterConnections(template)).toEqual([
+        { source: "cell-generate", sourceHandle: "image", targetHandle: "image" },
+      ]);
+
+      const { options } = makeBuildOptions(template, 1, 2);
+      const result = buildCellInstances({ ...options, routerNodeId: "router-1" });
+      expect(result.routerEdges).toHaveLength(2);
+      expect(new Set(result.routerEdges.map((edge) => edge.id)).size).toBe(2);
+    });
+
+    it("treats structurally invalid router metadata as unwired", () => {
+      const base = createClassicSplitGridTemplate();
+      const invalidValues: unknown[] = [{}, [null], [{ source: 42 }]];
+
+      for (const router of invalidValues) {
+        const template = { ...base, router } as SplitGridTemplate;
+        expect(getRouterConnections(template)).toEqual([]);
+        expect(() => computeMaterializedKey(2, 2, template)).not.toThrow();
+      }
     });
   });
 

--- a/src/store/utils/__tests__/splitGridTemplate.test.ts
+++ b/src/store/utils/__tests__/splitGridTemplate.test.ts
@@ -681,6 +681,59 @@ describe("splitGridTemplate utilities", () => {
       expect(result.routerEdges).toHaveLength(0);
       expect(result.routerPosition).toBeNull();
     });
+
+    it("carries the terminal's typed handle onto router edges for a text terminal", () => {
+      const template: SplitGridTemplate = {
+        ...createClassicSplitGridTemplate(),
+        router: [{ source: "cell-prompt", sourceHandle: "text", targetHandle: "text" }],
+      };
+      const { options } = makeBuildOptions(template, 1, 2);
+
+      const result = buildCellInstances({ ...options, routerNodeId: "router-1" });
+
+      expect(result.routerEdges).toHaveLength(2); // one per cell
+      for (const e of result.routerEdges) {
+        expect(e.target).toBe("router-1");
+        expect(e.sourceHandle).toBe("text");
+        expect(e.targetHandle).toBe("text");
+      }
+    });
+
+    it("emits connections*cells router edges with unique ids for multiple terminals", () => {
+      const template: SplitGridTemplate = {
+        ...createClassicSplitGridTemplate(),
+        router: [
+          { source: "cell-generate", sourceHandle: "image", targetHandle: "image" },
+          { source: "cell-prompt", sourceHandle: "text", targetHandle: "text" },
+        ],
+      };
+      const { options } = makeBuildOptions(template, 2, 2);
+
+      const result = buildCellInstances({ ...options, routerNodeId: "router-1" });
+
+      expect(result.routerEdges).toHaveLength(2 * 4); // 2 terminals * 4 cells
+      const ids = result.routerEdges.map((e) => e.id);
+      expect(new Set(ids).size).toBe(ids.length); // all unique
+      expect(result.routerEdges.every((e) => e.target === "router-1")).toBe(true);
+      expect(result.routerEdges.filter((e) => e.targetHandle === "image")).toHaveLength(4);
+      expect(result.routerEdges.filter((e) => e.targetHandle === "text")).toHaveLength(4);
+    });
+
+    it("ignores router connections with an unknown source or a non-router targetHandle", () => {
+      const template: SplitGridTemplate = {
+        ...createClassicSplitGridTemplate(),
+        router: [
+          { source: "does-not-exist", sourceHandle: "image", targetHandle: "image" },
+          { source: "cell-generate", sourceHandle: "image", targetHandle: "bogus" },
+        ],
+      };
+      const { options } = makeBuildOptions(template, 2, 2);
+
+      const result = buildCellInstances({ ...options, routerNodeId: "router-1" });
+
+      expect(result.routerEdges).toHaveLength(0);
+      expect(result.routerPosition).toBeNull();
+    });
   });
 
   describe("grid offset helpers", () => {

--- a/src/store/utils/__tests__/splitGridTemplate.test.ts
+++ b/src/store/utils/__tests__/splitGridTemplate.test.ts
@@ -254,6 +254,18 @@ describe("splitGridTemplate utilities", () => {
       expect(classicKey).not.toBe(defaultKey);
       expect(seededKey).not.toBe(classicKey);
     });
+
+    it("differs when a terminal is wired to the router port", () => {
+      const base = createClassicSplitGridTemplate();
+      const wired: SplitGridTemplate = {
+        ...base,
+        router: [{ source: "cell-generate", sourceHandle: "image", targetHandle: "image" }],
+      };
+      const baseKey = computeMaterializedKey(2, 2, base);
+      expect(computeMaterializedKey(2, 2, wired)).not.toBe(baseKey);
+      // An empty router array is treated as no router (byte-identical to legacy)
+      expect(computeMaterializedKey(2, 2, { ...wired, router: [] })).toBe(baseKey);
+    });
   });
 
   describe("getSplitGridCells", () => {
@@ -613,6 +625,61 @@ describe("splitGridTemplate utilities", () => {
       // Default fields survive the merge
       expect(data.status).toBe("idle");
       expect(data.outputImage).toBeNull();
+    });
+
+    it("emits one terminal->router edge per cell and a router position when a router is wired", () => {
+      const template: SplitGridTemplate = {
+        ...createClassicSplitGridTemplate(),
+        router: [{ source: "cell-generate", sourceHandle: "image", targetHandle: "image" }],
+      };
+      const { options } = makeBuildOptions(template, 2, 2);
+
+      const result = buildCellInstances({ ...options, routerNodeId: "router-1" });
+
+      // The router node itself is created by the store, not here
+      expect(result.nodes.filter((n) => n.type === "router")).toHaveLength(0);
+      // 3 real nodes per cell; the router is never a cell member
+      expect(result.nodes).toHaveLength(4 * 3);
+      for (const cell of result.cells) expect(cell.nodeIds).toHaveLength(3);
+
+      // One typed router edge per cell, from the generate node
+      expect(result.routerEdges).toHaveLength(4);
+      for (const e of result.routerEdges) {
+        expect(e.target).toBe("router-1");
+        expect(e.sourceHandle).toBe("image");
+        expect(e.targetHandle).toBe("image");
+      }
+      // Router edges are separate from the intra-cell edges
+      expect(result.edges.some((e) => e.target === "router-1")).toBe(false);
+
+      // Positioned to the right of the whole grid
+      expect(result.routerPosition).not.toBeNull();
+      const gridRight = Math.max(
+        ...Object.values(result.groups).map((g) => g.position.x + g.size.width)
+      );
+      expect(result.routerPosition!.x).toBeGreaterThan(gridRight);
+    });
+
+    it("emits no router edges or position when routerNodeId is not supplied", () => {
+      const template: SplitGridTemplate = {
+        ...createClassicSplitGridTemplate(),
+        router: [{ source: "cell-generate", sourceHandle: "image", targetHandle: "image" }],
+      };
+      const { options } = makeBuildOptions(template, 2, 2);
+
+      const result = buildCellInstances(options);
+
+      expect(result.routerEdges).toHaveLength(0);
+      expect(result.routerPosition).toBeNull();
+    });
+
+    it("emits no router edges when a routerNodeId is supplied but the port is unwired", () => {
+      const { options } = makeBuildOptions(createClassicSplitGridTemplate(), 2, 2);
+
+      const result = buildCellInstances({ ...options, routerNodeId: "router-1" });
+
+      expect(result.routerEdges).toHaveLength(0);
+      expect(result.routerPosition).toBeNull();
     });
   });
 

--- a/src/store/utils/__tests__/splitGridTemplate.test.ts
+++ b/src/store/utils/__tests__/splitGridTemplate.test.ts
@@ -16,6 +16,10 @@ import {
   hasLegacyCellsOnly,
   needsMaterialization,
   buildCellInstances,
+  sanitizeGridOffsets,
+  resolveGridOffsets,
+  gridBoundaries,
+  gridFractions,
   SPLIT_GRID_BASE_NODE_ID,
 } from "../splitGridTemplate";
 import type {
@@ -609,6 +613,73 @@ describe("splitGridTemplate utilities", () => {
       // Default fields survive the merge
       expect(data.status).toBe("idle");
       expect(data.outputImage).toBeNull();
+    });
+  });
+
+  describe("grid offset helpers", () => {
+    describe("sanitizeGridOffsets", () => {
+      it("accepts valid interior offsets of the right length", () => {
+        expect(sanitizeGridOffsets([0.25, 0.6], 3)).toEqual([0.25, 0.6]);
+      });
+
+      it("rejects wrong-length arrays", () => {
+        expect(sanitizeGridOffsets([0.5], 3)).toBeNull();
+        expect(sanitizeGridOffsets([0.25, 0.5, 0.75], 3)).toBeNull();
+      });
+
+      it("rejects out-of-range or non-ascending values", () => {
+        expect(sanitizeGridOffsets([0, 0.5], 3)).toBeNull(); // 0 not inside (0,1)
+        expect(sanitizeGridOffsets([0.5, 1], 3)).toBeNull(); // 1 not inside (0,1)
+        expect(sanitizeGridOffsets([0.6, 0.4], 3)).toBeNull(); // not ascending
+        expect(sanitizeGridOffsets([0.5, 0.5], 3)).toBeNull(); // equal, not strict
+      });
+
+      it("rejects non-array or non-finite input", () => {
+        expect(sanitizeGridOffsets(undefined, 3)).toBeNull();
+        expect(sanitizeGridOffsets("nope", 3)).toBeNull();
+        expect(sanitizeGridOffsets([Number.NaN], 2)).toBeNull();
+      });
+
+      it("returns an empty array for a single slice (no interior lines)", () => {
+        expect(sanitizeGridOffsets([], 1)).toEqual([]);
+      });
+    });
+
+    describe("resolveGridOffsets", () => {
+      it("returns evenly spaced offsets when none are provided", () => {
+        expect(resolveGridOffsets(4, undefined)).toEqual([0.25, 0.5, 0.75]);
+      });
+
+      it("falls back to uniform when the stored offsets are invalid", () => {
+        expect(resolveGridOffsets(3, [0.9, 0.1])).toEqual([1 / 3, 2 / 3]);
+      });
+
+      it("uses valid custom offsets", () => {
+        expect(resolveGridOffsets(3, [0.2, 0.8])).toEqual([0.2, 0.8]);
+      });
+
+      it("returns an empty array for a single slice", () => {
+        expect(resolveGridOffsets(1, undefined)).toEqual([]);
+      });
+    });
+
+    describe("gridBoundaries / gridFractions", () => {
+      it("wraps interior offsets with 0 and 1", () => {
+        expect(gridBoundaries(3, [0.2, 0.5])).toEqual([0, 0.2, 0.5, 1]);
+      });
+
+      it("derives per-slice fractions that sum to 1", () => {
+        const fractions = gridFractions(3, [0.2, 0.5]);
+        expect(fractions).toHaveLength(3);
+        expect(fractions[0]).toBeCloseTo(0.2);
+        expect(fractions[1]).toBeCloseTo(0.3);
+        expect(fractions[2]).toBeCloseTo(0.5);
+        expect(fractions.reduce((a, b) => a + b, 0)).toBeCloseTo(1);
+      });
+
+      it("gives equal fractions for uniform offsets", () => {
+        expect(gridFractions(2, resolveGridOffsets(2, undefined))).toEqual([0.5, 0.5]);
+      });
     });
   });
 });

--- a/src/store/utils/nodeDefaults.ts
+++ b/src/store/utils/nodeDefaults.ts
@@ -93,14 +93,6 @@ export const GROUP_COLOR_ORDER: GroupColor[] = [
 export const SPLIT_GRID_BASE_NODE_ID = "cell-image";
 
 /**
- * Reserved id of the fixed downstream-router port pseudo-node in the cell
- * template editor. Never a real template node — its incoming edges are
- * serialized into `SplitGridTemplate.router` instead. Distinct from any
- * `tmpl-*` editor id or preset id so it can never collide.
- */
-export const SPLIT_GRID_ROUTER_PORT_ID = "cell-router-port";
-
-/**
  * The minimal split-grid cell template: just the base image node that
  * receives the cell image. Lives here (not splitGridTemplate.ts) so the
  * template utilities can depend on nodeDefaults without a cycle.

--- a/src/store/utils/nodeDefaults.ts
+++ b/src/store/utils/nodeDefaults.ts
@@ -93,6 +93,14 @@ export const GROUP_COLOR_ORDER: GroupColor[] = [
 export const SPLIT_GRID_BASE_NODE_ID = "cell-image";
 
 /**
+ * Reserved id of the fixed downstream-router port pseudo-node in the cell
+ * template editor. Never a real template node — its incoming edges are
+ * serialized into `SplitGridTemplate.router` instead. Distinct from any
+ * `tmpl-*` editor id or preset id so it can never collide.
+ */
+export const SPLIT_GRID_ROUTER_PORT_ID = "cell-router-port";
+
+/**
  * The minimal split-grid cell template: just the base image node that
  * receives the cell image. Lives here (not splitGridTemplate.ts) so the
  * template utilities can depend on nodeDefaults without a cycle.
@@ -267,6 +275,7 @@ export const createDefaultNodeData = (type: NodeType): WorkflowNodeData => {
         template: createDefaultSplitGridTemplate(),
         cells: [],
         materializedKey: null,
+        routerNodeId: null,
         targetCount: 6,
         defaultPrompt: "",
         generateSettings: {

--- a/src/store/utils/splitGridTemplate.ts
+++ b/src/store/utils/splitGridTemplate.ts
@@ -16,6 +16,7 @@ import type {
   GroupColor,
   SplitGridNodeData,
   SplitGridTemplate,
+  SplitGridTemplateRouterConnection,
   SplitGridCell,
 } from "@/types";
 import { MODEL_DISPLAY_NAMES } from "@/types";
@@ -24,9 +25,33 @@ import {
   createDefaultSplitGridTemplate,
   defaultNodeDimensions,
   SPLIT_GRID_BASE_NODE_ID,
+  SPLIT_GRID_ROUTER_PORT_ID,
 } from "./nodeDefaults";
 
-export { createDefaultSplitGridTemplate, SPLIT_GRID_BASE_NODE_ID };
+export { createDefaultSplitGridTemplate, SPLIT_GRID_BASE_NODE_ID, SPLIT_GRID_ROUTER_PORT_ID };
+
+/**
+ * Terminal→router-port connections declared on the template (empty when the
+ * downstream router port is unwired). The single source of truth consumers use
+ * to decide whether a shared router should be materialized.
+ */
+export function getRouterConnections(
+  template: SplitGridTemplate
+): SplitGridTemplateRouterConnection[] {
+  return template.router ?? [];
+}
+
+/** Stable ordering for router connections so hashing/serialization is deterministic. */
+function compareRouterConnections(
+  a: SplitGridTemplateRouterConnection,
+  b: SplitGridTemplateRouterConnection
+): number {
+  return (
+    a.source.localeCompare(b.source) ||
+    a.sourceHandle.localeCompare(b.sourceHandle) ||
+    a.targetHandle.localeCompare(b.targetHandle)
+  );
+}
 
 export const MIN_GRID_DIMENSION = 1;
 export const MAX_GRID_DIMENSION = 16;
@@ -169,12 +194,19 @@ export function computeMaterializedKey(
   cols: number,
   template: SplitGridTemplate
 ): string {
+  // Only fold the router in when present, so legacy/no-router templates hash to
+  // the exact same string as before this feature and never spuriously rebuild.
+  const router =
+    template.router && template.router.length > 0
+      ? [...template.router].sort(compareRouterConnections)
+      : null;
   return JSON.stringify({
     rows,
     cols,
     baseNodeId: template.baseNodeId,
     nodes: [...template.nodes].sort((a, b) => a.id.localeCompare(b.id)),
     edges: [...template.edges].sort((a, b) => a.id.localeCompare(b.id)),
+    ...(router ? { router } : {}),
   });
 }
 
@@ -252,6 +284,13 @@ export interface BuildCellInstancesOptions {
     target: string;
     targetHandle: string;
   }) => Record<string, unknown>;
+  /**
+   * Real id of the shared downstream router. When set (and the template wires
+   * one or more terminals to the router port), each cell's copy of every wired
+   * terminal is connected into this single router. The router node itself is
+   * created/reused by the store, not here.
+   */
+  routerNodeId?: string | null;
 }
 
 export interface CellInstancesResult {
@@ -259,11 +298,17 @@ export interface CellInstancesResult {
   edges: WorkflowEdge[];
   groups: Record<string, NodeGroup>;
   cells: SplitGridCell[];
+  /** Per-cell terminal→router edges (empty when no router is wired). */
+  routerEdges: WorkflowEdge[];
+  /** Where to place the single shared router (right of the grid, centered); null when none. */
+  routerPosition: { x: number; y: number } | null;
 }
 
 const CLUSTER_GAP = 60;
 const SPLIT_NODE_MARGIN = 100;
 const GROUP_PADDING = 20;
+/** Horizontal gap between the rightmost cell group and the shared router. */
+const ROUTER_GAP = 160;
 
 function templateNodeDimensions(
   templateNode: Pick<SplitGridTemplate["nodes"][number], "type" | "size">
@@ -279,6 +324,10 @@ function templateNodeDimensions(
 export function buildCellInstances(options: BuildCellInstancesOptions): CellInstancesResult {
   const { splitNode, template, rows, cols, makeNodeId, makeGroupId, groupColor, makeEdgeData } =
     options;
+  // The shared router is only wired when the store supplies its id AND the
+  // template designates at least one terminal for the port.
+  const routerConnections = options.routerNodeId ? getRouterConnections(template) : [];
+  const routerEnabled = Boolean(options.routerNodeId) && routerConnections.length > 0;
 
   // Template bounding box (normalizes arbitrary editor positions to offsets)
   let minX = Infinity;
@@ -306,6 +355,7 @@ export function buildCellInstances(options: BuildCellInstancesOptions): CellInst
   const edges: WorkflowEdge[] = [];
   const groups: Record<string, NodeGroup> = {};
   const cells: SplitGridCell[] = [];
+  const routerEdges: WorkflowEdge[] = [];
 
   for (let index = 0; index < rows * cols; index++) {
     const row = Math.floor(index / cols);
@@ -372,6 +422,27 @@ export function buildCellInstances(options: BuildCellInstancesOptions): CellInst
       } as WorkflowEdge);
     }
 
+    // Wire this cell's copy of each designated terminal into the single shared
+    // router (all cells fan into one router; targetHandle is the typed router
+    // input so RouterNode derives the correct handle).
+    if (routerEnabled) {
+      for (const conn of routerConnections) {
+        const terminalRealId = idMap.get(conn.source);
+        if (!terminalRealId) continue;
+        const routerConnection = {
+          source: terminalRealId,
+          sourceHandle: conn.sourceHandle,
+          target: options.routerNodeId!,
+          targetHandle: conn.targetHandle,
+        };
+        routerEdges.push({
+          id: `edge-${terminalRealId}-${options.routerNodeId}-${conn.sourceHandle}-${conn.targetHandle}`,
+          ...routerConnection,
+          data: makeEdgeData(routerConnection),
+        } as WorkflowEdge);
+      }
+    }
+
     // Group wrapping the cell
     groups[groupId] = {
       id: groupId,
@@ -391,5 +462,25 @@ export function buildCellInstances(options: BuildCellInstancesOptions): CellInst
     });
   }
 
-  return { nodes, edges, groups, cells };
+  // Place the single shared router to the right of the whole grid, vertically
+  // centered on the cell groups (whose bounds already include GROUP_PADDING).
+  let routerPosition: { x: number; y: number } | null = null;
+  const groupFrames = Object.values(groups);
+  if (routerEnabled && groupFrames.length > 0) {
+    let gridMaxX = -Infinity;
+    let gridMinY = Infinity;
+    let gridMaxY = -Infinity;
+    for (const group of groupFrames) {
+      gridMaxX = Math.max(gridMaxX, group.position.x + group.size.width);
+      gridMinY = Math.min(gridMinY, group.position.y);
+      gridMaxY = Math.max(gridMaxY, group.position.y + group.size.height);
+    }
+    const routerHeight = defaultNodeDimensions.router.height;
+    routerPosition = {
+      x: gridMaxX + ROUTER_GAP,
+      y: (gridMinY + gridMaxY) / 2 - routerHeight / 2,
+    };
+  }
+
+  return { nodes, edges, groups, cells, routerEdges, routerPosition };
 }

--- a/src/store/utils/splitGridTemplate.ts
+++ b/src/store/utils/splitGridTemplate.ts
@@ -25,10 +25,9 @@ import {
   createDefaultSplitGridTemplate,
   defaultNodeDimensions,
   SPLIT_GRID_BASE_NODE_ID,
-  SPLIT_GRID_ROUTER_PORT_ID,
 } from "./nodeDefaults";
 
-export { createDefaultSplitGridTemplate, SPLIT_GRID_BASE_NODE_ID, SPLIT_GRID_ROUTER_PORT_ID };
+export { createDefaultSplitGridTemplate, SPLIT_GRID_BASE_NODE_ID };
 
 /** Handle types the Router node can render (mirrors RouterNode ALL_HANDLE_TYPES). */
 const ROUTER_HANDLE_TYPES = new Set(["image", "text", "video", "audio", "3d", "easeCurve"]);

--- a/src/store/utils/splitGridTemplate.ts
+++ b/src/store/utils/splitGridTemplate.ts
@@ -29,7 +29,7 @@ import {
 export { createDefaultSplitGridTemplate, SPLIT_GRID_BASE_NODE_ID };
 
 export const MIN_GRID_DIMENSION = 1;
-export const MAX_GRID_DIMENSION = 8;
+export const MAX_GRID_DIMENSION = 16;
 
 /**
  * Normalizes a grid dimension from untrusted data (AI-generated workflows,

--- a/src/store/utils/splitGridTemplate.ts
+++ b/src/store/utils/splitGridTemplate.ts
@@ -43,6 +43,46 @@ export function clampGridDimension(value: unknown): number {
   return Math.min(MAX_GRID_DIMENSION, Math.max(MIN_GRID_DIMENSION, Math.round(num)));
 }
 
+/** Smallest allowed gap between adjacent grid boundaries, as a fraction. */
+export const MIN_SLICE_GAP = 0.02;
+
+/**
+ * Validates interior grid-line offsets from untrusted data. Returns the offsets
+ * only when they are the right length (count-1), each strictly inside (0,1),
+ * and strictly ascending; otherwise null (caller falls back to uniform).
+ */
+export function sanitizeGridOffsets(raw: unknown, count: number): number[] | null {
+  if (!Array.isArray(raw) || raw.length !== count - 1) return null;
+  const nums = raw.map(Number);
+  for (let i = 0; i < nums.length; i++) {
+    const v = nums[i];
+    if (!Number.isFinite(v) || v <= 0 || v >= 1) return null;
+    if (i > 0 && v <= nums[i - 1]) return null;
+  }
+  return nums;
+}
+
+/**
+ * Interior boundary offsets for `count` slices: the sanitized custom offsets, or
+ * evenly spaced (1/count … (count-1)/count) when none/invalid. Length count-1.
+ */
+export function resolveGridOffsets(count: number, raw: unknown): number[] {
+  const clean = sanitizeGridOffsets(raw, count);
+  if (clean) return clean;
+  return Array.from({ length: Math.max(0, count - 1) }, (_, i) => (i + 1) / count);
+}
+
+/** Full boundary list [0, …interior, 1] for `count` slices. Length count+1. */
+export function gridBoundaries(count: number, offsets: number[]): number[] {
+  return [0, ...offsets, 1];
+}
+
+/** Per-slice size fractions (summing to 1) from interior offsets. Length count. */
+export function gridFractions(count: number, offsets: number[]): number[] {
+  const bounds = gridBoundaries(count, offsets);
+  return Array.from({ length: count }, (_, i) => bounds[i + 1] - bounds[i]);
+}
+
 /**
  * The classic pre-template layout: image + prompt feeding a generate node.
  * Optional legacy generate settings become overrides on the generate node.

--- a/src/store/utils/splitGridTemplate.ts
+++ b/src/store/utils/splitGridTemplate.ts
@@ -14,6 +14,7 @@ import type {
   WorkflowNodeData,
   NodeGroup,
   GroupColor,
+  HandleType,
   SplitGridNodeData,
   SplitGridTemplate,
   SplitGridTemplateRouterConnection,
@@ -30,27 +31,86 @@ import {
 export { createDefaultSplitGridTemplate, SPLIT_GRID_BASE_NODE_ID };
 
 /** Handle types the Router node can render (mirrors RouterNode ALL_HANDLE_TYPES). */
-const ROUTER_HANDLE_TYPES = new Set(["image", "text", "video", "audio", "3d", "easeCurve"]);
+const ROUTER_HANDLE_TYPES = new Set<HandleType>([
+  "image",
+  "text",
+  "video",
+  "audio",
+  "3d",
+  "easeCurve",
+]);
+
+const STATIC_OUTPUT_HANDLES: Partial<Record<NodeType, readonly HandleType[]>> = {
+  imageInput: ["image"],
+  audioInput: ["audio"],
+  videoInput: ["video"],
+  annotation: ["image"],
+  prompt: ["text"],
+  array: ["text"],
+  promptConstructor: ["text"],
+  nanoBanana: ["image"],
+  generateVideo: ["video"],
+  generate3d: ["3d"],
+  generateAudio: ["audio"],
+  llmGenerate: ["text"],
+  videoStitch: ["video"],
+  easeCurve: ["video", "easeCurve"],
+  videoTrim: ["video"],
+  videoFrameGrab: ["image"],
+  removeBackground: ["image"],
+  imageResize: ["image"],
+  gifEncoder: ["image"],
+  router: ["image", "text", "video", "audio", "3d", "easeCurve"],
+  glbViewer: ["image"],
+};
 
 /**
  * Terminal→router-port connections declared on the template (empty when the
  * downstream router port is unwired). The single source of truth consumers use
  * to decide whether a shared router should be materialized.
  *
- * Connections from untrusted templates (AI-generated / hand-edited JSON) are
- * validated here — the source must be a real template node and the targetHandle
- * a type the Router can actually render — so a malformed entry can never
- * produce an orphan router or an edge on a handle that never appears.
+ * Connections from untrusted templates are normalized here. Structurally
+ * invalid entries, unsupported or mismatched handles, missing source outputs,
+ * and duplicates are discarded before hashing or materialization.
  */
 export function getRouterConnections(
   template: SplitGridTemplate
 ): SplitGridTemplateRouterConnection[] {
-  if (!template.router || template.router.length === 0) return [];
-  const nodeIds = new Set(template.nodes.map((node) => node.id));
-  return template.router.filter(
-    (connection) =>
-      nodeIds.has(connection.source) && ROUTER_HANDLE_TYPES.has(connection.targetHandle)
+  const rawConnections: unknown = template.router;
+  if (!Array.isArray(rawConnections) || rawConnections.length === 0) return [];
+
+  const nodesById = new Map(
+    (Array.isArray(template.nodes) ? template.nodes : []).map((node) => [node.id, node])
   );
+  const uniqueConnections = new Map<string, SplitGridTemplateRouterConnection>();
+
+  for (const value of rawConnections) {
+    if (!value || typeof value !== "object") continue;
+    const connection = value as Record<string, unknown>;
+    const { source, sourceHandle, targetHandle } = connection;
+    if (
+      typeof source !== "string" ||
+      typeof sourceHandle !== "string" ||
+      typeof targetHandle !== "string" ||
+      sourceHandle !== targetHandle ||
+      !ROUTER_HANDLE_TYPES.has(targetHandle as HandleType)
+    ) {
+      continue;
+    }
+
+    const sourceNode = nodesById.get(source);
+    const outputs = sourceNode ? STATIC_OUTPUT_HANDLES[sourceNode.type] ?? [] : [];
+    if (!outputs.includes(sourceHandle as HandleType)) continue;
+
+    const normalized = {
+      source,
+      sourceHandle,
+      targetHandle,
+    } satisfies SplitGridTemplateRouterConnection;
+    uniqueConnections.set(`${source}\u0000${sourceHandle}`, normalized);
+  }
+
+  return [...uniqueConnections.values()].sort(compareRouterConnections);
 }
 
 /** Stable ordering for router connections so hashing/serialization is deterministic. */
@@ -261,7 +321,11 @@ export function hasLegacyCellsOnly(data: SplitGridNodeData): boolean {
 export function needsMaterialization(
   data: SplitGridNodeData,
   existingNodeIds: Set<string>,
-  options?: { ignoreLegacy?: boolean; template?: SplitGridTemplate }
+  options?: {
+    ignoreLegacy?: boolean;
+    template?: SplitGridTemplate;
+    existingRouterNodeIds?: Set<string>;
+  }
 ): boolean {
   const rows = clampGridDimension(data.gridRows);
   const cols = clampGridDimension(data.gridCols);
@@ -279,7 +343,8 @@ export function needsMaterialization(
   // restore the router and its terminal wiring.
   if (
     getRouterConnections(template).length > 0 &&
-    (!data.routerNodeId || !existingNodeIds.has(data.routerNodeId))
+    (!data.routerNodeId ||
+      !(options?.existingRouterNodeIds ?? existingNodeIds).has(data.routerNodeId))
   ) {
     return true;
   }

--- a/src/store/utils/splitGridTemplate.ts
+++ b/src/store/utils/splitGridTemplate.ts
@@ -30,15 +30,28 @@ import {
 
 export { createDefaultSplitGridTemplate, SPLIT_GRID_BASE_NODE_ID, SPLIT_GRID_ROUTER_PORT_ID };
 
+/** Handle types the Router node can render (mirrors RouterNode ALL_HANDLE_TYPES). */
+const ROUTER_HANDLE_TYPES = new Set(["image", "text", "video", "audio", "3d", "easeCurve"]);
+
 /**
  * Terminal→router-port connections declared on the template (empty when the
  * downstream router port is unwired). The single source of truth consumers use
  * to decide whether a shared router should be materialized.
+ *
+ * Connections from untrusted templates (AI-generated / hand-edited JSON) are
+ * validated here — the source must be a real template node and the targetHandle
+ * a type the Router can actually render — so a malformed entry can never
+ * produce an orphan router or an edge on a handle that never appears.
  */
 export function getRouterConnections(
   template: SplitGridTemplate
 ): SplitGridTemplateRouterConnection[] {
-  return template.router ?? [];
+  if (!template.router || template.router.length === 0) return [];
+  const nodeIds = new Set(template.nodes.map((node) => node.id));
+  return template.router.filter(
+    (connection) =>
+      nodeIds.has(connection.source) && ROUTER_HANDLE_TYPES.has(connection.targetHandle)
+  );
 }
 
 /** Stable ordering for router connections so hashing/serialization is deterministic. */
@@ -196,10 +209,10 @@ export function computeMaterializedKey(
 ): string {
   // Only fold the router in when present, so legacy/no-router templates hash to
   // the exact same string as before this feature and never spuriously rebuild.
+  // Use the validated set so malformed entries don't drift the key.
+  const connections = getRouterConnections(template);
   const router =
-    template.router && template.router.length > 0
-      ? [...template.router].sort(compareRouterConnections)
-      : null;
+    connections.length > 0 ? [...connections].sort(compareRouterConnections) : null;
   return JSON.stringify({
     rows,
     cols,
@@ -262,6 +275,15 @@ export function needsMaterialization(
   const cells = data.cells ?? [];
   if (cells.length === 0) return true;
   const template = options?.template ?? getSplitGridTemplate(data);
+  // A wired downstream router must exist. If it was manually deleted on the
+  // canvas (or a save is missing it) the cells can still match, so rebuild to
+  // restore the router and its terminal wiring.
+  if (
+    getRouterConnections(template).length > 0 &&
+    (!data.routerNodeId || !existingNodeIds.has(data.routerNodeId))
+  ) {
+    return true;
+  }
   const key = computeMaterializedKey(rows, cols, template);
   if (data.materializedKey !== key) return true;
   if (cells.length !== rows * cols) return true;

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -70,6 +70,7 @@ import {
   buildCellInstances,
   clampGridDimension,
   computeMaterializedKey,
+  getRouterConnections,
   getSplitGridCells,
   getSplitGridTemplate,
   needsMaterialization,
@@ -204,6 +205,28 @@ function buildConnectionEdgeData(
   }
 
   return baseData;
+}
+
+/**
+ * Null out any split-grid node's routerNodeId that points at a node being
+ * removed, so a manually-deleted shared router leaves no dangling reference
+ * (a stale id would otherwise block the reuse check on the next materialize).
+ */
+function healSplitGridRouterRefs(
+  nodes: WorkflowNode[],
+  removedIds: Set<string>
+): WorkflowNode[] {
+  let changed = false;
+  const next = nodes.map((node) => {
+    if (node.type !== "splitGrid") return node;
+    const routerNodeId = (node.data as SplitGridNodeData).routerNodeId;
+    if (routerNodeId && removedIds.has(routerNodeId)) {
+      changed = true;
+      return { ...node, data: { ...node.data, routerNodeId: null } as WorkflowNodeData };
+    }
+    return node;
+  });
+  return changed ? next : nodes;
 }
 
 // Workflow file format
@@ -841,7 +864,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
         remainingNodes
       );
       return {
-        nodes: remainingNodes,
+        nodes: healSplitGridRouterRefs(remainingNodes, new Set([nodeId])),
         edges: state.edges.filter(
           (edge) => edge.source !== nodeId && edge.target !== nodeId
         ),
@@ -885,13 +908,15 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
     }
 
     set((state) => {
-      const nextNodes = applyNodeChanges(changes, state.nodes);
+      let nextNodes = applyNodeChanges(changes, state.nodes);
       let groups = state.groups;
       if (hasRemoveChange) {
         const removedIds = new Set(
           changes.filter((c) => c.type === "remove").map((c) => c.id)
         );
         groups = pruneEmptiedGroups(state.groups, state.nodes, removedIds, nextNodes);
+        // A manually-deleted shared router must not leave a dangling routerNodeId
+        nextNodes = healSplitGridRouterRefs(nextNodes, removedIds);
       }
       return {
         nodes: nextNodes,
@@ -1082,7 +1107,14 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
         const allCopied =
           cells.length > 0 &&
           cells.every((cell) => cell.nodeIds.every((id) => idMapping.has(id)));
-        if (allCopied) {
+        // The pasted split must drive its OWN shared router, never the original's.
+        // Keep the copied cells only when the router was copied too (or the
+        // template wants none); otherwise detach so the paste rebuilds a fresh
+        // set + its own router on next split/apply.
+        const oldRouterId = splitData.routerNodeId;
+        const templateWantsRouter = getRouterConnections(template).length > 0;
+        const routerCopied = !!oldRouterId && idMapping.has(oldRouterId);
+        if (allCopied && (!templateWantsRouter || routerCopied)) {
           const remappedCells = cells.map((cell) => ({
             ...cell,
             baseImageNodeId: idMapping.get(cell.baseImageNodeId)!,
@@ -1097,6 +1129,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
             template,
             cells: remappedCells,
             childNodeIds: [],
+            routerNodeId: routerCopied ? idMapping.get(oldRouterId!)! : null,
             materializedKey:
               cells.length === rows * cols ? computeMaterializedKey(rows, cols, template) : null,
           } as WorkflowNodeData;
@@ -1106,6 +1139,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
             template,
             cells: [],
             childNodeIds: [],
+            routerNodeId: null,
             materializedKey: null,
           } as WorkflowNodeData;
         }
@@ -1349,6 +1383,17 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
     const rows = clampGridDimension(data.gridRows);
     const cols = clampGridDimension(data.gridCols);
 
+    // Shared downstream router lifecycle: reuse the persisted router across
+    // rebuilds (so the user's onward wiring survives), mint a fresh id only when
+    // the port newly gains wiring, and mark the old one for removal when the
+    // port is cleared. The router is never a cell member, so cell teardown below
+    // never touches it or its onward edges.
+    const hasRouter = getRouterConnections(template).length > 0;
+    const existingRouterId =
+      data.routerNodeId && existingNodeIds.has(data.routerNodeId) ? data.routerNodeId : null;
+    const routerNodeId = hasRouter ? existingRouterId ?? `router-${++nodeIdCounter}` : null;
+    const removedRouterId = !hasRouter ? existingRouterId : null;
+
     // Single checkpoint: one undo restores replaced cells and removes new ones
     pushUndoCheckpoint(get, set);
 
@@ -1384,12 +1429,33 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
       groupColor,
       makeEdgeData: (connection) =>
         buildConnectionEdgeData(connection as Connection, state.nodes, state.edges),
+      routerNodeId,
     });
 
     const materializedKey = computeMaterializedKey(rows, cols, template);
     const removedEdges = state.edges.filter(
-      (edge) => staleNodeIds.has(edge.source) || staleNodeIds.has(edge.target)
+      (edge) =>
+        staleNodeIds.has(edge.source) ||
+        staleNodeIds.has(edge.target) ||
+        edge.source === removedRouterId ||
+        edge.target === removedRouterId
     );
+
+    // A newly wired router needs a real node; a reused one is repositioned in
+    // place inside the set() below so its grown height + onward edges survive.
+    const newRouterNode: WorkflowNode | null =
+      routerNodeId && !existingRouterId && built.routerPosition
+        ? {
+            id: routerNodeId,
+            type: "router",
+            position: built.routerPosition,
+            data: createDefaultNodeData("router"),
+            style: {
+              width: defaultNodeDimensions.router.width,
+              height: defaultNodeDimensions.router.height,
+            },
+          }
+        : null;
 
     set((current) => {
       const remainingGroups = { ...current.groups };
@@ -1397,8 +1463,13 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
       return {
         nodes: [
           ...current.nodes
-            .filter((n) => !staleNodeIds.has(n.id))
+            .filter((n) => !staleNodeIds.has(n.id) && n.id !== removedRouterId)
             .map((n) => {
+              // Reused shared router: reposition it against the new grid in
+              // place, preserving its grown height and onward wiring.
+              if (existingRouterId && n.id === existingRouterId && built.routerPosition) {
+                return { ...n, position: built.routerPosition };
+              }
               // Surviving nodes (user nodes dragged into a cell group, pasted
               // copies) must not keep a groupId pointing at a deleted group
               const node =
@@ -1411,6 +1482,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
                       template,
                       cells: built.cells,
                       materializedKey,
+                      routerNodeId,
                       targetCount: rows * cols,
                       childNodeIds: [],
                       isConfigured: true,
@@ -1419,12 +1491,18 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
                 : node;
             }),
           ...built.nodes,
+          ...(newRouterNode ? [newRouterNode] : []),
         ] as WorkflowNode[],
         edges: [
           ...current.edges.filter(
-            (edge) => !staleNodeIds.has(edge.source) && !staleNodeIds.has(edge.target)
+            (edge) =>
+              !staleNodeIds.has(edge.source) &&
+              !staleNodeIds.has(edge.target) &&
+              edge.source !== removedRouterId &&
+              edge.target !== removedRouterId
           ),
           ...built.edges,
+          ...built.routerEdges,
         ],
         groups: { ...remainingGroups, ...built.groups },
         hasUnsavedChanges: true,

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -1369,17 +1369,21 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
     if (!splitNode) return false;
     const data = splitNode.data as SplitGridNodeData;
 
+    const template = options?.template ?? getSplitGridTemplate(data);
     const existingNodeIds = new Set(state.nodes.map((n) => n.id));
+    const existingRouterNodeIds = new Set(
+      state.nodes.filter((node) => node.type === "router").map((node) => node.id)
+    );
     if (
       !needsMaterialization(data, existingNodeIds, {
         ignoreLegacy: options?.force,
         template: options?.template,
+        existingRouterNodeIds,
       })
     ) {
       return false;
     }
 
-    const template = options?.template ?? getSplitGridTemplate(data);
     const rows = clampGridDimension(data.gridRows);
     const cols = clampGridDimension(data.gridCols);
 
@@ -1388,9 +1392,15 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
     // the port newly gains wiring, and mark the old one for removal when the
     // port is cleared. The router is never a cell member, so cell teardown below
     // never touches it or its onward edges.
-    const hasRouter = getRouterConnections(template).length > 0;
+    const routerConnections = getRouterConnections(template);
+    const activeRouterHandleTypes = new Set(
+      routerConnections.map((connection) => connection.targetHandle)
+    );
+    const hasRouter = routerConnections.length > 0;
     const existingRouterId =
-      data.routerNodeId && existingNodeIds.has(data.routerNodeId) ? data.routerNodeId : null;
+      data.routerNodeId && existingRouterNodeIds.has(data.routerNodeId)
+        ? data.routerNodeId
+        : null;
     const routerNodeId = hasRouter ? existingRouterId ?? `router-${++nodeIdCounter}` : null;
     const removedRouterId = !hasRouter ? existingRouterId : null;
 
@@ -1438,11 +1448,15 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
         staleNodeIds.has(edge.source) ||
         staleNodeIds.has(edge.target) ||
         edge.source === removedRouterId ||
-        edge.target === removedRouterId
+        edge.target === removedRouterId ||
+        (existingRouterId !== null &&
+          edge.source === existingRouterId &&
+          !activeRouterHandleTypes.has(edge.sourceHandle ?? ""))
     );
+    const removedEdgeIds = new Set(removedEdges.map((edge) => edge.id));
 
     // A newly wired router needs a real node; a reused one is repositioned in
-    // place inside the set() below so its grown height + onward edges survive.
+    // place below so its grown height and compatible onward edges survive.
     const newRouterNode: WorkflowNode | null =
       routerNodeId && !existingRouterId && built.routerPosition
         ? {
@@ -1504,13 +1518,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
           ...(newRouterNode ? [newRouterNode] : []),
         ] as WorkflowNode[],
         edges: [
-          ...current.edges.filter(
-            (edge) =>
-              !staleNodeIds.has(edge.source) &&
-              !staleNodeIds.has(edge.target) &&
-              edge.source !== removedRouterId &&
-              edge.target !== removedRouterId
-          ),
+          ...current.edges.filter((edge) => !removedEdgeIds.has(edge.id)),
           ...built.edges,
           ...built.routerEdges,
         ],

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -1465,10 +1465,20 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
           ...current.nodes
             .filter((n) => !staleNodeIds.has(n.id) && n.id !== removedRouterId)
             .map((n) => {
-              // Reused shared router: reposition it against the new grid in
-              // place, preserving its grown height and onward wiring.
+              // Reused shared router: keep the user's chosen spot unless the grid
+              // grew right up to it, then re-slot it just right of the grid and
+              // center it by its actual (possibly grown) height.
               if (existingRouterId && n.id === existingRouterId && built.routerPosition) {
-                return { ...n, position: built.routerPosition };
+                if (n.position.x >= built.routerPosition.x) return n;
+                const height =
+                  (n.style?.height as number | undefined) ??
+                  n.measured?.height ??
+                  defaultNodeDimensions.router.height;
+                const centerY = built.routerPosition.y + defaultNodeDimensions.router.height / 2;
+                return {
+                  ...n,
+                  position: { x: built.routerPosition.x, y: centerY - height / 2 },
+                };
               }
               // Surviving nodes (user nodes dragged into a cell group, pasted
               // copies) must not keep a groupId pointing at a deleted group

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -26,11 +26,12 @@ export type AspectRatio =
 export type Resolution = "512" | "1K" | "2K" | "4K";
 
 // Image Generation Model Options
-export type ModelType = "nano-banana" | "nano-banana-pro" | "nano-banana-2";
+export type ModelType = "nano-banana" | "nano-banana-pro" | "nano-banana-2" | "nano-banana-2-lite";
 
 // Display names for image generation models
 export const MODEL_DISPLAY_NAMES: Record<ModelType, string> = {
   "nano-banana": "Nano Banana",
   "nano-banana-pro": "Nano Banana Pro",
   "nano-banana-2": "Nano Banana 2",
+  "nano-banana-2-lite": "Nano Banana 2 Lite",
 };

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -499,6 +499,20 @@ export interface SplitGridTemplateEdge {
 }
 
 /**
+ * One terminal wired into the template's fixed downstream-router port. Each
+ * connection designates a template node whose output feeds the single shared
+ * Router materialized to the right of the whole cell grid.
+ */
+export interface SplitGridTemplateRouterConnection {
+  /** Template node id whose output feeds the router */
+  source: string;
+  /** That node's output handle id ("image" | "text" | …) */
+  sourceHandle: string;
+  /** Resolved Router input type id (equals the source handle's type) */
+  targetHandle: string;
+}
+
+/**
  * Per-cell node template for a split-grid node. Always contains a base
  * image node (`baseNodeId`) that receives the split cell image.
  */
@@ -506,6 +520,13 @@ export interface SplitGridTemplate {
   baseNodeId: string;
   nodes: SplitGridTemplateNode[];
   edges: SplitGridTemplateEdge[];
+  /**
+   * Optional shared downstream router: terminal outputs wired into the fixed
+   * router port. Absent/empty ⇒ no router is materialized. The router is
+   * created once (not per cell) to the right of the whole grid; every cell's
+   * copy of each listed terminal connects into it.
+   */
+  router?: SplitGridTemplateRouterConnection[];
 }
 
 /**
@@ -542,6 +563,13 @@ export interface SplitGridNodeData extends BaseNodeData {
   cells?: SplitGridCell[];
   /** Snapshot key of rows/cols/template at last materialization, for staleness detection */
   materializedKey?: string | null;
+  /**
+   * Real node id of the shared downstream Router materialized from the
+   * template's router port; null/undefined when no terminal is wired to the
+   * port. Persisted so grid-resize rematerializations reuse (reposition +
+   * re-wire) the same Router node, preserving the user's onward wiring.
+   */
+  routerNodeId?: string | null;
   /** @deprecated Legacy pre-template field, kept for backward compatibility */
   targetCount: number;
   /** @deprecated Legacy pre-template field, kept for backward compatibility */

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -528,6 +528,14 @@ export interface SplitGridNodeData extends BaseNodeData {
   sourceImageRef?: string; // External image reference for storage optimization
   gridRows: number;
   gridCols: number;
+  /**
+   * Interior column boundary positions, normalized to (0,1), strictly
+   * ascending, length gridCols-1. Absent/invalid → uniform slicing. Set by
+   * dragging the preview's vertical grid lines.
+   */
+  colOffsets?: number[];
+  /** Interior row boundary positions; see colOffsets. Length gridRows-1. */
+  rowOffsets?: number[];
   /** Per-cell node template; undefined on legacy saves (treated as image-only default) */
   template?: SplitGridTemplate;
   /** Materialized cells; undefined on legacy saves (falls back to childNodeIds) */

--- a/src/utils/__tests__/costCalculator.test.ts
+++ b/src/utils/__tests__/costCalculator.test.ts
@@ -290,3 +290,40 @@ describe("calculatePredictedCost - splitGrid nodes", () => {
     expect(result.breakdown[0].modelId).toBe("nano-banana");
   });
 });
+
+describe("calculatePredictedCost - nano-banana-2-lite", () => {
+  it("should price nano-banana-2-lite at flat $0.034 per image", () => {
+    const nodes: WorkflowNode[] = [
+      {
+        id: "1",
+        type: "nanoBanana",
+        position: { x: 0, y: 0 },
+        data: { model: "nano-banana-2-lite", resolution: "1K" },
+      },
+    ] as WorkflowNode[];
+
+    const result = calculatePredictedCost(nodes);
+
+    expect(result.totalCost).toBeCloseTo(0.034);
+    expect(result.breakdown).toHaveLength(1);
+    expect(result.breakdown[0].modelId).toBe("nano-banana-2-lite");
+    expect(result.breakdown[0].unitCost).toBeCloseTo(0.034);
+    expect(result.unknownPricingCount).toBe(0);
+  });
+
+  it("should charge flat 1K pricing for nano-banana-2-lite regardless of stored resolution", () => {
+    const nodes: WorkflowNode[] = [
+      {
+        id: "1",
+        type: "nanoBanana",
+        position: { x: 0, y: 0 },
+        data: { model: "nano-banana-2-lite", resolution: "4K" },
+      },
+    ] as WorkflowNode[];
+
+    const result = calculatePredictedCost(nodes);
+
+    // nano-banana-2-lite is 1K only: flat $0.034 even if a stale resolution is set
+    expect(result.totalCost).toBeCloseTo(0.034);
+  });
+});

--- a/src/utils/__tests__/gridSplitter.test.ts
+++ b/src/utils/__tests__/gridSplitter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { createGridForDimensions } from "../gridSplitter";
+
+/**
+ * createGridForDimensions is the pure geometry behind image slicing. These
+ * tests cover uniform slicing and the non-uniform slicing produced by the
+ * split-grid node's draggable grid lines.
+ */
+describe("createGridForDimensions", () => {
+  it("produces uniform cells that tile the image exactly with no offsets", () => {
+    const grid = createGridForDimensions(400, 200, 2, 2);
+    expect(grid.cells).toHaveLength(4);
+    // Row-major: (0,0) (0,1) (1,0) (1,1)
+    expect(grid.cells[0]).toEqual({ x: 0, y: 0, width: 200, height: 100 });
+    expect(grid.cells[1]).toEqual({ x: 200, y: 0, width: 200, height: 100 });
+    expect(grid.cells[2]).toEqual({ x: 0, y: 100, width: 200, height: 100 });
+    expect(grid.cells[3]).toEqual({ x: 200, y: 100, width: 200, height: 100 });
+  });
+
+  it("places interior boundaries at the custom column/row offsets", () => {
+    // A vertical line at 25% and a horizontal line at 75%.
+    const grid = createGridForDimensions(400, 200, 2, 2, {
+      colOffsets: [0.25],
+      rowOffsets: [0.75],
+    });
+    // Column boundary at 0.25*400 = 100; row boundary at 0.75*200 = 150.
+    expect(grid.cells[0]).toEqual({ x: 0, y: 0, width: 100, height: 150 });
+    expect(grid.cells[1]).toEqual({ x: 100, y: 0, width: 300, height: 150 });
+    expect(grid.cells[2]).toEqual({ x: 0, y: 150, width: 100, height: 50 });
+    expect(grid.cells[3]).toEqual({ x: 100, y: 150, width: 300, height: 50 });
+  });
+
+  it("tiles exactly (adjacent cells share edges, cover the full image) for uneven offsets", () => {
+    const width = 333;
+    const height = 217;
+    const grid = createGridForDimensions(width, height, 3, 3, {
+      colOffsets: [0.2, 0.55],
+      rowOffsets: [0.4, 0.9],
+    });
+    // Every row of cells spans the full width with no gap or overlap.
+    for (let row = 0; row < 3; row++) {
+      const rowCells = grid.cells.slice(row * 3, row * 3 + 3);
+      expect(rowCells[0].x).toBe(0);
+      expect(rowCells[0].x + rowCells[0].width).toBe(rowCells[1].x);
+      expect(rowCells[1].x + rowCells[1].width).toBe(rowCells[2].x);
+      expect(rowCells[2].x + rowCells[2].width).toBe(width);
+    }
+    // Every column spans the full height with no gap or overlap.
+    for (let col = 0; col < 3; col++) {
+      const colCells = [grid.cells[col], grid.cells[col + 3], grid.cells[col + 6]];
+      expect(colCells[0].y).toBe(0);
+      expect(colCells[0].y + colCells[0].height).toBe(colCells[1].y);
+      expect(colCells[1].y + colCells[1].height).toBe(colCells[2].y);
+      expect(colCells[2].y + colCells[2].height).toBe(height);
+    }
+  });
+
+  it("falls back to uniform slicing when offsets are the wrong length or malformed", () => {
+    const uniform = createGridForDimensions(400, 200, 2, 2);
+    const badLength = createGridForDimensions(400, 200, 2, 2, { colOffsets: [0.2, 0.5] });
+    const badRange = createGridForDimensions(400, 200, 2, 2, { colOffsets: [1.5] });
+    expect(badLength.cells).toEqual(uniform.cells);
+    expect(badRange.cells).toEqual(uniform.cells);
+  });
+});

--- a/src/utils/costCalculator.ts
+++ b/src/utils/costCalculator.ts
@@ -20,12 +20,18 @@ export const PRICING = {
     "2K": 0.101,
     "4K": 0.151,
   },
+  "nano-banana-2-lite": {
+    "512": 0.034,
+    "1K": 0.034,
+    "2K": 0.034, // nano-banana-2-lite only supports 1K
+    "4K": 0.034,
+  },
 } as const;
 
 export function calculateGenerationCost(model: ModelType, resolution: Resolution): number {
-  // nano-banana only supports 1K resolution (flat pricing)
-  if (model === "nano-banana") {
-    return PRICING["nano-banana"]["1K"];
+  // nano-banana and nano-banana-2-lite only support 1K resolution (flat pricing)
+  if (model === "nano-banana" || model === "nano-banana-2-lite") {
+    return PRICING[model]["1K"];
   }
   return PRICING[model][resolution];
 }
@@ -164,6 +170,10 @@ export function calculatePredictedCost(
       if (modelId === "nano-banana-2" || modelId === "gemini-3.1-flash-image-preview") {
         const res = resolution || "1K";
         return { unitCost: PRICING["nano-banana-2"][res], unit: "image" };
+      }
+      if (modelId === "nano-banana-2-lite" || modelId === "gemini-3.1-flash-lite-image") {
+        // 1K-only flat pricing, like nano-banana — resolution is ignored
+        return { unitCost: PRICING["nano-banana-2-lite"]["1K"], unit: "image" };
       }
     }
 

--- a/src/utils/gridSplitter.ts
+++ b/src/utils/gridSplitter.ts
@@ -84,25 +84,59 @@ export async function detectGrid(imageDataUrl: string): Promise<GridDetectionRes
 }
 
 /**
- * Creates a grid result for a specific rows x cols configuration
+ * Interior boundary offsets (normalized, ascending, length count-1) for a run of
+ * `count` slices. Custom offsets from draggable grid lines are used when valid;
+ * otherwise slices are uniform.
+ */
+export interface GridOffsets {
+  /** Interior column line positions in (0,1), length cols-1. */
+  colOffsets?: number[];
+  /** Interior row line positions in (0,1), length rows-1. */
+  rowOffsets?: number[];
+}
+
+/**
+ * Pixel boundaries [0, …, size] for `count` slices along one axis. Uses the
+ * given interior offsets when they are valid (length count-1, strictly inside
+ * (0,1), ascending), otherwise falls back to uniform division. Rounding to whole
+ * pixels keeps adjacent cells perfectly tiled (each cell's width is the gap
+ * between consecutive boundaries, so there are no seams or overlaps).
+ */
+function pixelBoundaries(size: number, count: number, offsets?: number[]): number[] {
+  const valid =
+    Array.isArray(offsets) &&
+    offsets.length === count - 1 &&
+    offsets.every(
+      (v, i) => Number.isFinite(v) && v > 0 && v < 1 && (i === 0 || v > offsets[i - 1])
+    );
+  const interior = valid
+    ? (offsets as number[])
+    : Array.from({ length: Math.max(0, count - 1) }, (_, i) => (i + 1) / count);
+  return [0, ...interior.map((o) => Math.round(o * size)), size];
+}
+
+/**
+ * Creates a grid result for a specific rows x cols configuration. Optional
+ * colOffsets/rowOffsets place the interior grid lines for non-uniform slicing.
  */
 export function createGridForDimensions(
   width: number,
   height: number,
   rows: number,
-  cols: number
+  cols: number,
+  offsets?: GridOffsets
 ): GridDetectionResult {
-  const cellWidth = width / cols;
-  const cellHeight = height / rows;
+  const xs = pixelBoundaries(width, cols, offsets?.colOffsets);
+  const ys = pixelBoundaries(height, rows, offsets?.rowOffsets);
 
   const cells: GridCell[] = [];
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < cols; col++) {
       cells.push({
-        x: Math.round(col * cellWidth),
-        y: Math.round(row * cellHeight),
-        width: Math.round(cellWidth),
-        height: Math.round(cellHeight),
+        x: xs[col],
+        y: ys[row],
+        width: xs[col + 1] - xs[col],
+        height: ys[row + 1] - ys[row],
       });
     }
   }
@@ -121,14 +155,15 @@ export function createGridForDimensions(
 export async function detectGridWithDimensions(
   imageDataUrl: string,
   rows: number,
-  cols: number
+  cols: number,
+  offsets?: GridOffsets
 ): Promise<GridDetectionResult> {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.crossOrigin = "anonymous";
 
     img.onload = () => {
-      const result = createGridForDimensions(img.width, img.height, rows, cols);
+      const result = createGridForDimensions(img.width, img.height, rows, cols, offsets);
       resolve(result);
     };
 
@@ -468,12 +503,13 @@ export async function detectAndSplitGrid(imageDataUrl: string): Promise<{
 export async function splitWithDimensions(
   imageDataUrl: string,
   rows: number,
-  cols: number
+  cols: number,
+  offsets?: GridOffsets
 ): Promise<{
   grid: GridDetectionResult;
   images: string[];
 }> {
-  const grid = await detectGridWithDimensions(imageDataUrl, rows, cols);
+  const grid = await detectGridWithDimensions(imageDataUrl, rows, cols, offsets);
   const images = await splitImage(imageDataUrl, grid);
   return { grid, images };
 }


### PR DESCRIPTION
## Summary

- add Nano Banana 2 Lite support and related model/cost coverage
- improve split-grid sizing, slice controls, cell-editor navigation, and template interactions
- raise split-grid dimensions to 16×16
- add a shared downstream Router for materialized cell workflows
- harden router lifecycle, imported metadata validation, copy/paste, undo, and output-type changes
- add behavioral and store-level regression coverage

## Impact

Split-grid workflows can scale to larger grids, edit cell templates more naturally, and aggregate generated cell outputs through one reusable Router without losing onward wiring during rematerialization.

## Validation

- `npm run test:run` — 96 files, 2,134 tests passed
- `npm run build` — passed
- `git diff --check` — passed