### PR TITLE
feat(run): "Run unprocessed only" — skip already-generated nodes on re-run

### DIFF
--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -614,6 +614,20 @@ export function FloatingActionBar() {
                 Run entire workflow
               </button>
               <button
+                onClick={() => {
+                  executeWorkflow(undefined, { skipCompleted: true });
+                  setRunMenuOpen(false);
+                }}
+                className="w-full px-3 py-2 text-left text-[11px] font-medium text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors flex items-center gap-2"
+                title="Skip nodes that already generated — only run new / not-yet-generated nodes"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                </svg>
+                Run unprocessed only
+              </button>
+              <div className="h-px bg-neutral-700 my-0.5" />
+              <button
                 onClick={handleRunFromSelected}
                 disabled={!selectedNode}
                 className={`w-full px-3 py-2 text-left text-[11px] font-medium transition-colors flex items-center gap-2 ${

--- a/src/store/__tests__/workflowStore.integration.test.ts
+++ b/src/store/__tests__/workflowStore.integration.test.ts
@@ -2733,4 +2733,85 @@ describe("workflowStore integration tests", () => {
       });
     });
   });
+
+  describe("executeWorkflow — Run unprocessed only (skipCompleted)", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function setupPromptToGenerate(generateData: Record<string, unknown>) {
+      useWorkflowStore.setState({
+        nodes: [
+          createTestNode("prompt-1", "prompt", { prompt: "a banana" }),
+          createTestNode("nanoBanana-1", "nanoBanana", {
+            aspectRatio: "1:1",
+            resolution: "1K",
+            model: "nano-banana",
+            ...generateData,
+          }),
+        ],
+        edges: [createTestEdge("prompt-1", "nanoBanana-1", "text", "text")],
+      });
+    }
+
+    function calledGenerateApi(mockFetch: ReturnType<typeof vi.fn>): boolean {
+      return mockFetch.mock.calls.some((call) => String(call[0]).includes("/api/generate"));
+    }
+
+    it("should skip an already-completed generative node and preserve its output", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      setupPromptToGenerate({
+        status: "complete",
+        outputImage: "data:image/png;base64,existingOutput",
+      });
+
+      const store = useWorkflowStore.getState();
+      await store.executeWorkflow(undefined, { skipCompleted: true });
+
+      // No generation request was made, and the existing output survived untouched
+      expect(calledGenerateApi(mockFetch)).toBe(false);
+      const genNode = useWorkflowStore.getState().nodes.find(n => n.id === "nanoBanana-1");
+      expect(genNode?.data).toHaveProperty("status", "complete");
+      expect(genNode?.data).toHaveProperty("outputImage", "data:image/png;base64,existingOutput");
+    });
+
+    it("should still re-run completed nodes on a normal run (flag off)", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ success: false, error: "mock" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      setupPromptToGenerate({
+        status: "complete",
+        outputImage: "data:image/png;base64,existingOutput",
+      });
+
+      const store = useWorkflowStore.getState();
+      await store.executeWorkflow();
+
+      // Default behavior unchanged: the completed node is re-generated
+      expect(calledGenerateApi(mockFetch)).toBe(true);
+    });
+
+    it("should still run errored generative nodes in skipCompleted mode", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ success: false, error: "mock" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      setupPromptToGenerate({ status: "error", error: "previous failure" });
+
+      const store = useWorkflowStore.getState();
+      await store.executeWorkflow(undefined, { skipCompleted: true });
+
+      // Only "complete" nodes are skipped — errored/idle nodes fire as usual
+      expect(calledGenerateApi(mockFetch)).toBe(true);
+    });
+  });
 });

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -323,7 +323,7 @@ interface WorkflowStore {
   maxConcurrentCalls: number;  // Configurable concurrency limit (1-10)
   _abortController: AbortController | null;  // Internal: for cancellation
   _buildExecutionContext: (node: WorkflowNode, signal?: AbortSignal) => NodeExecutionContext;
-  executeWorkflow: (startFromNodeId?: string) => Promise<void>;
+  executeWorkflow: (startFromNodeId?: string, options?: { skipCompleted?: boolean }) => Promise<void>;
   regenerateNode: (nodeId: string) => Promise<void>;
   executeSelectedNodes: (nodeIds: string[]) => Promise<void>;
   stopWorkflow: () => void;
@@ -1586,7 +1586,7 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
     get: get as () => unknown,
   }),
 
-  executeWorkflow: async (startFromNodeId?: string) => {
+  executeWorkflow: async (startFromNodeId?: string, options?: { skipCompleted?: boolean }) => {
     // Resume support: if Run is pressed with no explicit start node while the
     // workflow is paused at a node (pause edge), resume from that node instead
     // of restarting the whole graph (which would re-run/re-bill upstream nodes
@@ -1610,6 +1610,10 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
     }
 
     const { nodes, edges, groups, maxConcurrentCalls } = get();
+
+    // "Run unprocessed only" mode: skip generative nodes that already completed.
+    const skipCompleted = options?.skipCompleted ?? false;
+    const GENERATIVE_NODE_TYPES = new Set(["nanoBanana", "generateVideo", "generate3d", "generateAudio"]);
 
     // Create AbortController for this execution run
     const abortController = new AbortController();
@@ -1685,8 +1689,19 @@ const workflowStoreImpl: StateCreator<WorkflowStore> = (set, get) => ({
         return; // Skip this node but continue with others
       }
 
-      // Check 1: Optional input node with no data → skip this node
+      // "Run unprocessed only": skip a generative node that already completed, so re-running
+      // only fills in newly-added / not-yet-generated nodes. Existing output is preserved
+      // (early return keeps node data) and still flows to downstream nodes.
       const nodeData = node.data as Record<string, unknown>;
+      if (skipCompleted && GENERATIVE_NODE_TYPES.has(node.type as string) && nodeData.status === "complete") {
+        logger.info('node.execution', 'Node skipped (already generated — run-unprocessed mode)', {
+          nodeId: node.id,
+          nodeType: node.type,
+        });
+        return;
+      }
+
+      // Check 1: Optional input node with no data → skip this node
       if (nodeData.isOptional) {
         const isEmpty =
           (node.type === "imageInput" && !nodeData.image) ||


### PR DESCRIPTION
## The workflow pain

On expensive pipelines — especially video generation — a common iteration
loop is: run a graph, review, add a few more nodes, run again. Today that
second Run re-processes (and re-bills) every generative node in the graph,
even the ones whose output you already approved.

## The feature

A new entry in the Run dropdown: **Run unprocessed only**. It re-runs the
workflow while skipping generative nodes already at status `complete`
(nanoBanana / generateVideo / generate3d / generateAudio). Only newly-added
or not-yet-generated nodes fire. Existing outputs are preserved and still
feed downstream nodes; errored and idle nodes run as usual.

Scope is deliberately "fill the blanks", not dirty-tracking: editing an input
that feeds an already-complete node won't re-run it — that's what "Run from
selected node" is for. The two compose nicely.

## Implementation

- `executeWorkflow` gains an `options.skipCompleted` flag (default off —
  normal Run is completely unchanged)
- The skip is one more early-return in the node executor, alongside the
  existing locked-group/optional-input checks
- A divider in the Run dropdown groups graph-wide vs selection actions

## Testing

Integration tests in `workflowStore.integration.test.ts`:
- completed generative node is skipped, no `/api/generate` call, output
  preserved (fails without the feature)
- default run without the flag still re-runs completed nodes (unchanged)
- errored nodes still run in skipCompleted mode