### PR TITLE
fix(comfy): keep the widgets an author promoted onto a subgraph node

### DIFF
--- a/src/lib/comfy/__tests__/editor.test.ts
+++ b/src/lib/comfy/__tests__/editor.test.ts
@@ -732,3 +732,181 @@ describe("blueprints", () => {
     expect(() => blueprintToWorkflowFile(blueprintFile(), "nope")).toThrow(ComfyConversionError);
   });
 });
+
+/* ── a workflow containing a subgraph whose widgets were promoted ── */
+
+/**
+ * The shape ComfyUI saves for a subgraph node with promoted widgets.
+ *
+ * Two things about it are easy to get wrong, and both were:
+ *
+ * - The instance's `widgets_values` line up against the *definition's* widget
+ *   boundary slots, not against the instance's own `inputs`. An instance only
+ *   materialises the slots the author wired or touched, so `inputs` is shorter
+ *   and in a different order.
+ * - App Mode addresses a promoted widget by the *instance* node, which does not
+ *   survive conversion — the subgraph is expanded into `instance:inner` ids.
+ */
+const SUBGRAPH_ID = "sub-abc";
+
+const promotedCatalog: ComfyObjectInfo = {
+  Sampler: {
+    input: {
+      required: {
+        prompt: ["STRING", { multiline: true }],
+        width: ["INT", { default: 512 }],
+        height: ["INT", { default: 512 }],
+      },
+    },
+  },
+  PrimitiveFloat: { input: { required: { value: ["FLOAT", { default: 1 }] } } },
+  VAELoader: { input: { required: { vae_name: [["a.safetensors"], {}] } } },
+  SaveImage: { input: { required: { images: ["IMAGE", {}], filename_prefix: ["STRING", {}] } } },
+};
+
+const promotedFile = (): EditorWorkflowFile =>
+  JSON.parse(
+    JSON.stringify({
+      nodes: [
+        {
+          id: 105,
+          type: SUBGRAPH_ID,
+          // Only the slots the author touched: three of the five, out of order.
+          inputs: [
+            { name: "first_frame", type: "IMAGE", link: null },
+            { name: "width", type: "INT", widget: { name: "width" }, link: null },
+            { name: "duration", type: "FLOAT", widget: { name: "duration" }, link: null },
+          ],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [90] }],
+          widgets_values: ["a red car", 1344, 768, 5, "audio.safetensors"],
+        },
+        {
+          id: 92,
+          type: "SaveImage",
+          inputs: [{ name: "images", type: "IMAGE", link: 90 }],
+          widgets_values: ["ComfyUI"],
+        },
+      ],
+      links: [{ id: 90, origin_id: 105, origin_slot: 0, target_id: 92, target_slot: 0 }],
+      extra: {
+        linearData: {
+          inputs: [
+            ["root:105:prompt", "prompt"],
+            ["root:105:duration", "duration"],
+          ],
+          outputs: ["92"],
+        },
+      },
+      definitions: {
+        subgraphs: [
+          {
+            id: SUBGRAPH_ID,
+            name: "Inner",
+            // `first_frame` is fed into a socket, so it carries no widget value
+            // and must not consume one of the positional slots.
+            inputs: [
+              { name: "first_frame", type: "IMAGE", linkIds: [] },
+              { name: "prompt", type: "STRING", linkIds: [11] },
+              { name: "width", type: "INT", linkIds: [12] },
+              { name: "height", type: "INT", linkIds: [13] },
+              { name: "duration", type: "FLOAT", label: "clip length", linkIds: [14] },
+              { name: "vae_name", type: "COMBO", linkIds: [15] },
+            ],
+            outputs: [{ name: "IMAGE", type: "IMAGE", linkIds: [16] }],
+            nodes: [
+              {
+                id: 1,
+                type: "Sampler",
+                inputs: [
+                  { name: "prompt", type: "STRING", widget: { name: "prompt" }, link: 11 },
+                  { name: "width", type: "INT", widget: { name: "width" }, link: 12 },
+                  { name: "height", type: "INT", widget: { name: "height" }, link: 13 },
+                ],
+                outputs: [{ name: "IMAGE", type: "IMAGE", links: [16] }],
+                widgets_values: ["saved prompt", 512, 512],
+              },
+              {
+                id: 2,
+                type: "PrimitiveFloat",
+                inputs: [{ name: "value", type: "FLOAT", widget: { name: "value" }, link: 14 }],
+                outputs: [{ name: "FLOAT", type: "FLOAT", links: [] }],
+                widgets_values: [1],
+              },
+              {
+                id: 3,
+                type: "VAELoader",
+                inputs: [
+                  { name: "vae_name", type: "COMBO", widget: { name: "vae_name" }, link: 15 },
+                ],
+                outputs: [{ name: "VAE", type: "VAE", links: [] }],
+                widgets_values: ["old.safetensors"],
+              },
+            ],
+            links: [
+              { id: 11, origin_id: -10, origin_slot: 1, target_id: 1, target_slot: 0 },
+              { id: 12, origin_id: -10, origin_slot: 2, target_id: 1, target_slot: 1 },
+              { id: 13, origin_id: -10, origin_slot: 3, target_id: 1, target_slot: 2 },
+              { id: 14, origin_id: -10, origin_slot: 4, target_id: 2, target_slot: 0 },
+              { id: 15, origin_id: -10, origin_slot: 5, target_id: 3, target_slot: 0 },
+            ],
+          },
+        ],
+      },
+    })
+  ) as EditorWorkflowFile;
+
+describe("a subgraph instance's promoted widget values", () => {
+  it("lines them up against the definition's slots, not the instance's inputs", () => {
+    // Zipping against the instance's three materialised inputs put the prompt
+    // string into `width`, `1344` into `duration`, and a VAE filename slot got
+    // the number 5. Every value here belongs to a different slot under the two
+    // orderings, so a regression cannot pass by coincidence.
+    const graph = convertEditorGraph(promotedFile(), promotedCatalog);
+
+    expect(graph["105:1"]?.inputs.prompt).toBe("a red car");
+    expect(graph["105:1"]?.inputs.width).toBe(1344);
+    expect(graph["105:1"]?.inputs.height).toBe(768);
+    expect(graph["105:2"]?.inputs.value).toBe(5);
+    expect(graph["105:3"]?.inputs.vae_name).toBe("audio.safetensors");
+  });
+
+  it("does not spend a value on a slot that is fed by a link", () => {
+    // `first_frame` reaches a socket, so it carries no widget value. Counting
+    // it would shift every value after it by one.
+    const graph = convertEditorGraph(promotedFile(), promotedCatalog);
+    expect(graph["105:1"]?.inputs.prompt).not.toBe(1344);
+  });
+});
+
+describe("App Mode entries that name a subgraph instance", () => {
+  it("resolves them to the inner input the boundary slot drives", () => {
+    // The author sees one control on the subgraph node; conversion expands that
+    // node away, so the id matched nothing and the control was dropped in
+    // silence — a workflow arrived with no inputs and no settings at all.
+    const file = promotedFile();
+    const graph = convertEditorGraph(file, promotedCatalog);
+    const appMode = extractAppMode(file, Object.keys(graph));
+
+    expect(appMode?.inputs).toEqual([
+      { nodeId: "105:1", widget: "prompt", label: "prompt", connectAs: "text" },
+      { nodeId: "105:2", widget: "value", label: "clip length" },
+    ]);
+  });
+
+  it("prefers the author's own name for the slot", () => {
+    // "clip length" is what they renamed it to; "PrimitiveFloat · Value" is
+    // what the inner node would have been called.
+    const file = promotedFile();
+    const graph = convertEditorGraph(file, promotedCatalog);
+    expect(extractAppMode(file, Object.keys(graph))?.inputs[1]?.label).toBe("clip length");
+  });
+
+  it("still resolves an entry that names a real node", () => {
+    const file = promotedFile();
+    file.extra!.linearData!.inputs = [["root:92:filename_prefix", "filename_prefix"]];
+    const graph = convertEditorGraph(file, promotedCatalog);
+    expect(extractAppMode(file, Object.keys(graph))?.inputs).toEqual([
+      { nodeId: "92", widget: "filename_prefix" },
+    ]);
+  });
+});

--- a/src/lib/comfy/__tests__/inspect.test.ts
+++ b/src/lib/comfy/__tests__/inspect.test.ts
@@ -302,3 +302,38 @@ describe("normalizeInputs", () => {
     expect(normalizeInputs(inputs).map((i) => i.name)).toEqual(["reference", "reference_2"]);
   });
 });
+
+describe("an App Mode whose entries all failed to resolve", () => {
+  it("detects a surface rather than proposing an empty node", () => {
+    // App Mode is followed exactly, which is right when it resolves and
+    // catastrophic when it does not: a workflow whose entries addressed a
+    // subgraph instance arrived with no inputs, no settings, and no hint that
+    // anything had been lost. Detection is a poorer answer than the author's,
+    // and a far better one than nothing.
+    const inspection = inspectWorkflow(graph(), {
+      appMode: { inputs: [{ nodeId: "does-not-exist", widget: "prompt" }], outputNodeIds: ["9"] },
+    });
+
+    // The prompt is only ever offered by detection: the curated branch adds
+    // media loaders regardless, so counting inputs would pass either way.
+    expect(inspection.suggested.inputs.map((i) => `${i.nodeId}.${i.inputKey}`)).toContain("24.text");
+    // The author's outputs are recorded separately and stay honoured.
+    expect(inspection.suggested.outputs.map((o) => o.nodeId)).toEqual(["9"]);
+  });
+
+  it("still follows App Mode when even one entry resolves", () => {
+    const inspection = inspectWorkflow(graph(), {
+      appMode: {
+        inputs: [
+          { nodeId: "does-not-exist", widget: "prompt" },
+          { nodeId: "31", widget: "steps" },
+        ],
+        outputNodeIds: ["9"],
+      },
+    });
+
+    // Curated, so the loaders are added but the KSampler's `cfg` — which the
+    // author did not expose — stays off the node.
+    expect(inspection.suggested.params.map((p) => p.inputKey)).toEqual(["steps"]);
+  });
+});

--- a/src/lib/comfy/editor.ts
+++ b/src/lib/comfy/editor.ts
@@ -320,17 +320,19 @@ function buildScope(
   for (const [slot, input] of (def?.inputs ?? []).entries()) {
     for (const linkId of input.linkIds ?? []) scope.boundaryOwner.set(linkId, slot);
   }
-  // Promoted widgets: instance inputs marked as widgets carry their values
-  // positionally in the instance's widgets_values. Keyed by NAME — an instance
-  // materializes only the boundary inputs the author touched.
+  // Promoted widget values, keyed by the boundary slot they belong to.
+  //
+  // They are stored positionally, and the list they are positional *against* is
+  // the definition's own slots — not the instance's `inputs`. The instance
+  // materialises only the slots the author wired or touched, so the two lists
+  // routinely differ in length and order. One published workflow carries nine
+  // values beside four materialised inputs, and zipping against the latter put
+  // the prompt into `width`, `1344` into `height`, and left five slots unset.
   if (instance && Array.isArray(instance.widgets_values)) {
-    let i = 0;
-    for (const input of instance.inputs ?? []) {
-      if (!input.widget) continue;
-      if (i >= instance.widgets_values.length) break;
-      scope.boundaryWidgetValue.set(input.name, instance.widgets_values[i]);
-      i += 1;
-    }
+    const values = instance.widgets_values;
+    widgetBackedSlots(def).forEach((name, index) => {
+      if (index < values.length) scope.boundaryWidgetValue.set(name, values[index]);
+    });
   }
   for (const node of nodes) {
     const childDef = defs.get(String(node.type));
@@ -351,6 +353,28 @@ function buildScope(
     }
   }
   return scope;
+}
+
+/**
+ * The boundary input slots that carry a widget value, in declaration order.
+ *
+ * A slot fed into a socket takes its value from a link and has no widget; one
+ * fed into a widget is a promoted control, and it is exactly these — in this
+ * order — that an instance's `widgets_values` lines up against.
+ */
+function widgetBackedSlots(def: SubgraphDef | null | undefined): string[] {
+  const nodes = new Map((def?.nodes ?? []).map((n) => [String(n.id), n]));
+  const targets = linkTargets(def?.links);
+  const names: string[] = [];
+  for (const slot of def?.inputs ?? []) {
+    if (!slot.name) continue;
+    const backed = (slot.linkIds ?? []).some((linkId) => {
+      const target = targets.get(linkId);
+      return target ? Boolean(nodes.get(target.target)?.inputs?.[target.slot]?.widget) : false;
+    });
+    if (backed) names.push(slot.name);
+  }
+  return names;
 }
 
 function resolveLinkId(scope: Scope, linkId: number, depth: number): Resolved | null {
@@ -664,6 +688,48 @@ export function parseAppModeInputId(
  * becoming a dead handle. Pass `knownNodeIds` from the converted graph; without
  * it only root-level nodes can be validated.
  */
+/**
+ * Where a widget promoted onto a subgraph instance actually lives.
+ *
+ * The author sees one control on the subgraph node; the graph has no such node
+ * once conversion expands it. `widget` names the boundary slot, and the control
+ * belongs to every inner input that slot drives — usually one, occasionally
+ * several, in which case they move together as a single setting.
+ */
+function promotedBindings(
+  file: EditorWorkflowFile,
+  instanceNodeId: string,
+  widget: string
+): AppModeData["inputs"] {
+  const instance = (file.nodes ?? []).find((n) => String(n.id) === instanceNodeId);
+  if (!instance) return [];
+  const def = (file.definitions?.subgraphs ?? []).find(
+    (d) => String(d.id) === String(instance.type)
+  );
+  if (!def) return [];
+
+  const [primary, ...rest] = resolveProxied(
+    file,
+    def,
+    instanceNodeId,
+    BOUNDARY_SLOT_ID,
+    widget
+  );
+  if (!primary) return [];
+
+  const slot = (def.inputs ?? []).find((s) => s.name === widget);
+  const label = slot ? slotLabel(slot, widget) : widget;
+  return [
+    {
+      nodeId: primary.nodeId,
+      widget: primary.widget,
+      ...(label ? { label } : {}),
+      ...(slot?.type === "STRING" ? { connectAs: "text" as const } : {}),
+      ...(rest.length > 0 ? { alsoBind: rest } : {}),
+    },
+  ];
+}
+
 export function extractAppMode(
   file: EditorWorkflowFile,
   knownNodeIds?: Iterable<string>
@@ -697,7 +763,17 @@ export function extractAppMode(
     const widget = String(entry[1] ?? parsed.widget ?? "");
     if (!widget) continue;
     const nodeId = resolveId(parsed.nodeId);
-    if (!nodeId) continue;
+    if (!nodeId) {
+      // The id may name a subgraph *instance*, which conversion expands away —
+      // so it matches nothing in the graph, and the author's control was being
+      // dropped without a word. The widget is then a boundary slot name, and
+      // the control belongs to whatever that slot drives inside.
+      for (const binding of promotedBindings(file, parsed.nodeId, widget)) {
+        if (inputs.some((i) => i.nodeId === binding.nodeId && i.widget === binding.widget)) continue;
+        inputs.push(binding);
+      }
+      continue;
+    }
     if (inputs.some((i) => i.nodeId === nodeId && i.widget === widget)) continue;
     inputs.push({ nodeId, widget });
   }

--- a/src/lib/comfy/inspect.ts
+++ b/src/lib/comfy/inspect.ts
@@ -270,7 +270,13 @@ export function inspectWorkflow(
   const params: ComfyAppParam[] = [];
   let outputs: ComfyAppOutput[] = [];
 
-  if (appMode) {
+  // An App Mode whose every entry failed to resolve is not a curated surface,
+  // it is a lost one — and following it exactly would propose a node with no
+  // inputs and no settings at all. Detection is a poorer answer than the
+  // author's, and a far better one than nothing.
+  const curated = (appMode?.inputs ?? []).some((entry) => graph[entry.nodeId] !== undefined);
+
+  if (curated && appMode) {
     // The author curated this surface — follow it exactly, in their order.
     for (const entry of appMode.inputs) {
       const node = graph[entry.nodeId];
@@ -336,17 +342,6 @@ export function inspectWorkflow(
       });
     }
 
-    outputs = appMode.outputNodeIds
-      .map((nodeId) => {
-        const node = graph[nodeId];
-        if (!node) return null;
-        return outputFromCandidate({
-          nodeId,
-          classType: node.class_type,
-          label: nodeLabel(nodeId, node),
-        });
-      })
-      .filter((o): o is ComfyAppOutput => o !== null);
   } else {
     for (const candidate of imageInputCandidates) {
       inputs.push(inputFromLoader(candidate, "image", taken, graph[candidate.nodeId]));
@@ -361,6 +356,20 @@ export function inspectWorkflow(
       }
     }
   }
+
+  // Outputs follow the author whether or not their inputs survived: the two are
+  // recorded separately, and one being unreadable says nothing about the other.
+  outputs = (appMode?.outputNodeIds ?? [])
+    .map((nodeId) => {
+      const node = graph[nodeId];
+      if (!node) return null;
+      return outputFromCandidate({
+        nodeId,
+        classType: node.class_type,
+        label: nodeLabel(nodeId, node),
+      });
+    })
+    .filter((o): o is ComfyAppOutput => o !== null);
 
   // Fall back to every sink when the author exposed none — a workflow with no
   // bound output would run and produce nothing the node could show.


### PR DESCRIPTION
A workflow whose subgraph carries promoted widgets arrived with no inputs and
no settings at all. Unpacking the subgraph in ComfyUI made them work, which is
the tell: expansion is where they were being lost.

Two independent faults, both silent, found with a real reported workflow.

## App Mode entries naming the subgraph instance were dropped

App Mode addresses a promoted widget by the *instance* node — `105:prompt`.
Conversion expands that node away into `105:104`, so the id matched nothing and
the entry was discarded without a word. Worse, App Mode is followed exactly once
present, so the heuristics did not fill in behind it:

| | before | after |
|---|---|---|
| inputs | *(none)* | `prompt` (text) |
| settings | Aspect Ratio, Megapixels | Aspect Ratio, Megapixels, **duration** |

The widget name is a boundary slot, and the control belongs to whatever that
slot drives inside. Resolving it that way also recovers the author's own name
for it — `duration`, rather than the derived `PrimitiveFloat · Value`.

## Promoted values were written to the wrong widgets

An instance's `widgets_values` line up against the **definition's** widget-backed
boundary slots, not against the instance's own `inputs`, which materialise only
the slots the author wired or touched. On the reported workflow that is nine
values against four inputs:

| inner input | before | after |
|---|---|---|
| `MiniMaxH3ImageToVideo.prompt` | a stale default saved inside the subgraph | the user's own prompt |
| `PrimitiveFloat.value` (duration) | `768` | `5` |
| `RandomNoise.noise_seed` | `1` | `556589502035082` |
| `VAELoader.vae_name` (audio) | `5` | `minimax_h3_audio_vae_fp32.safetensors` |

Duration was the height. The audio VAE filename was the number `5`. The prompt
the user typed was discarded. None of it reported an error — the node would have
rendered the wrong thing quietly.

## Also

An App Mode that resolves to nothing now falls back to detection rather than
proposing an empty node. Detection is a poorer answer than the author's and a
far better one than none; outputs are recorded separately, so they stay honoured
either way.

## Test plan

- `npm run test:run` — 2516 tests, 113 files
- Each fix A/B-verified: reverting it individually fails its own test and
  nothing else
- The reported workflow re-inspected end to end through `/api/comfy/inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
