### PR TITLE
fix: address CodeRabbit feedback for release PR

### DIFF
--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -1644,36 +1644,7 @@ export function WorkflowCanvas() {
           event.preventDefault();
           const { centerX, centerY } = getViewportCenter();
           // Offset by half the default node dimensions to center it
-          const defaultDimensions: Record<NodeType, { width: number; height: number }> = {
-            imageInput: { width: 300, height: 280 },
-            audioInput: { width: 300, height: 200 },
-            videoInput: { width: 300, height: 280 },
-            annotation: { width: 300, height: 280 },
-            prompt: { width: 320, height: 220 },
-            array: { width: 360, height: 360 },
-            promptConstructor: { width: 340, height: 280 },
-            nanoBanana: { width: 300, height: 300 },
-            generateVideo: { width: 300, height: 300 },
-            generate3d: { width: 300, height: 300 },
-            generateAudio: { width: 300, height: 280 },
-            llmGenerate: { width: 320, height: 360 },
-            splitGrid: { width: 300, height: 400 },
-            output: { width: 320, height: 320 },
-            outputGallery: { width: 320, height: 360 },
-            imageCompare: { width: 400, height: 360 },
-            videoStitch: { width: 400, height: 280 },
-            easeCurve: { width: 340, height: 480 },
-            videoTrim: { width: 360, height: 360 },
-            videoFrameGrab: { width: 320, height: 320 },
-            removeBackground: { width: 320, height: 320 },
-            imageResize: { width: 320, height: 360 },
-            gifEncoder: { width: 480, height: 380 },
-            router: { width: 200, height: 80 },
-            switch: { width: 220, height: 120 },
-            conditionalSwitch: { width: 260, height: 180 },
-            glbViewer: { width: 360, height: 380 },
-          };
-          const dims = defaultDimensions[nodeType];
+          const dims = defaultNodeDimensions[nodeType];
           addNode(nodeType, { x: centerX - dims.width / 2, y: centerY - dims.height / 2 });
           return;
         }

--- a/src/components/nodes/ControlPanel.tsx
+++ b/src/components/nodes/ControlPanel.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Node } from "@xyflow/react";
 import { useWorkflowStore, saveNanoBananaDefaults, useProviderApiKeys } from "@/store/workflowStore";
-import { NodeType, NanoBananaNodeData, LLMGenerateNodeData, GenerateVideoNodeData, Generate3DNodeData, GenerateAudioNodeData, EaseCurveNodeData, ConditionalSwitchNodeData, AspectRatio, Resolution, ModelType, ProviderType, SelectedModel, LLMProvider, LLMModelType, MatchMode, ConditionalSwitchRule } from "@/types";
+import { NodeType, NanoBananaNodeData, LLMGenerateNodeData, GenerateVideoNodeData, Generate3DNodeData, GenerateAudioNodeData, EaseCurveNodeData, ConditionalSwitchNodeData, AspectRatio, Resolution, ProviderType, SelectedModel, LLMProvider, LLMModelType, MatchMode, ConditionalSwitchRule, GEMINI_IMAGE_MODELS } from "@/types";
 import { ProviderModel, ModelCapability } from "@/lib/providers/types";
 import { ModelSearchDialog } from "@/components/modals/ModelSearchDialog";
 import { ModelParameters } from "./ModelParameters";
@@ -43,14 +43,6 @@ const EXTENDED_ASPECT_RATIOS: AspectRatio[] = ["1:1", "1:4", "1:8", "2:3", "3:2"
 // Resolutions per model
 const RESOLUTIONS_PRO: Resolution[] = ["1K", "2K", "4K"];
 const RESOLUTIONS_NB2: Resolution[] = ["512", "1K", "2K", "4K"];
-
-// Hardcoded Gemini image models
-const GEMINI_IMAGE_MODELS: { value: ModelType; label: string }[] = [
-  { value: "nano-banana", label: "Nano Banana" },
-  { value: "nano-banana-2", label: "Nano Banana 2" },
-  { value: "nano-banana-2-lite", label: "Nano Banana 2 Lite" },
-  { value: "nano-banana-pro", label: "Nano Banana Pro" },
-];
 
 // LLM providers and models
 const LLM_PROVIDERS: { value: LLMProvider; label: string }[] = [

--- a/src/components/nodes/GenerateImageNode.tsx
+++ b/src/components/nodes/GenerateImageNode.tsx
@@ -6,7 +6,7 @@ import { BaseNode } from "./BaseNode";
 import { ModelParameters } from "./ModelParameters";
 import { useWorkflowStore, saveNanoBananaDefaults, useProviderApiKeys } from "@/store/workflowStore";
 import { deduplicatedFetch } from "@/utils/deduplicatedFetch";
-import { NanoBananaNodeData, AspectRatio, Resolution, ModelType, MODEL_DISPLAY_NAMES, ProviderType, SelectedModel, ModelInputDef } from "@/types";
+import { NanoBananaNodeData, AspectRatio, Resolution, MODEL_DISPLAY_NAMES, ProviderType, SelectedModel, ModelInputDef, GEMINI_IMAGE_MODELS, ModelType } from "@/types";
 import { ProviderModel, ModelCapability } from "@/lib/providers/types";
 import { ModelSearchDialog } from "@/components/modals/ModelSearchDialog";
 import { getImageDimensions } from "@/utils/nodeDimensions";
@@ -47,14 +47,6 @@ const EXTENDED_ASPECT_RATIOS: AspectRatio[] = ["1:1", "1:4", "1:8", "2:3", "3:2"
 // Resolutions per model (nano-banana-pro: 1K-4K, nano-banana-2: 512-4K)
 const RESOLUTIONS_PRO: Resolution[] = ["1K", "2K", "4K"];
 const RESOLUTIONS_NB2: Resolution[] = ["512", "1K", "2K", "4K"];
-
-// Hardcoded Gemini image models (always available)
-const GEMINI_IMAGE_MODELS: { value: ModelType; label: string }[] = [
-  { value: "nano-banana", label: "Nano Banana" },
-  { value: "nano-banana-2", label: "Nano Banana 2" },
-  { value: "nano-banana-2-lite", label: "Nano Banana 2 Lite" },
-  { value: "nano-banana-pro", label: "Nano Banana Pro" },
-];
 
 // Image generation capabilities
 const IMAGE_CAPABILITIES: ModelCapability[] = ["text-to-image", "image-to-image"];

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -59,13 +59,13 @@ import {
   type TemplateHandleKind,
 } from "./templateCatalog";
 import {
-  GEMINI_IMAGE_MODELS,
   SplitGridTemplateNode,
   TemplateEditableEdge,
   TemplateEditorContext,
   type TemplateNodeData,
   type TemplateRFNode,
 } from "./TemplateNodes";
+import { GEMINI_IMAGE_MODELS } from "@/types";
 
 const nodeTypes: NodeTypes = {
   splitGridTemplateNode: SplitGridTemplateNode,

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -30,6 +30,7 @@ import type {
   Resolution,
   SelectedModel,
 } from "@/types";
+import { GEMINI_IMAGE_MODELS } from "@/types";
 import type { ProviderModel } from "@/lib/providers/types";
 import { ModelSearchDialog } from "../modals/ModelSearchDialog";
 import { ModelParameters } from "../nodes/ModelParameters";
@@ -91,13 +92,6 @@ export function TemplateEditableEdge({
   );
 }
 
-// Mirrors GenerateImageNode's gemini constants
-export const GEMINI_IMAGE_MODELS: { value: ModelType; label: string }[] = [
-  { value: "nano-banana", label: "Nano Banana" },
-  { value: "nano-banana-2", label: "Nano Banana 2" },
-  { value: "nano-banana-2-lite", label: "Nano Banana 2 Lite" },
-  { value: "nano-banana-pro", label: "Nano Banana Pro" },
-];
 const BASE_ASPECT_RATIOS: AspectRatio[] = ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"];
 const EXTENDED_ASPECT_RATIOS: AspectRatio[] = ["1:1", "1:4", "1:8", "2:3", "3:2", "3:4", "4:1", "4:3", "4:5", "5:4", "8:1", "9:16", "16:9", "21:9"];
 const RESOLUTIONS_PRO: Resolution[] = ["1K", "2K", "4K"];

--- a/src/hooks/__tests__/useWheelPanZoom.test.ts
+++ b/src/hooks/__tests__/useWheelPanZoom.test.ts
@@ -74,15 +74,17 @@ describe("createPanActivityTracker", () => {
 
   it("clears performance mode when disposed", () => {
     const setActive = vi.fn();
+    const cancelEnd = vi.fn();
     const tracker = createPanActivityTracker({
       setActive,
       scheduleEnd: () => 11 as ReturnType<typeof setTimeout>,
-      cancelEnd: vi.fn(),
+      cancelEnd,
     });
 
     tracker.signal();
     tracker.dispose();
 
+    expect(cancelEnd).toHaveBeenCalledWith(11);
     expect(setActive).toHaveBeenLastCalledWith(false);
   });
 });

--- a/src/store/utils/__tests__/connectedInputs.test.ts
+++ b/src/store/utils/__tests__/connectedInputs.test.ts
@@ -269,6 +269,31 @@ describe("getConnectedInputsPure", () => {
     expect(result.images).toEqual(["data:image/png;base64,a"]);
   });
 
+  it("should populate dynamicInputs through an enabled switch passthrough", () => {
+    const nodes = [
+      makeNode("img", "imageInput", { image: "data:image/png;base64,a" }),
+      makeNode("sw", "switch", {
+        inputType: "image",
+        switches: [{ id: "sw-1", name: "Output 1", enabled: true }],
+      }),
+      makeNode("gen", "nanoBanana", {
+        inputSchema: [{ name: "image_url", type: "image" }],
+      }),
+    ];
+    const edges = [
+      makeEdge("img", "sw", "image"),
+      {
+        ...makeEdge("sw", "gen", "image-0"),
+        sourceHandle: "sw-1",
+      },
+    ];
+
+    const result = getConnectedInputsPure("gen", nodes, edges);
+
+    expect(result.dynamicInputs).toEqual({ image_url: "data:image/png;base64,a" });
+    expect(result.images).toEqual(["data:image/png;base64,a"]);
+  });
+
   it("should map a connected video into dynamicInputs and videos via schema", () => {
     const nodes = [
       makeNode("vid", "videoInput", { video: "data:video/mp4;base64,v" }),

--- a/src/store/utils/__tests__/splitGridTemplate.test.ts
+++ b/src/store/utils/__tests__/splitGridTemplate.test.ts
@@ -787,6 +787,12 @@ describe("splitGridTemplate utilities", () => {
         expect(sanitizeGridOffsets([0.5, 0.5], 3)).toBeNull(); // equal, not strict
       });
 
+      it("rejects boundaries that create slices smaller than the minimum gap", () => {
+        expect(sanitizeGridOffsets([0.01, 0.5], 3)).toBeNull();
+        expect(sanitizeGridOffsets([0.4, 0.41], 3)).toBeNull();
+        expect(sanitizeGridOffsets([0.5, 0.99], 3)).toBeNull();
+      });
+
       it("rejects non-array or non-finite input", () => {
         expect(sanitizeGridOffsets(undefined, 3)).toBeNull();
         expect(sanitizeGridOffsets("nope", 3)).toBeNull();

--- a/src/store/utils/splitGridTemplate.ts
+++ b/src/store/utils/splitGridTemplate.ts
@@ -145,8 +145,8 @@ export const MIN_SLICE_GAP = 0.02;
 
 /**
  * Validates interior grid-line offsets from untrusted data. Returns the offsets
- * only when they are the right length (count-1), each strictly inside (0,1),
- * and strictly ascending; otherwise null (caller falls back to uniform).
+ * only when they are the right length (count-1), each boundary leaves the
+ * minimum slice gap, and all values are strictly inside (0,1).
  */
 export function sanitizeGridOffsets(raw: unknown, count: number): number[] | null {
   if (!Array.isArray(raw) || raw.length !== count - 1) return null;
@@ -154,8 +154,10 @@ export function sanitizeGridOffsets(raw: unknown, count: number): number[] | nul
   for (let i = 0; i < nums.length; i++) {
     const v = nums[i];
     if (!Number.isFinite(v) || v <= 0 || v >= 1) return null;
-    if (i > 0 && v <= nums[i - 1]) return null;
+    const previousBoundary = i > 0 ? nums[i - 1] : 0;
+    if (v - previousBoundary < MIN_SLICE_GAP) return null;
   }
+  if (nums.length > 0 && 1 - nums[nums.length - 1] < MIN_SLICE_GAP) return null;
   return nums;
 }
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -35,3 +35,10 @@ export const MODEL_DISPLAY_NAMES: Record<ModelType, string> = {
   "nano-banana-2": "Nano Banana 2",
   "nano-banana-2-lite": "Nano Banana 2 Lite",
 };
+
+export const GEMINI_IMAGE_MODELS: ReadonlyArray<{ value: ModelType; label: string }> = [
+  { value: "nano-banana", label: MODEL_DISPLAY_NAMES["nano-banana"] },
+  { value: "nano-banana-2", label: MODEL_DISPLAY_NAMES["nano-banana-2"] },
+  { value: "nano-banana-2-lite", label: MODEL_DISPLAY_NAMES["nano-banana-2-lite"] },
+  { value: "nano-banana-pro", label: MODEL_DISPLAY_NAMES["nano-banana-pro"] },
+];


### PR DESCRIPTION
Summary:
- Enforce the minimum slice gap when sanitizing persisted split-grid offsets.
- Reuse shared node dimensions and Gemini image model metadata.
- Add switch passthrough and wheel timer cleanup regression coverage.

CodeRabbit disposition:
- Implements the actionable inline and review-summary feedback.
- Keeps minimap visibility as ephemeral component-local UI state; it has no cross-component consumer or persistence requirement and matches neighboring canvas UI state.

Verification:
- Focused regression suite: 98 tests passed.
- Full suite: 99 files and 2,154 tests passed.
- Production build passed.