### PR TITLE
Optimize large workflow canvas navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,11 +58,7 @@ body {
 
 /* Large-workflow performance mode: images and nodes remain visible while
    expensive connection and control layers are skipped during navigation. */
-.canvas-panning .react-flow__edges,
-.canvas-wheel-panning .react-flow__edges,
 .canvas-overview .react-flow__edges,
-.canvas-panning .react-flow__edge,
-.canvas-wheel-panning .react-flow__edge,
 .canvas-overview .react-flow__edge {
   display: none !important;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,6 +55,24 @@ body {
   pointer-events: none;
 }
 
+/* Large-workflow performance mode: images and nodes remain visible while
+   expensive connection and control layers are skipped during navigation. */
+.canvas-panning .react-flow__edges,
+.canvas-overview .react-flow__edges {
+  visibility: hidden;
+}
+
+.canvas-panning .group-interactive-controls,
+.canvas-panning .group-resize-controls,
+.canvas-panning .react-flow__resize-control {
+  visibility: hidden;
+}
+
+.canvas-panning .react-flow__node > * {
+  box-shadow: none !important;
+  transition: none !important;
+}
+
 /* Remove default React Flow styling for output nodes to match custom nodes */
 .react-flow__node-output {
   border: none !important;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,13 +56,13 @@ body {
   pointer-events: none;
 }
 
-/* Large-workflow performance mode: images and nodes remain visible while
-   expensive connection and control layers are skipped during navigation. */
+/* Hide edges below 15% zoom while keeping nodes and images visible. */
 .canvas-overview .react-flow__edges,
 .canvas-overview .react-flow__edge {
   display: none !important;
 }
 
+/* During panning, hide editing controls and disable costly visual effects. */
 .canvas-native-navigation-active .group-interactive-controls,
 .canvas-wheel-navigation-active .group-interactive-controls,
 .canvas-native-navigation-active .group-resize-controls,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,7 +52,7 @@ body {
    content to eliminate expensive browser hit-testing against the DOM tree.
    The class is toggled on <html> via direct DOM access (no React re-render). */
 .canvas-interacting .react-flow__node > *,
-.canvas-wheel-panning .react-flow__node > * {
+.canvas-wheel-navigation-active .react-flow__node > * {
   pointer-events: none;
 }
 
@@ -63,21 +63,21 @@ body {
   display: none !important;
 }
 
-.canvas-panning .group-interactive-controls,
-.canvas-wheel-panning .group-interactive-controls,
-.canvas-panning .group-resize-controls,
-.canvas-wheel-panning .group-resize-controls,
-.canvas-panning .react-flow__resize-control,
-.canvas-wheel-panning .react-flow__resize-control {
+.canvas-native-navigation-active .group-interactive-controls,
+.canvas-wheel-navigation-active .group-interactive-controls,
+.canvas-native-navigation-active .group-resize-controls,
+.canvas-wheel-navigation-active .group-resize-controls,
+.canvas-native-navigation-active .react-flow__resize-control,
+.canvas-wheel-navigation-active .react-flow__resize-control {
   visibility: hidden;
 }
 
-.canvas-panning .react-flow__node > * {
+.canvas-native-navigation-active .react-flow__node > * {
   box-shadow: none !important;
   transition: none !important;
 }
 
-.canvas-wheel-panning .react-flow__node > * {
+.canvas-wheel-navigation-active .react-flow__node > * {
   box-shadow: none !important;
   transition: none !important;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,24 +51,37 @@ body {
 /* During active panning or node dragging, disable pointer events on all node
    content to eliminate expensive browser hit-testing against the DOM tree.
    The class is toggled on <html> via direct DOM access (no React re-render). */
-.canvas-interacting .react-flow__node > * {
+.canvas-interacting .react-flow__node > *,
+.canvas-wheel-panning .react-flow__node > * {
   pointer-events: none;
 }
 
 /* Large-workflow performance mode: images and nodes remain visible while
    expensive connection and control layers are skipped during navigation. */
 .canvas-panning .react-flow__edges,
-.canvas-overview .react-flow__edges {
-  visibility: hidden;
+.canvas-wheel-panning .react-flow__edges,
+.canvas-overview .react-flow__edges,
+.canvas-panning .react-flow__edge,
+.canvas-wheel-panning .react-flow__edge,
+.canvas-overview .react-flow__edge {
+  display: none !important;
 }
 
 .canvas-panning .group-interactive-controls,
+.canvas-wheel-panning .group-interactive-controls,
 .canvas-panning .group-resize-controls,
-.canvas-panning .react-flow__resize-control {
+.canvas-wheel-panning .group-resize-controls,
+.canvas-panning .react-flow__resize-control,
+.canvas-wheel-panning .react-flow__resize-control {
   visibility: hidden;
 }
 
 .canvas-panning .react-flow__node > * {
+  box-shadow: none !important;
+  transition: none !important;
+}
+
+.canvas-wheel-panning .react-flow__node > * {
   box-shadow: none !important;
   transition: none !important;
 }

--- a/src/components/GroupsOverlay.tsx
+++ b/src/components/GroupsOverlay.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useState, useRef, useEffect } from "react";
-import { useViewport, ViewportPortal } from "@xyflow/react";
+import { memo, useCallback, useState, useRef, useEffect } from "react";
+import { useStore, ViewportPortal, type ReactFlowState } from "@xyflow/react";
+import { useShallow } from "zustand/shallow";
 import { useWorkflowStore, GROUP_COLORS } from "@/store/workflowStore";
 import { GroupColor } from "@/types";
 
@@ -30,8 +31,7 @@ interface GroupBackgroundProps {
 
 // Renders just the group background - displayed below nodes (z-index 1)
 function GroupBackground({ groupId }: GroupBackgroundProps) {
-  const { groups } = useWorkflowStore();
-  const group = groups[groupId];
+  const group = useWorkflowStore((state) => state.groups[groupId]);
 
   if (!group) return null;
 
@@ -59,9 +59,17 @@ interface GroupControlsProps {
 }
 
 // Renders the group header and resize handles - displayed above nodes (z-index 5)
-function GroupControls({ groupId, zoom }: GroupControlsProps) {
-  const { groups, updateGroup, deleteGroup, moveGroupNodes, toggleGroupLock } = useWorkflowStore();
-  const group = groups[groupId];
+const GroupControls = memo(function GroupControls({ groupId, zoom }: GroupControlsProps) {
+  const { group, updateGroup, deleteGroup, moveGroupNodes, toggleGroupLock } =
+    useWorkflowStore(
+      useShallow((state) => ({
+        group: state.groups[groupId],
+        updateGroup: state.updateGroup,
+        deleteGroup: state.deleteGroup,
+        moveGroupNodes: state.moveGroupNodes,
+        toggleGroupLock: state.toggleGroupLock,
+      }))
+    );
 
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(group?.name || "");
@@ -519,13 +527,16 @@ function GroupControls({ groupId, zoom }: GroupControlsProps) {
       />
     </div>
   );
+});
+
+export function selectViewportZoom(state: Pick<ReactFlowState, "transform">): number {
+  return state.transform[2];
 }
 
 // Renders group backgrounds inside ReactFlow's viewport using ViewportPortal
 // This participates in React Flow's stacking context so z-index works properly
 export function GroupBackgroundsPortal() {
-  const { groups } = useWorkflowStore();
-  const groupIds = Object.keys(groups);
+  const groupIds = useWorkflowStore(useShallow((state) => Object.keys(state.groups)));
 
   if (groupIds.length === 0) return null;
 
@@ -542,10 +553,8 @@ export function GroupBackgroundsPortal() {
 
 // Renders group controls (headers, resize handles) using ViewportPortal above nodes
 export function GroupControlsOverlay() {
-  const { groups } = useWorkflowStore();
-  const { zoom } = useViewport();
-
-  const groupIds = Object.keys(groups);
+  const groupIds = useWorkflowStore(useShallow((state) => Object.keys(state.groups)));
+  const zoom = useStore(selectViewportZoom);
 
   if (groupIds.length === 0) return null;
 

--- a/src/components/GroupsOverlay.tsx
+++ b/src/components/GroupsOverlay.tsx
@@ -5,6 +5,7 @@ import { useStore, ViewportPortal, type ReactFlowState } from "@xyflow/react";
 import { useShallow } from "zustand/shallow";
 import { useWorkflowStore, GROUP_COLORS } from "@/store/workflowStore";
 import { GroupColor } from "@/types";
+import { isOverviewZoom } from "@/utils/canvasPerformance";
 
 const COLOR_OPTIONS: { color: GroupColor; label: string }[] = [
   { color: "neutral", label: "Gray" },
@@ -56,10 +57,15 @@ function GroupBackground({ groupId }: GroupBackgroundProps) {
 interface GroupControlsProps {
   groupId: string;
   zoom: number;
+  showInteractiveControls: boolean;
 }
 
 // Renders the group header and resize handles - displayed above nodes (z-index 5)
-const GroupControls = memo(function GroupControls({ groupId, zoom }: GroupControlsProps) {
+const GroupControls = memo(function GroupControls({
+  groupId,
+  zoom,
+  showInteractiveControls,
+}: GroupControlsProps) {
   const { group, updateGroup, deleteGroup, moveGroupNodes, toggleGroupLock } =
     useWorkflowStore(
       useShallow((state) => ({
@@ -90,6 +96,14 @@ const GroupControls = memo(function GroupControls({ groupId, zoom }: GroupContro
       setShowColorPicker(false);
     }
   }, [showMenu]);
+
+  useEffect(() => {
+    if (!showInteractiveControls) {
+      setShowMenu(false);
+      setShowColorPicker(false);
+      setIsEditing(false);
+    }
+  }, [showInteractiveControls]);
 
   useEffect(() => {
     if (group?.name && !isEditing) {
@@ -353,7 +367,7 @@ const GroupControls = memo(function GroupControls({ groupId, zoom }: GroupContro
             </div>
 
             {/* Three-dot menu toggle - always visible */}
-            <div className="relative">
+            {showInteractiveControls && <div className="relative group-interactive-controls">
               <button
                 onClick={(e) => { e.stopPropagation(); setShowMenu(!showMenu); }}
                 className="w-6 h-6 rounded-md flex flex-col items-center justify-center gap-[2px] hover:bg-white/20 transition-colors"
@@ -487,11 +501,12 @@ const GroupControls = memo(function GroupControls({ groupId, zoom }: GroupContro
                   </button>
                 </div>
               )}
-            </div>
+            </div>}
           </div>
         </div>
       </div>
 
+      {showInteractiveControls && <div className="group-resize-controls">
       {/* Resize handles - interactive */}
       <div
         className="absolute top-0 left-0 w-3 h-3 cursor-nw-resize pointer-events-auto"
@@ -525,6 +540,7 @@ const GroupControls = memo(function GroupControls({ groupId, zoom }: GroupContro
         className="absolute right-0 top-3 bottom-3 w-2 cursor-e-resize pointer-events-auto"
         onMouseDown={(e) => handleResizeMouseDown(e, "e")}
       />
+      </div>}
     </div>
   );
 });
@@ -555,14 +571,20 @@ export function GroupBackgroundsPortal() {
 export function GroupControlsOverlay() {
   const groupIds = useWorkflowStore(useShallow((state) => Object.keys(state.groups)));
   const zoom = useStore(selectViewportZoom);
+  const showInteractiveControls = !isOverviewZoom(zoom);
 
   if (groupIds.length === 0) return null;
 
   return (
     <ViewportPortal>
-      <div style={{ position: "absolute", top: 0, left: 0, zIndex: 1000, pointerEvents: "none" }}>
+      <div className="group-controls-overlay" style={{ position: "absolute", top: 0, left: 0, zIndex: 1000, pointerEvents: "none" }}>
         {groupIds.map((groupId) => (
-          <GroupControls key={groupId} groupId={groupId} zoom={zoom} />
+          <GroupControls
+            key={groupId}
+            groupId={groupId}
+            zoom={zoom}
+            showInteractiveControls={showInteractiveControls}
+          />
         ))}
       </div>
     </ViewportPortal>

--- a/src/components/GroupsOverlay.tsx
+++ b/src/components/GroupsOverlay.tsx
@@ -98,14 +98,6 @@ const GroupControls = memo(function GroupControls({
   }, [showMenu]);
 
   useEffect(() => {
-    if (!showInteractiveControls) {
-      setShowMenu(false);
-      setShowColorPicker(false);
-      setIsEditing(false);
-    }
-  }, [showInteractiveControls]);
-
-  useEffect(() => {
     if (group?.name && !isEditing) {
       setEditName(group.name);
     }
@@ -142,6 +134,13 @@ const GroupControls = memo(function GroupControls({
     }
     setIsEditing(false);
   }, [editName, group?.name, groupId, updateGroup]);
+
+  useEffect(() => {
+    if (showInteractiveControls) return;
+    if (isEditing) handleNameSubmit();
+    setShowMenu(false);
+    setShowColorPicker(false);
+  }, [showInteractiveControls, isEditing, handleNameSubmit]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -322,14 +321,18 @@ const GroupControls = memo(function GroupControls({
         {/* Inner scaled element: bottom-anchored so it grows upward, scale keeps bottom-left fixed */}
         <div
           ref={menuRef}
-          className="absolute left-0 pointer-events-auto cursor-grab active:cursor-grabbing select-none"
+          className={`absolute left-0 select-none ${
+            showInteractiveControls
+              ? "pointer-events-auto cursor-grab active:cursor-grabbing"
+              : "pointer-events-none"
+          }`}
           style={{
             bottom: 0,
             transform: `scale(${1 / zoom})`,
             transformOrigin: "bottom left",
             whiteSpace: "nowrap",
           }}
-          onMouseDown={handleHeaderMouseDown}
+          onMouseDown={showInteractiveControls ? handleHeaderMouseDown : undefined}
         >
           <div
             className="flex items-center gap-0.5 mb-1"
@@ -359,14 +362,14 @@ const GroupControls = memo(function GroupControls({
                 <span
                   className="text-xs font-medium text-white truncate"
                   style={{ maxWidth: 200 }}
-                  onDoubleClick={(e) => { e.stopPropagation(); setIsEditing(true); }}
+                  onDoubleClick={showInteractiveControls ? (e) => { e.stopPropagation(); setIsEditing(true); } : undefined}
                 >
                   {group.name}
                 </span>
               )}
             </div>
 
-            {/* Three-dot menu toggle - always visible */}
+            {/* Three-dot menu toggle — omitted in overview mode */}
             {showInteractiveControls && <div className="relative group-interactive-controls">
               <button
                 onClick={(e) => { e.stopPropagation(); setShowMenu(!showMenu); }}

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -151,6 +151,8 @@ const edgeTypes: EdgeTypes = {
   reference: ReferenceEdge,
 };
 
+const OVERVIEW_EDGES: Edge[] = [];
+
 // Connection validation rules
 // - Image handles (green) can only connect to image handles
 // - Text handles (blue) can only connect to text handles
@@ -2107,7 +2109,7 @@ export function WorkflowCanvas() {
 
       <ReactFlow
         nodes={allNodes}
-        edges={edges}
+        edges={isCanvasOverview ? OVERVIEW_EDGES : edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={handleConnect}

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -153,6 +153,39 @@ const edgeTypes: EdgeTypes = {
 
 const OVERVIEW_EDGES: Edge[] = [];
 
+function getMiniMapNodeColor(node: Node): string {
+  switch (node.type) {
+    case "imageInput": return "#3b82f6";
+    case "audioInput": return "#a78bfa";
+    case "videoInput": return "#c084fc";
+    case "annotation": return "#8b5cf6";
+    case "prompt": return "#f97316";
+    case "array": return "#a3e635";
+    case "promptConstructor": return "#f472b6";
+    case "nanoBanana": return "#22c55e";
+    case "generateVideo": return "#9333ea";
+    case "generate3d": return "#fb923c";
+    case "generateAudio": return "#d946ef";
+    case "llmGenerate": return "#06b6d4";
+    case "splitGrid": return "#f59e0b";
+    case "output": return "#ef4444";
+    case "outputGallery": return "#ec4899";
+    case "imageCompare": return "#14b8a6";
+    case "videoStitch": return "#f97316";
+    case "easeCurve": return "#bef264";
+    case "videoTrim": return "#60a5fa";
+    case "videoFrameGrab": return "#38bdf8";
+    case "removeBackground": return "#2dd4bf";
+    case "imageResize": return "#0d9488";
+    case "gifEncoder": return "#f472b6";
+    case "router": return "#6b7280";
+    case "switch": return "#8b5cf6";
+    case "conditionalSwitch": return "#06b6d4";
+    case "glbViewer": return "#0ea5e9";
+    default: return "#94a3b8";
+  }
+}
+
 // Connection validation rules
 // - Image handles (green) can only connect to image handles
 // - Text handles (blue) can only connect to text handles
@@ -304,6 +337,7 @@ export function WorkflowCanvas() {
   >(null);
   const [isSplitting, setIsSplitting] = useState(false);
   const [isChatOpen, setIsChatOpen] = useState(false);
+  const [isMinimapVisible, setIsMinimapVisible] = useState(true);
   const [isBuildingWorkflow, setIsBuildingWorkflow] = useState(false);
   const [showNewProjectSetup, setShowNewProjectSetup] = useState(false);
   const [expandingNode, setExpandingNode] = useState<{ id: string; type: string } | null>(null);
@@ -2189,72 +2223,44 @@ export function WorkflowCanvas() {
           className={tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}
         />
         <Controls className={`bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg [&>button]:bg-neutral-800 [&>button]:border-neutral-700 [&>button]:fill-neutral-300 [&>button:hover]:bg-neutral-700 [&>button:hover]:fill-neutral-100 ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`} />
-        <MiniMap
-          className={`bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
-          maskColor="rgba(0, 0, 0, 0.6)"
-          pannable
-          zoomable
-          nodeColor={(node) => {
-            switch (node.type) {
-              case "imageInput":
-                return "#3b82f6";
-              case "audioInput":
-                return "#a78bfa";
-              case "videoInput":
-                return "#c084fc"; // purple-400 (video input, distinct from generateVideo's #9333ea)
-              case "annotation":
-                return "#8b5cf6";
-              case "prompt":
-                return "#f97316";
-              case "array":
-                return "#a3e635";
-              case "promptConstructor":
-                return "#f472b6";
-              case "nanoBanana":
-                return "#22c55e";
-              case "generateVideo":
-                return "#9333ea";
-              case "generate3d":
-                return "#fb923c";
-              case "generateAudio":
-                return "#d946ef"; // fuchsia-500 (audio/TTS)
-              case "llmGenerate":
-                return "#06b6d4";
-              case "splitGrid":
-                return "#f59e0b";
-              case "output":
-                return "#ef4444";
-              case "outputGallery":
-                return "#ec4899";
-              case "imageCompare":
-                return "#14b8a6";
-              case "videoStitch":
-                return "#f97316";
-              case "easeCurve":
-                return "#bef264"; // lime-300 (easy-peasy-ease)
-              case "videoTrim":
-                return "#60a5fa"; // blue-400 (trim/cut)
-              case "videoFrameGrab":
-                return "#38bdf8"; // sky-400 (image from video)
-              case "removeBackground":
-                return "#2dd4bf"; // teal-400 (background removal)
-              case "imageResize":
-                return "#0d9488"; // teal-600 (image utility)
-              case "gifEncoder":
-                return "#f472b6"; // pink-400 (animated output)
-              case "router":
-                return "#6b7280"; // neutral-500 (gray/slate utility theme)
-              case "switch":
-                return "#8b5cf6"; // violet-500 (distinct from Router)
-              case "conditionalSwitch":
-                return "#06b6d4"; // cyan-500 (distinct from Router gray and Switch violet)
-              case "glbViewer":
-                return "#0ea5e9"; // sky-500 (3D viewport)
-              default:
-                return "#94a3b8";
-            }
-          }}
-        />
+        {isMinimapVisible ? (
+          <div
+            className={`absolute bottom-[15px] right-[15px] z-[5] h-[150px] w-[200px] overflow-hidden rounded-lg shadow-lg ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
+          >
+            <MiniMap
+              className="bg-neutral-800 border border-neutral-700 rounded-lg"
+              style={{ position: "absolute", inset: 0, width: "100%", height: "100%", margin: 0 }}
+              maskColor="rgba(0, 0, 0, 0.6)"
+              pannable
+              zoomable
+              nodeColor={getMiniMapNodeColor}
+            />
+            <button
+              type="button"
+              aria-label="Hide minimap"
+              title="Hide minimap"
+              onClick={() => setIsMinimapVisible(false)}
+              className="nodrag nopan nowheel absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-neutral-600/80 bg-neutral-950/85 text-neutral-400 shadow-sm backdrop-blur-sm transition-colors hover:border-neutral-500 hover:bg-neutral-800 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4" fill="none">
+                <path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+              </svg>
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            aria-label="Show minimap"
+            title="Show minimap"
+            onClick={() => setIsMinimapVisible(true)}
+            className={`nodrag nopan nowheel absolute bottom-[15px] right-[15px] z-[5] flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-700 bg-neutral-800 text-neutral-400 shadow-lg transition-colors hover:border-neutral-600 hover:bg-neutral-700 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
+          >
+            <svg aria-hidden="true" viewBox="0 0 20 20" className="h-[18px] w-[18px]" fill="none">
+              <rect x="2.5" y="3.5" width="15" height="13" rx="2" stroke="currentColor" strokeWidth="1.5" />
+              <path d="M5.5 7h2v2h-2zM9 7h2v2H9zM12.5 7h2v2h-2zM5.5 10.5h2v2h-2zM9 10.5h5.5v2H9z" fill="currentColor" />
+            </svg>
+          </button>
+        )}
         <ViewportPortal>
           {allNodes.map((node) => {
             // Groups don't get floating headers

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -152,6 +152,22 @@ const edgeTypes: EdgeTypes = {
 };
 
 const OVERVIEW_EDGES: Edge[] = [];
+const MINIMAP_GEOMETRY = {
+  width: 200,
+  height: 150,
+  margin: 15,
+  controlInset: 8,
+  controlSize: 28,
+} as const;
+
+const MINIMAP_CLOSE_POSITION = {
+  right: MINIMAP_GEOMETRY.margin + MINIMAP_GEOMETRY.controlInset,
+  bottom:
+    MINIMAP_GEOMETRY.margin +
+    MINIMAP_GEOMETRY.height -
+    MINIMAP_GEOMETRY.controlInset -
+    MINIMAP_GEOMETRY.controlSize,
+} as const;
 
 function getMiniMapNodeColor(node: Node): string {
   switch (node.type) {
@@ -371,9 +387,12 @@ export function WorkflowCanvas() {
   }, []);
 
   useEffect(() => {
+    const wrapper = reactFlowWrapper.current;
     return () => {
       document.documentElement.classList.remove("canvas-interacting");
-      setCanvasPanningClass(false);
+      if (wrapper) setCanvasPanningClass(false, wrapper);
+      isPanningRef.current = false;
+      isDraggingNodeRef.current = false;
     };
   }, []);
 
@@ -2148,8 +2167,8 @@ export function WorkflowCanvas() {
         onEdgesChange={onEdgesChange}
         onConnect={handleConnect}
         onConnectEnd={handleConnectEnd}
-        onMoveStart={() => { isPanningRef.current = true; setHoveredNodeId(null); document.documentElement.classList.add("canvas-interacting"); setCanvasPanningClass(true); }}
-        onMoveEnd={() => { isPanningRef.current = false; document.documentElement.classList.remove("canvas-interacting"); setCanvasPanningClass(false); }}
+        onMoveStart={() => { isPanningRef.current = true; setHoveredNodeId(null); document.documentElement.classList.add("canvas-interacting"); if (reactFlowWrapper.current) setCanvasPanningClass(true, reactFlowWrapper.current); }}
+        onMoveEnd={() => { isPanningRef.current = false; document.documentElement.classList.remove("canvas-interacting"); if (reactFlowWrapper.current) setCanvasPanningClass(false, reactFlowWrapper.current); }}
         onNodeDragStart={() => { isDraggingNodeRef.current = true; document.documentElement.classList.add("canvas-interacting"); }}
         onNodeDragStop={(event, node) => { isDraggingNodeRef.current = false; document.documentElement.classList.remove("canvas-interacting"); handleNodeDragStop(event, node); }}
         onSelectionChange={handleSelectionChange}
@@ -2227,6 +2246,11 @@ export function WorkflowCanvas() {
           <>
             <MiniMap
               className={`bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
+              style={{
+                width: MINIMAP_GEOMETRY.width,
+                height: MINIMAP_GEOMETRY.height,
+                margin: MINIMAP_GEOMETRY.margin,
+              }}
               maskColor="rgba(0, 0, 0, 0.6)"
               pannable
               zoomable
@@ -2236,8 +2260,10 @@ export function WorkflowCanvas() {
               type="button"
               aria-label="Hide minimap"
               title="Hide minimap"
+              disabled={tutorialActive && lockedFeatures}
               onClick={() => setIsMinimapVisible(false)}
-              className={`nodrag nopan nowheel absolute bottom-[130px] right-[23px] z-[6] flex h-7 w-7 items-center justify-center rounded-md border border-neutral-600/80 bg-neutral-950/85 text-neutral-400 shadow-sm backdrop-blur-sm transition-colors hover:border-neutral-500 hover:bg-neutral-800 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
+              style={MINIMAP_CLOSE_POSITION}
+              className="nodrag nopan nowheel absolute z-[6] flex h-7 w-7 items-center justify-center rounded-md border border-neutral-600/80 bg-neutral-950/85 text-neutral-400 shadow-sm backdrop-blur-sm transition-colors hover:border-neutral-500 hover:bg-neutral-800 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed"
             >
               <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4" fill="none">
                 <path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
@@ -2249,8 +2275,10 @@ export function WorkflowCanvas() {
             type="button"
             aria-label="Show minimap"
             title="Show minimap"
+            disabled={tutorialActive && lockedFeatures}
             onClick={() => setIsMinimapVisible(true)}
-            className={`nodrag nopan nowheel absolute bottom-[15px] right-[15px] z-[5] flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-700 bg-neutral-800 text-neutral-400 shadow-lg transition-colors hover:border-neutral-600 hover:bg-neutral-700 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
+            style={{ right: MINIMAP_GEOMETRY.margin, bottom: MINIMAP_GEOMETRY.margin }}
+            className={`nodrag nopan nowheel absolute z-[5] flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-700 bg-neutral-800 text-neutral-400 shadow-lg transition-colors hover:border-neutral-600 hover:bg-neutral-700 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
           >
             <svg aria-hidden="true" viewBox="0 0 20 20" className="h-[18px] w-[18px]" fill="none">
               <rect x="2.5" y="3.5" width="15" height="13" rx="2" stroke="currentColor" strokeWidth="1.5" />

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -15,6 +15,7 @@ import {
   Node,
   OnSelectionChangeParams,
   ViewportPortal,
+  useStore,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
@@ -82,6 +83,7 @@ import { LLMFallbackPopover } from "./nodes/LLMFallbackPopover";
 import { browseRegistry } from "@/utils/browseRegistry";
 import { useInlineParameters } from "@/hooks/useInlineParameters";
 import { useWheelPanZoom } from "@/hooks/useWheelPanZoom";
+import { selectCanvasOverview, setCanvasPanningClass } from "@/utils/canvasPerformance";
 import { SplitGridTemplateModal } from "./splitgrid/SplitGridTemplateModal";
 import { createPortal } from "react-dom";
 import { useAnnotationStore } from "@/store/annotationStore";
@@ -289,6 +291,7 @@ export function WorkflowCanvas() {
   const setHoveredNodeId = useWorkflowStore((state) => state.setHoveredNodeId);
   const openAnnotationModal = useAnnotationStore((state) => state.openModal);
   const { screenToFlowPosition, getViewport, setCenter } = useReactFlow();
+  const isCanvasOverview = useStore(selectCanvasOverview);
   const { show: showToast } = useToast();
   const [isDragOver, setIsDragOver] = useState(false);
   const [dropType, setDropType] = useState<"image" | "audio" | "workflow" | "node" | null>(null);
@@ -329,6 +332,13 @@ export function WorkflowCanvas() {
     setLockedFeatures(currentState.lockedFeatures);
 
     return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      document.documentElement.classList.remove("canvas-interacting");
+      setCanvasPanningClass(false);
+    };
   }, []);
 
   // Detect if canvas is empty for showing quickstart
@@ -2029,7 +2039,9 @@ export function WorkflowCanvas() {
   return (
     <div
       ref={reactFlowWrapper}
-      className={`flex-1 bg-canvas-bg relative ${isDragOver ? "ring-2 ring-inset ring-blue-500" : ""}`}
+      className={`flex-1 bg-canvas-bg relative ${
+        isCanvasOverview ? "canvas-overview" : ""
+      } ${isDragOver ? "ring-2 ring-inset ring-blue-500" : ""}`}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
@@ -2100,8 +2112,8 @@ export function WorkflowCanvas() {
         onEdgesChange={onEdgesChange}
         onConnect={handleConnect}
         onConnectEnd={handleConnectEnd}
-        onMoveStart={() => { isPanningRef.current = true; setHoveredNodeId(null); document.documentElement.classList.add("canvas-interacting"); }}
-        onMoveEnd={() => { isPanningRef.current = false; document.documentElement.classList.remove("canvas-interacting"); }}
+        onMoveStart={() => { isPanningRef.current = true; setHoveredNodeId(null); document.documentElement.classList.add("canvas-interacting"); setCanvasPanningClass(true); }}
+        onMoveEnd={() => { isPanningRef.current = false; document.documentElement.classList.remove("canvas-interacting"); setCanvasPanningClass(false); }}
         onNodeDragStart={() => { isDraggingNodeRef.current = true; document.documentElement.classList.add("canvas-interacting"); }}
         onNodeDragStop={(event, node) => { isDraggingNodeRef.current = false; document.documentElement.classList.remove("canvas-interacting"); handleNodeDragStop(event, node); }}
         onSelectionChange={handleSelectionChange}

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -2224,12 +2224,9 @@ export function WorkflowCanvas() {
         />
         <Controls className={`bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg [&>button]:bg-neutral-800 [&>button]:border-neutral-700 [&>button]:fill-neutral-300 [&>button:hover]:bg-neutral-700 [&>button:hover]:fill-neutral-100 ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`} />
         {isMinimapVisible ? (
-          <div
-            className={`absolute bottom-[15px] right-[15px] z-[5] h-[150px] w-[200px] overflow-hidden rounded-lg shadow-lg ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
-          >
+          <>
             <MiniMap
-              className="bg-neutral-800 border border-neutral-700 rounded-lg"
-              style={{ position: "absolute", inset: 0, width: "100%", height: "100%", margin: 0 }}
+              className={`bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
               maskColor="rgba(0, 0, 0, 0.6)"
               pannable
               zoomable
@@ -2240,13 +2237,13 @@ export function WorkflowCanvas() {
               aria-label="Hide minimap"
               title="Hide minimap"
               onClick={() => setIsMinimapVisible(false)}
-              className="nodrag nopan nowheel absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-neutral-600/80 bg-neutral-950/85 text-neutral-400 shadow-sm backdrop-blur-sm transition-colors hover:border-neutral-500 hover:bg-neutral-800 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              className={`nodrag nopan nowheel absolute bottom-[130px] right-[23px] z-[6] flex h-7 w-7 items-center justify-center rounded-md border border-neutral-600/80 bg-neutral-950/85 text-neutral-400 shadow-sm backdrop-blur-sm transition-colors hover:border-neutral-500 hover:bg-neutral-800 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
             >
               <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4" fill="none">
                 <path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
               </svg>
             </button>
-          </div>
+          </>
         ) : (
           <button
             type="button"

--- a/src/components/__tests__/GroupsOverlay.test.tsx
+++ b/src/components/__tests__/GroupsOverlay.test.tsx
@@ -195,7 +195,7 @@ describe("GroupControlsOverlay", () => {
   });
 
   it("keeps group titles but omits interactive controls at overview zoom", () => {
-    mockViewport.zoom = 0.2;
+    mockViewport.zoom = 0.1;
     mockUseWorkflowStore.mockImplementation((selector) => {
       return selector(
         createDefaultState({ groups: { "group-1": createMockGroup({ name: "Overview Group" }) } })

--- a/src/components/__tests__/GroupsOverlay.test.tsx
+++ b/src/components/__tests__/GroupsOverlay.test.tsx
@@ -209,6 +209,46 @@ describe("GroupControlsOverlay", () => {
     expect(container.querySelector(".group-resize-controls")).not.toBeInTheDocument();
   });
 
+  it("keeps overview titles passive", () => {
+    mockViewport.zoom = 0.1;
+    mockUseWorkflowStore.mockImplementation((selector) =>
+      selector(
+        createDefaultState({
+          groups: { "group-1": createMockGroup({ name: "Passive Group" }) },
+        })
+      )
+    );
+
+    render(<GroupControlsOverlay />);
+    const title = screen.getByText("Passive Group");
+
+    fireEvent.doubleClick(title);
+    fireEvent.mouseDown(title, { clientX: 10, clientY: 10 });
+    fireEvent.mouseMove(window, { clientX: 30, clientY: 30 });
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(mockMoveGroupNodes).not.toHaveBeenCalled();
+  });
+
+  it("commits an active rename before entering overview mode", () => {
+    mockUseWorkflowStore.mockImplementation((selector) =>
+      selector(
+        createDefaultState({
+          groups: { "group-1": createMockGroup({ name: "Original Name" }) },
+        })
+      )
+    );
+
+    const { rerender } = render(<GroupControlsOverlay />);
+    fireEvent.doubleClick(screen.getByText("Original Name"));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Renamed Group" } });
+
+    mockViewport.zoom = 0.1;
+    rerender(<GroupControlsOverlay />);
+
+    expect(mockUpdateGroup).toHaveBeenCalledWith("group-1", { name: "Renamed Group" });
+  });
+
   describe("Group Controls Rendering", () => {
     it("should render controls inside ViewportPortal", () => {
       mockUseWorkflowStore.mockImplementation((selector) => {

--- a/src/components/__tests__/GroupsOverlay.test.tsx
+++ b/src/components/__tests__/GroupsOverlay.test.tsx
@@ -8,13 +8,15 @@ import {
 } from "@/components/GroupsOverlay";
 import { Group } from "@/types";
 
+const mockViewport = vi.hoisted(() => ({ zoom: 1 }));
+
 // Mock ReactFlow hooks and components
 vi.mock("@xyflow/react", () => ({
   useReactFlow: () => ({
     getViewport: () => ({ zoom: 1, x: 0, y: 0 }),
   }),
   useStore: (selector: (state: { transform: [number, number, number] }) => unknown) =>
-    selector({ transform: [0, 0, 1] }),
+    selector({ transform: [0, 0, mockViewport.zoom] }),
   ViewportPortal: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="viewport-portal">{children}</div>
   ),
@@ -68,6 +70,7 @@ const createDefaultState = (overrides: { groups?: Record<string, Group> } = {}) 
 describe("GroupBackgroundsPortal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockViewport.zoom = 1;
     mockUseWorkflowStore.mockImplementation((selector) => {
       return selector(createDefaultState());
     });
@@ -170,6 +173,7 @@ describe("GroupBackgroundsPortal", () => {
 describe("GroupControlsOverlay", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockViewport.zoom = 1;
     mockUseWorkflowStore.mockImplementation((selector) => {
       return selector(createDefaultState());
     });
@@ -188,6 +192,21 @@ describe("GroupControlsOverlay", () => {
 
   it("selects only zoom from viewport state", () => {
     expect(selectViewportZoom({ transform: [125, -80, 0.4] } as never)).toBe(0.4);
+  });
+
+  it("keeps group titles but omits interactive controls at overview zoom", () => {
+    mockViewport.zoom = 0.2;
+    mockUseWorkflowStore.mockImplementation((selector) => {
+      return selector(
+        createDefaultState({ groups: { "group-1": createMockGroup({ name: "Overview Group" }) } })
+      );
+    });
+
+    const { container } = render(<GroupControlsOverlay />);
+
+    expect(screen.getByText("Overview Group")).toBeInTheDocument();
+    expect(screen.queryByTitle("Group options")).not.toBeInTheDocument();
+    expect(container.querySelector(".group-resize-controls")).not.toBeInTheDocument();
   });
 
   describe("Group Controls Rendering", () => {

--- a/src/components/__tests__/GroupsOverlay.test.tsx
+++ b/src/components/__tests__/GroupsOverlay.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import { GroupBackgroundsPortal, GroupControlsOverlay, GroupsOverlay } from "@/components/GroupsOverlay";
+import {
+  GroupBackgroundsPortal,
+  GroupControlsOverlay,
+  GroupsOverlay,
+  selectViewportZoom,
+} from "@/components/GroupsOverlay";
 import { Group } from "@/types";
 
 // Mock ReactFlow hooks and components
@@ -8,7 +13,8 @@ vi.mock("@xyflow/react", () => ({
   useReactFlow: () => ({
     getViewport: () => ({ zoom: 1, x: 0, y: 0 }),
   }),
-  useViewport: () => ({ zoom: 1, x: 0, y: 0 }),
+  useStore: (selector: (state: { transform: [number, number, number] }) => unknown) =>
+    selector({ transform: [0, 0, 1] }),
   ViewportPortal: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="viewport-portal">{children}</div>
   ),
@@ -178,6 +184,10 @@ describe("GroupControlsOverlay", () => {
       const { container } = render(<GroupControlsOverlay />);
       expect(container.firstChild).toBeNull();
     });
+  });
+
+  it("selects only zoom from viewport state", () => {
+    expect(selectViewportZoom({ transform: [125, -80, 0.4] } as never)).toBe(0.4);
   });
 
   describe("Group Controls Rendering", () => {

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -19,6 +19,7 @@ const mockPasteNodes = vi.fn();
 const mockClearClipboard = vi.fn();
 const mockSetShowQuickstart = vi.fn();
 const mockUseWorkflowStore = vi.fn();
+const mockViewport = vi.hoisted(() => ({ zoom: 1 }));
 
 vi.mock("@/store/workflowStore", () => ({
   useWorkflowStore: (selector?: (state: unknown) => unknown) => {
@@ -40,6 +41,8 @@ vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react");
   return {
     ...actual,
+    useStore: (selector: (state: { transform: [number, number, number]; nodeLookup: Map<string, unknown> }) => unknown) =>
+      selector({ transform: [0, 0, mockViewport.zoom], nodeLookup: new Map() }),
     useReactFlow: () => ({
       screenToFlowPosition: mockScreenToFlowPosition,
       getViewport: mockGetViewport,
@@ -155,6 +158,7 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 describe("WorkflowCanvas", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockViewport.zoom = 1;
     // Default mock implementation
     mockUseWorkflowStore.mockImplementation((selector) => {
       return selector(createDefaultState());
@@ -171,6 +175,17 @@ describe("WorkflowCanvas", () => {
 
       // ReactFlow container should be present
       expect(document.querySelector(".react-flow")).toBeInTheDocument();
+    });
+
+    it("marks the canvas as overview mode below the edge visibility threshold", () => {
+      mockViewport.zoom = 0.2;
+      render(
+        <TestWrapper>
+          <WorkflowCanvas />
+        </TestWrapper>
+      );
+
+      expect(document.querySelector(".bg-canvas-bg")).toHaveClass("canvas-overview");
     });
 
     it("should render Background component", () => {

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -20,6 +20,9 @@ const mockClearClipboard = vi.fn();
 const mockSetShowQuickstart = vi.fn();
 const mockUseWorkflowStore = vi.fn();
 const mockViewport = vi.hoisted(() => ({ zoom: 1 }));
+const mockReactFlowProps = vi.hoisted(() => ({
+  current: null as Record<string, unknown> | null,
+}));
 
 vi.mock("@/store/workflowStore", () => ({
   useWorkflowStore: (selector?: (state: unknown) => unknown) => {
@@ -38,9 +41,14 @@ const mockZoomOut = vi.fn();
 const mockSetViewport = vi.fn();
 
 vi.mock("@xyflow/react", async () => {
-  const actual = await vi.importActual("@xyflow/react");
+  const actual = await vi.importActual<typeof import("@xyflow/react")>("@xyflow/react");
+  const React = await vi.importActual<typeof import("react")>("react");
   return {
     ...actual,
+    ReactFlow: (props: Record<string, unknown>) => {
+      mockReactFlowProps.current = props;
+      return React.createElement(actual.ReactFlow, props);
+    },
     useStore: (selector: (state: { transform: [number, number, number]; nodeLookup: Map<string, unknown> }) => unknown) =>
       selector({ transform: [0, 0, mockViewport.zoom], nodeLookup: new Map() }),
     useReactFlow: () => ({
@@ -159,6 +167,7 @@ describe("WorkflowCanvas", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockViewport.zoom = 1;
+    mockReactFlowProps.current = null;
     // Default mock implementation
     mockUseWorkflowStore.mockImplementation((selector) => {
       return selector(createDefaultState());
@@ -186,6 +195,27 @@ describe("WorkflowCanvas", () => {
       );
 
       expect(document.querySelector(".bg-canvas-bg")).toHaveClass("canvas-overview");
+    });
+
+    it("removes edges from React Flow while in overview mode", () => {
+      mockViewport.zoom = 0.3;
+      mockUseWorkflowStore.mockImplementation((selector) =>
+        selector(
+          createDefaultState({
+            edges: [
+              { id: "router-edge", source: "source", target: "router" },
+            ],
+          })
+        )
+      );
+
+      render(
+        <TestWrapper>
+          <WorkflowCanvas />
+        </TestWrapper>
+      );
+
+      expect(mockReactFlowProps.current?.edges).toEqual([]);
     });
 
     it("should render Background component", () => {

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { WorkflowCanvas } from "@/components/WorkflowCanvas";
 import { ReactFlowProvider } from "@xyflow/react";
 
@@ -18,6 +18,7 @@ const mockCopySelectedNodes = vi.fn();
 const mockPasteNodes = vi.fn();
 const mockClearClipboard = vi.fn();
 const mockSetShowQuickstart = vi.fn();
+const mockSetHoveredNodeId = vi.fn();
 const mockUseWorkflowStore = vi.fn();
 const mockViewport = vi.hoisted(() => ({ zoom: 1 }));
 const mockReactFlowProps = vi.hoisted(() => ({
@@ -138,6 +139,7 @@ const createDefaultState = (overrides = {}) => ({
   isModalOpen: false,
   showQuickstart: false,
   setShowQuickstart: mockSetShowQuickstart,
+  setHoveredNodeId: mockSetHoveredNodeId,
   copySelectedNodes: mockCopySelectedNodes,
   pasteNodes: mockPasteNodes,
   clearClipboard: mockClearClipboard,
@@ -281,6 +283,49 @@ describe("WorkflowCanvas", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Show minimap" }));
       expect(document.querySelector(".react-flow__minimap")).toBeInTheDocument();
+    });
+
+    it("uses shared explicit geometry for the minimap and close toggle", () => {
+      render(
+        <TestWrapper>
+          <WorkflowCanvas />
+        </TestWrapper>
+      );
+
+      const minimap = document.querySelector(".react-flow__minimap");
+      const closeButton = screen.getByRole("button", { name: "Hide minimap" });
+
+      expect(minimap).toHaveStyle({ width: "200px", height: "150px", margin: "15px" });
+      expect(minimap?.parentElement).toHaveClass("react-flow");
+      expect(closeButton).toHaveStyle({ right: "23px", bottom: "129px" });
+    });
+
+    it("keeps edges visible and scopes native pan state to this canvas", () => {
+      const edge = { id: "edge-1", source: "source", target: "target" };
+      mockViewport.zoom = 0.2;
+      mockUseWorkflowStore.mockImplementation((selector) =>
+        selector(createDefaultState({ edges: [edge] }))
+      );
+
+      render(
+        <TestWrapper>
+          <WorkflowCanvas />
+        </TestWrapper>
+      );
+
+      const canvas = document.querySelector(".bg-canvas-bg") as HTMLElement;
+      act(() => {
+        (mockReactFlowProps.current?.onMoveStart as (() => void) | undefined)?.();
+      });
+
+      expect(mockReactFlowProps.current?.edges).toEqual([edge]);
+      expect(canvas).toHaveClass("canvas-native-navigation-active");
+      expect(document.documentElement).not.toHaveClass("canvas-native-navigation-active");
+
+      act(() => {
+        (mockReactFlowProps.current?.onMoveEnd as (() => void) | undefined)?.();
+      });
+      expect(canvas).not.toHaveClass("canvas-native-navigation-active");
     });
 
     it("should render EdgeToolbar component", () => {

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -264,7 +264,9 @@ describe("WorkflowCanvas", () => {
       );
 
       // MiniMap should be rendered
-      expect(document.querySelector(".react-flow__minimap")).toBeInTheDocument();
+      const minimap = document.querySelector(".react-flow__minimap");
+      expect(minimap).toBeInTheDocument();
+      expect(minimap).not.toHaveStyle({ width: "100%", height: "100%" });
     });
 
     it("allows the minimap to be hidden and restored", () => {

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -187,7 +187,7 @@ describe("WorkflowCanvas", () => {
     });
 
     it("marks the canvas as overview mode below the edge visibility threshold", () => {
-      mockViewport.zoom = 0.2;
+      mockViewport.zoom = 0.1;
       render(
         <TestWrapper>
           <WorkflowCanvas />
@@ -198,7 +198,7 @@ describe("WorkflowCanvas", () => {
     });
 
     it("removes edges from React Flow while in overview mode", () => {
-      mockViewport.zoom = 0.3;
+      mockViewport.zoom = 0.1;
       mockUseWorkflowStore.mockImplementation((selector) =>
         selector(
           createDefaultState({
@@ -216,6 +216,22 @@ describe("WorkflowCanvas", () => {
       );
 
       expect(mockReactFlowProps.current?.edges).toEqual([]);
+    });
+
+    it("keeps edges rendered above the fifteen-percent threshold", () => {
+      const edge = { id: "router-edge", source: "source", target: "router" };
+      mockViewport.zoom = 0.2;
+      mockUseWorkflowStore.mockImplementation((selector) =>
+        selector(createDefaultState({ edges: [edge] }))
+      );
+
+      render(
+        <TestWrapper>
+          <WorkflowCanvas />
+        </TestWrapper>
+      );
+
+      expect(mockReactFlowProps.current?.edges).toEqual([edge]);
     });
 
     it("should render Background component", () => {

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -267,6 +267,20 @@ describe("WorkflowCanvas", () => {
       expect(document.querySelector(".react-flow__minimap")).toBeInTheDocument();
     });
 
+    it("allows the minimap to be hidden and restored", () => {
+      render(
+        <TestWrapper>
+          <WorkflowCanvas />
+        </TestWrapper>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Hide minimap" }));
+      expect(document.querySelector(".react-flow__minimap")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Show minimap" }));
+      expect(document.querySelector(".react-flow__minimap")).toBeInTheDocument();
+    });
+
     it("should render EdgeToolbar component", () => {
       render(
         <TestWrapper>

--- a/src/hooks/__tests__/useWheelPanZoom.integration.test.tsx
+++ b/src/hooks/__tests__/useWheelPanZoom.integration.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+const reactFlow = vi.hoisted(() => ({
+  getViewport: vi.fn(() => ({ x: 100, y: 200, zoom: 0.5 })),
+  setViewport: vi.fn(),
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  useReactFlow: () => reactFlow,
+}));
+
+describe("useWheelPanZoom", () => {
+  const originalPlatform = navigator.platform;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+    document.documentElement.className = "";
+    document.body.innerHTML = "";
+  });
+
+  it("batches Mac trackpad movement and scopes activity to its wrapper", async () => {
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
+    vi.resetModules();
+
+    let frameCallback: FrameRequestCallback | null = null;
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frameCallback = callback;
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const { useWheelPanZoom } = await import("../useWheelPanZoom");
+    const wrapper = document.createElement("div");
+    wrapper.className = "react-flow-wrapper";
+    document.body.appendChild(wrapper);
+
+    const { unmount } = renderHook(() =>
+      useWheelPanZoom(
+        { current: wrapper },
+        { panMode: "space", zoomMode: "altScroll", selectionMode: "click" }
+      )
+    );
+    const wheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaMode: 0,
+      deltaX: 4,
+      deltaY: 6,
+    });
+
+    act(() => wrapper.dispatchEvent(wheelEvent));
+
+    expect(wheelEvent.defaultPrevented).toBe(true);
+    expect(wrapper).toHaveClass("canvas-wheel-navigation-active");
+    expect(document.documentElement).not.toHaveClass("canvas-wheel-navigation-active");
+    expect(reactFlow.setViewport).not.toHaveBeenCalled();
+
+    act(() => frameCallback?.(0));
+    expect(reactFlow.setViewport).toHaveBeenCalledWith({ x: 96, y: 194, zoom: 0.5 });
+
+    unmount();
+    expect(wrapper).not.toHaveClass("canvas-wheel-navigation-active");
+  });
+});

--- a/src/hooks/__tests__/useWheelPanZoom.test.ts
+++ b/src/hooks/__tests__/useWheelPanZoom.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createViewportPanBatcher } from "../useWheelPanZoom";
+import { createPanActivityTracker, createViewportPanBatcher } from "../useWheelPanZoom";
 
 describe("createViewportPanBatcher", () => {
   it("coalesces multiple wheel events into one viewport update per frame", () => {
@@ -44,5 +44,45 @@ describe("createViewportPanBatcher", () => {
 
     expect(cancelFrame).toHaveBeenCalledWith(12);
     expect(setViewport).not.toHaveBeenCalled();
+  });
+});
+
+describe("createPanActivityTracker", () => {
+  it("keeps performance mode active until wheel activity settles", () => {
+    let endCallback: (() => void) | null = null;
+    const setActive = vi.fn();
+    const cancelEnd = vi.fn();
+    const tracker = createPanActivityTracker({
+      setActive,
+      scheduleEnd: (callback) => {
+        endCallback = callback;
+        return 9 as ReturnType<typeof setTimeout>;
+      },
+      cancelEnd,
+    });
+
+    tracker.signal();
+    tracker.signal();
+
+    expect(setActive).toHaveBeenCalledTimes(1);
+    expect(setActive).toHaveBeenCalledWith(true);
+    expect(cancelEnd).toHaveBeenCalledWith(9);
+
+    endCallback?.();
+    expect(setActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it("clears performance mode when disposed", () => {
+    const setActive = vi.fn();
+    const tracker = createPanActivityTracker({
+      setActive,
+      scheduleEnd: () => 11 as ReturnType<typeof setTimeout>,
+      cancelEnd: vi.fn(),
+    });
+
+    tracker.signal();
+    tracker.dispose();
+
+    expect(setActive).toHaveBeenLastCalledWith(false);
   });
 });

--- a/src/hooks/__tests__/useWheelPanZoom.test.ts
+++ b/src/hooks/__tests__/useWheelPanZoom.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { createViewportPanBatcher } from "../useWheelPanZoom";
+
+describe("createViewportPanBatcher", () => {
+  it("coalesces multiple wheel events into one viewport update per frame", () => {
+    let frameCallback: FrameRequestCallback | null = null;
+    const requestFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallback = callback;
+      return 7;
+    });
+    const getViewport = vi.fn(() => ({ x: 100, y: 200, zoom: 0.5 }));
+    const setViewport = vi.fn();
+    const batcher = createViewportPanBatcher({
+      getViewport,
+      setViewport,
+      requestFrame,
+      cancelFrame: vi.fn(),
+    });
+
+    batcher.queue(4, 6);
+    batcher.queue(-1, 3);
+
+    expect(requestFrame).toHaveBeenCalledTimes(1);
+    expect(setViewport).not.toHaveBeenCalled();
+
+    frameCallback?.(0);
+
+    expect(setViewport).toHaveBeenCalledTimes(1);
+    expect(setViewport).toHaveBeenCalledWith({ x: 97, y: 191, zoom: 0.5 });
+  });
+
+  it("cancels pending work when disposed", () => {
+    const cancelFrame = vi.fn();
+    const setViewport = vi.fn();
+    const batcher = createViewportPanBatcher({
+      getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+      setViewport,
+      requestFrame: () => 12,
+      cancelFrame,
+    });
+
+    batcher.queue(10, 10);
+    batcher.dispose();
+
+    expect(cancelFrame).toHaveBeenCalledWith(12);
+    expect(setViewport).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useWheelPanZoom.ts
+++ b/src/hooks/useWheelPanZoom.ts
@@ -18,6 +18,59 @@ import type { CanvasNavigationSettings } from "@/types/canvas";
 const isMacOS =
   typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
+interface ViewportState {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+interface ViewportPanBatcherOptions {
+  getViewport: () => ViewportState;
+  setViewport: (viewport: ViewportState) => void;
+  requestFrame?: (callback: FrameRequestCallback) => number;
+  cancelFrame?: (handle: number) => void;
+}
+
+export function createViewportPanBatcher({
+  getViewport,
+  setViewport,
+  requestFrame = requestAnimationFrame,
+  cancelFrame = cancelAnimationFrame,
+}: ViewportPanBatcherOptions): {
+  queue: (deltaX: number, deltaY: number) => void;
+  dispose: () => void;
+} {
+  let frameId: number | null = null;
+  let pendingDeltaX = 0;
+  let pendingDeltaY = 0;
+
+  const flush = () => {
+    frameId = null;
+    const viewport = getViewport();
+    setViewport({
+      x: viewport.x - pendingDeltaX,
+      y: viewport.y - pendingDeltaY,
+      zoom: viewport.zoom,
+    });
+    pendingDeltaX = 0;
+    pendingDeltaY = 0;
+  };
+
+  return {
+    queue(deltaX, deltaY) {
+      pendingDeltaX += deltaX;
+      pendingDeltaY += deltaY;
+      if (frameId === null) frameId = requestFrame(flush);
+    },
+    dispose() {
+      if (frameId !== null) cancelFrame(frameId);
+      frameId = null;
+      pendingDeltaX = 0;
+      pendingDeltaY = 0;
+    },
+  };
+}
+
 // Detect if a wheel event is from a mouse (vs trackpad).
 function isMouseWheel(event: WheelEvent): boolean {
   // Mouse wheels typically use deltaMode 1 (lines); trackpads use deltaMode 0
@@ -71,6 +124,7 @@ export function useWheelPanZoom(
   useEffect(() => {
     const wrapper = wrapperRef.current;
     if (!wrapper || !enabled) return;
+    const panBatcher = createViewportPanBatcher({ getViewport, setViewport });
 
     const handleWheel = (event: WheelEvent) => {
       // Let inner scroll areas (nowheel/textarea) keep their own scrolling.
@@ -105,12 +159,7 @@ export function useWheelPanZoom(
         } else {
           // Trackpad pan (also blocks horizontal swipe navigation).
           event.preventDefault();
-          const viewport = getViewport();
-          setViewport({
-            x: viewport.x - event.deltaX,
-            y: viewport.y - event.deltaY,
-            zoom: viewport.zoom,
-          });
+          panBatcher.queue(event.deltaX, event.deltaY);
         }
         return;
       }
@@ -124,6 +173,9 @@ export function useWheelPanZoom(
     };
 
     wrapper.addEventListener("wheel", handleWheel, { passive: false });
-    return () => wrapper.removeEventListener("wheel", handleWheel);
+    return () => {
+      wrapper.removeEventListener("wheel", handleWheel);
+      panBatcher.dispose();
+    };
   }, [wrapperRef, enabled, settings, getViewport, setViewport, zoomIn, zoomOut]);
 }

--- a/src/hooks/useWheelPanZoom.ts
+++ b/src/hooks/useWheelPanZoom.ts
@@ -1,6 +1,7 @@
 import { useEffect, type RefObject } from "react";
 import { useReactFlow } from "@xyflow/react";
 import type { CanvasNavigationSettings } from "@/types/canvas";
+import { setCanvasWheelPanningClass } from "@/utils/canvasPerformance";
 
 /**
  * Wheel-based pan/zoom for a React Flow canvas, honoring the user's
@@ -29,6 +30,49 @@ interface ViewportPanBatcherOptions {
   setViewport: (viewport: ViewportState) => void;
   requestFrame?: (callback: FrameRequestCallback) => number;
   cancelFrame?: (handle: number) => void;
+}
+
+interface PanActivityTrackerOptions {
+  setActive: (active: boolean) => void;
+  endDelayMs?: number;
+  scheduleEnd?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  cancelEnd?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+export function createPanActivityTracker({
+  setActive,
+  endDelayMs = 120,
+  scheduleEnd = setTimeout,
+  cancelEnd = clearTimeout,
+}: PanActivityTrackerOptions): { signal: () => void; dispose: () => void } {
+  let active = false;
+  let endTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const deactivate = () => {
+    endTimer = null;
+    if (!active) return;
+    active = false;
+    setActive(false);
+  };
+
+  return {
+    signal() {
+      if (!active) {
+        active = true;
+        setActive(true);
+      }
+      if (endTimer !== null) cancelEnd(endTimer);
+      endTimer = scheduleEnd(deactivate, endDelayMs);
+    },
+    dispose() {
+      if (endTimer !== null) cancelEnd(endTimer);
+      endTimer = null;
+      if (active) {
+        active = false;
+        setActive(false);
+      }
+    },
+  };
 }
 
 export function createViewportPanBatcher({
@@ -125,6 +169,9 @@ export function useWheelPanZoom(
     const wrapper = wrapperRef.current;
     if (!wrapper || !enabled) return;
     const panBatcher = createViewportPanBatcher({ getViewport, setViewport });
+    const panActivity = createPanActivityTracker({
+      setActive: setCanvasWheelPanningClass,
+    });
 
     const handleWheel = (event: WheelEvent) => {
       // Let inner scroll areas (nowheel/textarea) keep their own scrolling.
@@ -159,6 +206,7 @@ export function useWheelPanZoom(
         } else {
           // Trackpad pan (also blocks horizontal swipe navigation).
           event.preventDefault();
+          panActivity.signal();
           panBatcher.queue(event.deltaX, event.deltaY);
         }
         return;
@@ -176,6 +224,7 @@ export function useWheelPanZoom(
     return () => {
       wrapper.removeEventListener("wheel", handleWheel);
       panBatcher.dispose();
+      panActivity.dispose();
     };
   }, [wrapperRef, enabled, settings, getViewport, setViewport, zoomIn, zoomOut]);
 }

--- a/src/hooks/useWheelPanZoom.ts
+++ b/src/hooks/useWheelPanZoom.ts
@@ -170,7 +170,7 @@ export function useWheelPanZoom(
     if (!wrapper || !enabled) return;
     const panBatcher = createViewportPanBatcher({ getViewport, setViewport });
     const panActivity = createPanActivityTracker({
-      setActive: setCanvasWheelPanningClass,
+      setActive: (active) => setCanvasWheelPanningClass(active, wrapper),
     });
 
     const handleWheel = (event: WheelEvent) => {

--- a/src/utils/__tests__/canvasPerformance.test.ts
+++ b/src/utils/__tests__/canvasPerformance.test.ts
@@ -3,6 +3,7 @@ import {
   OVERVIEW_ZOOM_THRESHOLD,
   selectCanvasOverview,
   setCanvasPanningClass,
+  setCanvasWheelPanningClass,
 } from "../canvasPerformance";
 
 describe("canvas performance helpers", () => {
@@ -25,5 +26,15 @@ describe("canvas performance helpers", () => {
     setCanvasPanningClass(false, root);
     expect(root).toHaveClass("existing");
     expect(root).not.toHaveClass("canvas-panning");
+  });
+
+  it("toggles wheel-panning independently from React Flow gestures", () => {
+    const root = document.createElement("div");
+
+    setCanvasWheelPanningClass(true, root);
+    expect(root).toHaveClass("canvas-wheel-panning");
+
+    setCanvasWheelPanningClass(false, root);
+    expect(root).not.toHaveClass("canvas-wheel-panning");
   });
 });

--- a/src/utils/__tests__/canvasPerformance.test.ts
+++ b/src/utils/__tests__/canvasPerformance.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  OVERVIEW_ZOOM_THRESHOLD,
+  selectCanvasOverview,
+  setCanvasPanningClass,
+} from "../canvasPerformance";
+
+describe("canvas performance helpers", () => {
+  it("enters overview mode only below the zoom threshold", () => {
+    expect(selectCanvasOverview({ transform: [0, 0, OVERVIEW_ZOOM_THRESHOLD] } as never)).toBe(
+      false
+    );
+    expect(
+      selectCanvasOverview({ transform: [120, -40, OVERVIEW_ZOOM_THRESHOLD - 0.01] } as never)
+    ).toBe(true);
+  });
+
+  it("toggles the panning performance class without affecting other classes", () => {
+    const root = document.createElement("div");
+    root.classList.add("existing");
+
+    setCanvasPanningClass(true, root);
+    expect(root).toHaveClass("existing", "canvas-panning");
+
+    setCanvasPanningClass(false, root);
+    expect(root).toHaveClass("existing");
+    expect(root).not.toHaveClass("canvas-panning");
+  });
+});

--- a/src/utils/__tests__/canvasPerformance.test.ts
+++ b/src/utils/__tests__/canvasPerformance.test.ts
@@ -21,20 +21,20 @@ describe("canvas performance helpers", () => {
     root.classList.add("existing");
 
     setCanvasPanningClass(true, root);
-    expect(root).toHaveClass("existing", "canvas-panning");
+    expect(root).toHaveClass("existing", "canvas-native-navigation-active");
 
     setCanvasPanningClass(false, root);
     expect(root).toHaveClass("existing");
-    expect(root).not.toHaveClass("canvas-panning");
+    expect(root).not.toHaveClass("canvas-native-navigation-active");
   });
 
   it("toggles wheel-panning independently from React Flow gestures", () => {
     const root = document.createElement("div");
 
     setCanvasWheelPanningClass(true, root);
-    expect(root).toHaveClass("canvas-wheel-panning");
+    expect(root).toHaveClass("canvas-wheel-navigation-active");
 
     setCanvasWheelPanningClass(false, root);
-    expect(root).not.toHaveClass("canvas-wheel-panning");
+    expect(root).not.toHaveClass("canvas-wheel-navigation-active");
   });
 });

--- a/src/utils/canvasPerformance.ts
+++ b/src/utils/canvasPerformance.ts
@@ -1,6 +1,6 @@
 import type { ReactFlowState } from "@xyflow/react";
 
-export const OVERVIEW_ZOOM_THRESHOLD = 0.4;
+export const OVERVIEW_ZOOM_THRESHOLD = 0.15;
 
 export function isOverviewZoom(zoom: number): boolean {
   return zoom < OVERVIEW_ZOOM_THRESHOLD;

--- a/src/utils/canvasPerformance.ts
+++ b/src/utils/canvasPerformance.ts
@@ -1,6 +1,6 @@
 import type { ReactFlowState } from "@xyflow/react";
 
-export const OVERVIEW_ZOOM_THRESHOLD = 0.25;
+export const OVERVIEW_ZOOM_THRESHOLD = 0.4;
 
 export function isOverviewZoom(zoom: number): boolean {
   return zoom < OVERVIEW_ZOOM_THRESHOLD;
@@ -17,4 +17,11 @@ export function setCanvasPanningClass(
   root: HTMLElement = document.documentElement
 ): void {
   root.classList.toggle("canvas-panning", isPanning);
+}
+
+export function setCanvasWheelPanningClass(
+  isPanning: boolean,
+  root: HTMLElement = document.documentElement
+): void {
+  root.classList.toggle("canvas-wheel-panning", isPanning);
 }

--- a/src/utils/canvasPerformance.ts
+++ b/src/utils/canvasPerformance.ts
@@ -16,12 +16,12 @@ export function setCanvasPanningClass(
   isPanning: boolean,
   root: HTMLElement = document.documentElement
 ): void {
-  root.classList.toggle("canvas-panning", isPanning);
+  root.classList.toggle("canvas-native-navigation-active", isPanning);
 }
 
 export function setCanvasWheelPanningClass(
   isPanning: boolean,
   root: HTMLElement = document.documentElement
 ): void {
-  root.classList.toggle("canvas-wheel-panning", isPanning);
+  root.classList.toggle("canvas-wheel-navigation-active", isPanning);
 }

--- a/src/utils/canvasPerformance.ts
+++ b/src/utils/canvasPerformance.ts
@@ -14,14 +14,14 @@ export function selectCanvasOverview(
 
 export function setCanvasPanningClass(
   isPanning: boolean,
-  root: HTMLElement = document.documentElement
+  root: HTMLElement
 ): void {
   root.classList.toggle("canvas-native-navigation-active", isPanning);
 }
 
 export function setCanvasWheelPanningClass(
   isPanning: boolean,
-  root: HTMLElement = document.documentElement
+  root: HTMLElement
 ): void {
   root.classList.toggle("canvas-wheel-navigation-active", isPanning);
 }

--- a/src/utils/canvasPerformance.ts
+++ b/src/utils/canvasPerformance.ts
@@ -1,0 +1,20 @@
+import type { ReactFlowState } from "@xyflow/react";
+
+export const OVERVIEW_ZOOM_THRESHOLD = 0.25;
+
+export function isOverviewZoom(zoom: number): boolean {
+  return zoom < OVERVIEW_ZOOM_THRESHOLD;
+}
+
+export function selectCanvasOverview(
+  state: Pick<ReactFlowState, "transform">
+): boolean {
+  return isOverviewZoom(state.transform[2]);
+}
+
+export function setCanvasPanningClass(
+  isPanning: boolean,
+  root: HTMLElement = document.documentElement
+): void {
+  root.classList.toggle("canvas-panning", isPanning);
+}


### PR DESCRIPTION
## Summary
- batch trackpad viewport updates and scope navigation performance state per canvas
- reduce overview rendering work while preserving node images and panning edges
- optimize group overlay subscriptions and overview interactions
- add a close/restore toggle for the minimap
- address review findings around group draft preservation and minimap geometry

## Validation
- npm run test:run: 99 files, 2,152 tests passed
- npm run build
- verified against the 405-node / 503-edge tests2 workflow