### PR TITLE
fix(node): outline the whole node while it runs, settings included

### DIFF
--- a/src/components/__tests__/BaseNode.test.tsx
+++ b/src/components/__tests__/BaseNode.test.tsx
@@ -177,4 +177,59 @@ describe("BaseNode", () => {
       expect(screen.getByTestId("test-children")).toBeInTheDocument();
     });
   });
+
+  describe("the highlight around a node with an open settings panel", () => {
+    const settingsPanel = <div data-testid="settings-panel">Settings</div>;
+
+    /** The element carrying a `ring-*` class, and whether it holds the panel. */
+    const ringEnclosesSettings = (container: HTMLElement): boolean => {
+      const ringed = [...container.querySelectorAll<HTMLElement>("*")].filter((el) =>
+        /(^|\s)ring-\d/.test(el.className.toString())
+      );
+      const panel = screen.getByTestId("settings-panel");
+      return ringed.some((el) => el.contains(panel));
+    };
+
+    it("encloses the settings panel while the node is running", () => {
+      // It used to hug the body only, so a running node and a selected node
+      // were drawn as two different shapes. Reported from a Comfy app node,
+      // but BaseNode is shared, so every node with settings was affected.
+      const { container } = render(
+        <TestWrapper>
+          <BaseNode {...defaultProps} isExecuting settingsExpanded settingsPanel={settingsPanel} />
+        </TestWrapper>
+      );
+
+      expect(ringEnclosesSettings(container)).toBe(true);
+    });
+
+    it("encloses it when selected too, as it always did", () => {
+      const { container } = render(
+        <TestWrapper>
+          <BaseNode {...defaultProps} selected settingsExpanded settingsPanel={settingsPanel} />
+        </TestWrapper>
+      );
+
+      expect(ringEnclosesSettings(container)).toBe(true);
+    });
+
+    it("draws one highlight, not two, when a running node is also selected", () => {
+      const { container } = render(
+        <TestWrapper>
+          <BaseNode
+            {...defaultProps}
+            selected
+            isExecuting
+            settingsExpanded
+            settingsPanel={settingsPanel}
+          />
+        </TestWrapper>
+      );
+
+      const ringed = [...container.querySelectorAll<HTMLElement>("*")].filter((el) =>
+        /(^|\s)ring-\d/.test(el.className.toString())
+      );
+      expect(ringed).toHaveLength(1);
+    });
+  });
 });

--- a/src/components/nodes/BaseNode.tsx
+++ b/src/components/nodes/BaseNode.tsx
@@ -286,11 +286,23 @@ export function BaseNode({
   );
 
   const hasExpandedSettings = settingsExpanded && settingsPanel;
+  const running = isCurrentlyExecuting || isExecuting;
 
   return (
     <div
       className={hasExpandedSettings
-        ? `relative flex flex-col w-full h-full overflow-visible bg-neutral-800 rounded-lg ${selected ? "ring-2 ring-blue-500/40 shadow-lg shadow-blue-500/25" : ""}`
+        // Both outlines belong on this wrapper once it exists, because it is
+        // the only element that encloses the settings panel as well as the
+        // body. Selection already did this; the running outline did not, and
+        // stopped short of the settings — the same node looked like two
+        // different shapes depending on why it was highlighted.
+        ? `relative flex flex-col w-full h-full overflow-visible bg-neutral-800 rounded-lg ${
+            selected
+              ? "ring-2 ring-blue-500/40 shadow-lg shadow-blue-500/25"
+              : running
+                ? "ring-1 ring-blue-500/20"
+                : ""
+          }`
         : "contents"}
       onDoubleClick={handleResizeHandleDblClick}
       data-tutorial={hasExpandedSettings ? dataTutorial : undefined}
@@ -309,7 +321,14 @@ export function BaseNode({
           ${fullBleed
             ? `${settingsExpanded ? "rounded-t-lg border-b-0" : "rounded-lg"} bg-neutral-800/50 border border-neutral-700/40`
             : `bg-neutral-800 ${settingsExpanded ? "rounded-t-lg border-b-0" : "rounded-lg"} shadow-lg border`}
-          ${fullBleed ? "" : (isCurrentlyExecuting || isExecuting ? "border-blue-500 ring-1 ring-blue-500/20" : "border-neutral-700/60")}
+          ${fullBleed
+            ? ""
+            : running
+              // The wrapper above carries the ring when it exists, so drawing
+              // one here too would trace the body's edge through the middle of
+              // the node. Mirrors what selection does two lines down.
+              ? (hasExpandedSettings ? "border-blue-500" : "border-blue-500 ring-1 ring-blue-500/20")
+              : "border-neutral-700/60"}
           ${fullBleed ? "" : (hasError ? "border-red-500" : "")}
           ${fullBleed && selected && !settingsExpanded ? "ring-2 ring-blue-500/40 shadow-lg shadow-blue-500/25" : ""}
           ${!fullBleed && selected && !settingsExpanded ? "border-blue-500 ring-2 ring-blue-500/40 shadow-lg shadow-blue-500/25" : ""}


### PR DESCRIPTION
A running node drew its blue outline around the body only, stopping above the
settings panel. Selecting the same node outlined all of it, so the two states
described the same node as two different shapes.

Selection already handled this: it moves its ring onto the wrapper that encloses
both the body and the panel, and leaves the body a plain border. The running
outline never learned the trick — it was drawn on the body unconditionally, so
with the panel open it traced an edge through the middle of the node.

Reported on a Comfy app node, but `BaseNode` is shared, so every node type with a
settings panel had it. Also stops a node that is both running and selected from
drawing two rings.

## Test plan

- Three tests in `BaseNode.test.tsx` assert the ringed element actually contains
  the settings panel — the visual claim, expressed structurally.
- A/B: reverting the fix fails two of them and nothing else.
- `npm run test:run` — 2519 tests, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
