### PR TITLE
fix(annotation): handle uppercase undo shortcuts

### DIFF
--- a/src/components/AnnotationModal.tsx
+++ b/src/components/AnnotationModal.tsx
@@ -130,7 +130,7 @@ export function AnnotationModal() {
         }
         return;
       }
-      if ((e.ctrlKey || e.metaKey) && e.key === "z") {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "z") {
         e.preventDefault();
         e.stopImmediatePropagation();
         if (e.shiftKey) {

--- a/src/components/__tests__/AnnotationModal.test.tsx
+++ b/src/components/__tests__/AnnotationModal.test.tsx
@@ -434,9 +434,17 @@ describe("AnnotationModal", () => {
     it("should call redo when Ctrl+Shift+Z is pressed", () => {
       render(<AnnotationModal />);
 
-      fireEvent.keyDown(window, { key: "z", ctrlKey: true, shiftKey: true });
+      fireEvent.keyDown(window, { key: "Z", ctrlKey: true, shiftKey: true });
 
       expect(mockRedo).toHaveBeenCalled();
+    });
+
+    it("should call undo when the Z key is uppercase", () => {
+      render(<AnnotationModal />);
+
+      fireEvent.keyDown(window, { key: "Z", ctrlKey: true });
+
+      expect(mockUndo).toHaveBeenCalled();
     });
 
     it("should call undo when Cmd+Z is pressed (Mac)", () => {
@@ -450,7 +458,7 @@ describe("AnnotationModal", () => {
     it("should call redo when Cmd+Shift+Z is pressed (Mac)", () => {
       render(<AnnotationModal />);
 
-      fireEvent.keyDown(window, { key: "z", metaKey: true, shiftKey: true });
+      fireEvent.keyDown(window, { key: "Z", metaKey: true, shiftKey: true });
 
       expect(mockRedo).toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- Normalize the annotation modal undo/redo shortcut key before comparison.
- Exercise browser-accurate uppercase Z events for Ctrl/Cmd+Shift+Z.
- Cover uppercase Z without Shift, including Caps Lock behavior.

## Why

KeyboardEvent.key reflects Shift and Caps Lock, so the lowercase-only comparison prevented redo and could prevent undo.

## Validation

- AnnotationModal suite: 49 tests passed.
- Full repository test suite passed.
- Production build passed.