### PR TITLE
chore(release): v1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-banana",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-banana",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "@ai-sdk/google": "^3.0.13",
         "@ai-sdk/react": "^3.0.51",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-banana",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "dev": "node server.js",


### PR DESCRIPTION
## Summary

- Bump the application version from 1.7.0 to 1.8.0.
- Keep package.json and the package-lock root metadata aligned.

## Validation

- Full test suite: 99 files, 2,154 tests passed.
- Production build passed.

This prepares the existing develop-to-master release PR for the v1.8.0 tag and GitHub Release.