### PR TITLE
fix(models): stop classifying string settings like video_size as video inputs

### DIFF
--- a/src/app/api/models/[modelId]/__tests__/route.test.ts
+++ b/src/app/api/models/[modelId]/__tests__/route.test.ts
@@ -414,6 +414,88 @@ describe("/api/models/[modelId] schema endpoint", () => {
     });
   });
 
+  describe("isVideoInput classification", () => {
+    it("should NOT classify string settings like video_size as video inputs", async () => {
+      // Regression: string enums such as video_size ("720p"/"1080p") matched the
+      // video_ name pattern and surfaced as a bogus video handle instead of a
+      // settings parameter.
+      mockFetch.mockResolvedValueOnce(
+        createReplicateModelResponse({
+          video_size: {
+            type: "string",
+            description: "Output resolution of the generated video",
+            enum: ["720p", "1080p"],
+            default: "720p",
+          },
+          prompt: {
+            type: "string",
+            description: "Text prompt",
+          },
+        })
+      );
+
+      const modelId = `test/model-video-size-${testCounter}`;
+      const request = createMockSchemaRequest(modelId, "replicate");
+      const response = await GET(request, { params: Promise.resolve({ modelId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const paramNames = data.parameters.map((p: { name: string }) => p.name);
+      const videoInputNames = data.inputs
+        .filter((i: { type: string }) => i.type === "video")
+        .map((i: { name: string }) => i.name);
+
+      expect(paramNames).toContain("video_size");
+      expect(videoInputNames).not.toContain("video_size");
+    });
+
+    it("should classify mid-name video params like ref_video_url as video inputs", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createReplicateModelResponse({
+          ref_video_url: {
+            type: "string",
+            description: "Reference clip",
+          },
+        })
+      );
+
+      const modelId = `test/model-mid-video-${testCounter}`;
+      const request = createMockSchemaRequest(modelId, "replicate");
+      const response = await GET(request, { params: Promise.resolve({ modelId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const videoInputNames = data.inputs
+        .filter((i: { type: string }) => i.type === "video")
+        .map((i: { name: string }) => i.name);
+
+      expect(videoInputNames).toContain("ref_video_url");
+    });
+
+    it("should classify params described as a source video as video inputs", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createReplicateModelResponse({
+          media_reference: {
+            type: "string",
+            description: "URL of the source video to restyle",
+          },
+        })
+      );
+
+      const modelId = `test/model-source-video-${testCounter}`;
+      const request = createMockSchemaRequest(modelId, "replicate");
+      const response = await GET(request, { params: Promise.resolve({ modelId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      const videoInputNames = data.inputs
+        .filter((i: { type: string }) => i.type === "video")
+        .map((i: { name: string }) => i.name);
+
+      expect(videoInputNames).toContain("media_reference");
+    });
+  });
+
   describe("fal.ai provider", () => {
     it("should correctly classify inputs from fal.ai schema", async () => {
       mockFetch.mockResolvedValueOnce(

--- a/src/app/api/models/[modelId]/route.ts
+++ b/src/app/api/models/[modelId]/route.ts
@@ -70,6 +70,7 @@ const VIDEO_INPUT_PATTERNS = [
   "video_urls",
   "video",
   "videos",
+  "video_input",
   "input_video",
   "source_video",
   "init_video",
@@ -275,6 +276,15 @@ function isVideoInput(name: string, prop: Record<string, unknown>, schemaCompone
     }
   }
 
+  // Exclude counts/sizes/scales/guidance — these are settings, not video inputs.
+  // Providers commonly expose string enums like video_size ("720p"), which would
+  // otherwise match the name patterns below and surface as a bogus video input
+  // handle instead of a settings parameter.
+  if (name.includes("_count") || name.includes("_size") || name.includes("_scale") ||
+      name.includes("guidance") || name.startsWith("num_")) {
+    return false;
+  }
+
   // Check explicit patterns
   if (VIDEO_INPUT_PATTERNS.includes(name)) {
     return true;
@@ -285,12 +295,13 @@ function isVideoInput(name: string, prop: Record<string, unknown>, schemaCompone
   if (description.includes("video url") ||
       description.includes("video file") ||
       description.includes("url of the video") ||
+      description.includes("source video") ||
       description.includes("input video")) {
     return true;
   }
 
-  // Check name patterns
-  return name.endsWith("_video") || name.startsWith("video_");
+  // Check name patterns (mid-name _video_ catches e.g. ref_video_url)
+  return name.endsWith("_video") || name.startsWith("video_") || name.includes("_video_");
 }
 
 /**


### PR DESCRIPTION
## Problem

`isVideoInput` falls through to a name heuristic (`startsWith("video_")`), so
**string-typed settings** with video-ish names are classified as connectable
video inputs. The common case: `video_size` — a resolution enum
(`"720p"`/`"1080p"`) on many video models. The setting disappears from the
parameters panel and the node grows a bogus "Video Size" input handle.

Numeric settings are already safe (they fail the string/array type check),
which is why the same bug doesn't show for e.g. `guidance_scale` — it only
bites on string enums.

## Fix

Exclude settings-shaped names (`_count`, `_size`, `_scale`, `guidance`,
`num_`) before the pattern checks — mirroring the intent of the existing
image-side exclusions. While here, tighten genuine detection:

- add `video_input` to the explicit patterns
- recognize "source video" in descriptions
- match mid-name `_video_` (e.g. `ref_video_url`), which none of the existing
  patterns caught

## Testing

- Three new regression tests (`video_size` must stay a parameter;
  `ref_video_url` and a "source video"-described param must be video inputs)
  — all three fail on `develop` without the fix
- All 26 tests in the `[modelId]` route test file pass