### PR TITLE
fix(comfy): CodeRabbit review pass, plus saved nodes and live previews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,26 @@ detected heuristically and confirmed in the dialog.
 on Cloud and local alike). Their data enters and leaves through boundary slots,
 so importing one materialises a loader per media input and a sink per output.
 
+### Live previews
+
+While a run is going, a v2 engine streams partial images over
+`GET /api/v2/jobs/{id}/events`. `/api/comfy/preview` relays those to the node,
+which shows the latent forming instead of a spinner. Two things to know:
+
+- The payload is **not** the bare JPEG the SDK's types describe. ComfyUI wraps
+  it: `[uint32 kind][uint32 jsonLength][JSON metadata][image bytes]`, and the
+  frame's own `node_id` arrives empty — the real one is in the metadata. See
+  `previewImage` in `src/lib/comfy/server/sdkEngine.ts`.
+- The same stream carries `progress`, and it is deliberately **not** used.
+  Measured against a live Cloud render it reports no node name, no step counts,
+  and a fraction computed against a node total that grows as the graph expands
+  — so it reaches 100% several times before the job ends. The job record's
+  `progress` field is `null` on Cloud throughout, despite the spec.
+
+Previews live in component state (`useComfyPreview`), never in the workflow
+store: they are 50–80KB JPEGs belonging to a run, and node data gets written
+into saved workflow files.
+
 ### Smoke tests
 
 The Blueprint corpus is the regression net for this integration — every entry
@@ -302,6 +322,7 @@ All routes in `src/app/api/`:
 | `/api/comfy/blueprints` | 2 min | List/import ComfyUI Blueprints |
 | `/api/comfy/run` | 5 min | Submit a Comfy app run |
 | `/api/comfy/poll` | 5 min | Poll a run and collect its outputs |
+| `/api/comfy/preview` | 5 min | Stream a running job's preview images (NDJSON) |
 
 ## localStorage Keys
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,24 @@ routes, which is why the legacy engine is the default there.
 | Import/confirm dialog | `src/components/modals/ComfyWorkflowImportModal.tsx` |
 | Settings tab | `src/components/settings/ComfySettingsTab.tsx` |
 | Executor | `src/store/execution/comfyAppExecutor.ts` |
+| Saved-node library | `src/lib/comfy/library.ts` |
+
+### Saved nodes
+
+A confirmed node can be kept — "Save as node" in the confirm step of the import
+and edit dialog. An entry holds the workflow, the contract *and* the values the
+node was running (seeds excluded, since they are re-randomised per run), so it
+comes back set up rather than merely attached.
+
+Saved nodes then appear as ordinary nodes: in the canvas double-click search
+under "Saved nodes", in the connection-drop menus for any handle type their
+contract matches, and in the dialog's own "Saved nodes" tab. All three create a
+plain `comfyApp` node seeded via `seedFromSavedComfyNode`; there is no new node
+type.
+
+Saving is a **snapshot**. A node created from an entry records `savedNodeId`, so
+the dialog can offer "Update saved node" as well as "Save as new"; attaching a
+different workflow clears it.
 
 ### Formats
 
@@ -291,6 +309,7 @@ All routes in `src/app/api/`:
 - `node-banana-workflow-costs` - Cost tracking per workflow
 - `node-banana-nanoBanana-defaults` - Sticky generation settings
 - `node-banana-comfy-settings` - ComfyUI backend (cloud/local/remote), keys, job timeout
+- `node-banana-comfy-apps` - Saved Comfy nodes (workflow + contract + settings)
 
 ## Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ usual way — the environment variables are for headless or shared deployments.
 
 ### Running ComfyUI workflows
 
-Any ComfyUI workflow can be dropped onto the canvas as a node (`Shift + C`).
+Drop any ComfyUI workflow onto the canvas and it becomes a node. `Shift + C`
+adds an empty ComfyUI node and opens the same dialog to pick a workflow for it.
 If the workflow was set up as an app in ComfyUI — using **App Mode** to pick
 its inputs and outputs — those selections become the node's handles and
 settings directly; otherwise Node Banana detects them and asks you to confirm.

--- a/scripts/comfy-smoke.mjs
+++ b/scripts/comfy-smoke.mjs
@@ -173,6 +173,7 @@ async function record() {
 
   const classTypes = new Set(INJECTED_CLASSES);
   const recorded = [];
+  const pending = [];
 
   for (const { id, why } of CORPUS) {
     try {
@@ -186,10 +187,13 @@ async function record() {
       collect(workflow);
       for (const sub of workflow.definitions?.subgraphs ?? []) collect(sub);
 
-      writeFileSync(
-        join(FIXTURES, "blueprints", `${id}.json`),
-        JSON.stringify({ name: entry.name ?? id, why, workflow })
-      );
+      // Held in memory, not written yet: the catalog fetch below can still
+      // fail, and fresh blueprints beside a stale object-info.json fail the
+      // hermetic test with "unknown node type" rather than "re-record me".
+      pending.push({
+        file: join(FIXTURES, "blueprints", `${id}.json`),
+        body: JSON.stringify({ name: entry.name ?? id, why, workflow }),
+      });
       recorded.push({ id, name: entry.name ?? id, why });
       ok(id);
     } catch (error) {
@@ -202,6 +206,9 @@ async function record() {
   for (const type of [...classTypes].sort()) {
     if (catalog[type]) trimmed[type] = trimEntry(catalog[type]);
   }
+
+  // Everything collected: now the corpus can be replaced as one piece.
+  for (const { file, body } of pending) writeFileSync(file, body);
   writeFileSync(join(FIXTURES, "object-info.json"), JSON.stringify(trimmed));
 
   writeFileSync(
@@ -319,6 +326,9 @@ async function runOne(id, timeoutMs) {
       // A route that says it could not reach the engine is reporting the
       // network, not a verdict — the render is very likely still going.
       if (polled.json?.transient) continue;
+      // Giving up locally does not stop the render — and it is billed. The
+      // timeout branch above already cancels; so must this one.
+      await nb("/api/comfy/poll", { jobId, app, cancel: true }).catch(() => {});
       return { id, ok: false, stage: "run", error: polled.json?.error ?? polled.text.slice(0, 200) };
     }
     if (polled.json.polling) continue;

--- a/src/app/api/comfy/__tests__/poll.route.test.ts
+++ b/src/app/api/comfy/__tests__/poll.route.test.ts
@@ -7,6 +7,10 @@
  * produced. One measured at 73 seconds against Comfy Cloud, well past the 45
  * the client allows a poll — so the download was cut off, retried from nothing,
  * and cut off again.
+ *
+ * The two limits themselves are the client's, in `comfyAppExecutor`. What this
+ * route owes is the split those limits rely on: answering "is it done?" without
+ * downloading anything when asked, which is what these cover.
  */
 
 import { NextRequest } from "next/server";
@@ -15,10 +19,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ComfyAppDefinition } from "@/lib/comfy/types";
 
 const poll = vi.fn();
+const cancel = vi.fn();
 const collectRun = vi.fn();
 
 vi.mock("@/lib/comfy/server", () => ({
-  engineFromRequest: () => ({ engine: { poll, cancel: vi.fn(), label: "Comfy Cloud" } }),
+  engineFromRequest: () => ({ engine: { poll, cancel, label: "Comfy Cloud" } }),
 }));
 
 vi.mock("@/lib/comfy/server/run", async (importOriginal) => ({
@@ -55,6 +60,7 @@ const call = (body: Record<string, unknown>) =>
 
 beforeEach(() => {
   poll.mockReset();
+  cancel.mockReset();
   collectRun.mockReset();
 });
 
@@ -88,6 +94,41 @@ describe("POST /api/comfy/poll", () => {
 
     expect(body).toMatchObject({ polling: true, status: "running" });
     expect(body.ready).toBeUndefined();
+  });
+
+  it("stops the job, and asks nothing else, when told to cancel", async () => {
+    const body = await (await call({ cancel: true })).json();
+
+    expect(cancel).toHaveBeenCalledWith("job-1", expect.anything());
+    expect(poll).not.toHaveBeenCalled();
+    expect(body).toMatchObject({ success: true, polling: false, status: "cancelled" });
+  });
+
+  it("cancels without a contract, because stopping needs no output map", async () => {
+    const response = await POST(
+      new NextRequest("http://localhost/api/comfy/poll", {
+        method: "POST",
+        body: JSON.stringify({ jobId: "job-1", cancel: true }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("says what is missing when a poll arrives with no contract", async () => {
+    // `nameFailedOutput` and `collectRun` both read it. Without this guard the
+    // failure happens inside them and reaches the caller as a bare 500.
+    const response = await POST(
+      new NextRequest("http://localhost/api/comfy/poll", {
+        method: "POST",
+        body: JSON.stringify({ jobId: "job-1" }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ success: false });
+    expect(poll).not.toHaveBeenCalled();
   });
 
   it("names the output a failed sink belongs to", async () => {

--- a/src/app/api/comfy/__tests__/run.route.test.ts
+++ b/src/app/api/comfy/__tests__/run.route.test.ts
@@ -1,0 +1,107 @@
+/**
+ * What the run route refuses to submit.
+ *
+ * Validation and the split loop have to agree on what "present" means. When
+ * they did not, an empty string sent for a required input was present enough to
+ * pass the check and absent enough to be skipped by the loop — so the job went
+ * to the engine with nothing patched in, and the user got a render from the
+ * workflow author's saved value instead of the curated 400.
+ */
+
+import { NextRequest } from "next/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { ComfyAppDefinition } from "@/lib/comfy/types";
+
+const submit = vi.fn();
+const uploadInputs = vi.fn();
+
+vi.mock("@/lib/comfy/server", () => ({
+  engineFromRequest: () => ({
+    engine: { submit, label: "Comfy Cloud" },
+    orgApiKey: null,
+  }),
+}));
+
+vi.mock("@/lib/comfy/server/run", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/comfy/server/run")>()),
+  uploadInputs,
+}));
+
+const { POST } = await import("../run/route");
+
+const app = {
+  id: "app-1",
+  name: "App",
+  description: "",
+  source: "upload",
+  graph: {
+    "3": { class_type: "CLIPTextEncode", inputs: { text: "a cat" } },
+    "9": { class_type: "SaveImage", inputs: { images: ["3", 0] } },
+  },
+  inputs: [
+    {
+      id: "3:text",
+      name: "prompt",
+      label: "Prompt",
+      type: "text" as const,
+      nodeId: "3",
+      inputKey: "text",
+      required: true,
+    },
+  ],
+  params: [],
+  outputs: [
+    { id: "9", label: "Result", type: "image" as const, nodeId: "9", classType: "SaveImage" },
+  ],
+  classTypes: ["CLIPTextEncode", "SaveImage"],
+  nodeCount: 2,
+  createdAt: 0,
+} satisfies ComfyAppDefinition;
+
+const call = (inputs: Record<string, string>) =>
+  POST(
+    new NextRequest("http://localhost/api/comfy/run", {
+      method: "POST",
+      body: JSON.stringify({ app, inputs }),
+    })
+  );
+
+beforeEach(() => {
+  submit.mockReset().mockResolvedValue("job-1");
+  uploadInputs.mockReset().mockResolvedValue({});
+});
+
+describe("POST /api/comfy/run", () => {
+  it("submits when the required input carries text", async () => {
+    const body = await (await call({ prompt: "a dog" })).json();
+
+    expect(body).toMatchObject({ success: true, jobId: "job-1" });
+    expect(submit).toHaveBeenCalledOnce();
+    const graph = submit.mock.calls[0]![0] as Record<string, { inputs: Record<string, unknown> }>;
+    expect(graph["3"]!.inputs.text).toBe("a dog");
+  });
+
+  it("refuses an empty string for a required input instead of running the author's value", async () => {
+    const response = await call({ prompt: "" });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("Prompt");
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("refuses an absent required input", async () => {
+    const response = await call({});
+
+    expect(response.status).toBe(400);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("reports the missing input before spending anything on uploads", async () => {
+    // Decoding and hashing media for a run that cannot be submitted is work
+    // thrown away, and on a large image it is not cheap work.
+    await call({});
+
+    expect(uploadInputs).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/comfy/__tests__/shared.test.ts
+++ b/src/app/api/comfy/__tests__/shared.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Getting media out of a data URL, and naming it for the engine.
+ *
+ * The failure this pins down: a data URL is allowed parameters between its
+ * media type and the `;base64` marker, and a pattern that expected the marker
+ * to follow the type directly matched no such URL at all. `decodeDataUrl` then
+ * returned null and the run route blamed the user's input — "could not read the
+ * media connected to …" — for a perfectly valid one.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { decodeDataUrl, uploadFilename } from "../shared";
+
+const text = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
+
+describe("decodeDataUrl", () => {
+  it("reads the ordinary base64 form", () => {
+    const decoded = decodeDataUrl(`data:image/png;base64,${Buffer.from("PNG").toString("base64")}`);
+
+    expect(decoded?.contentType).toBe("image/png");
+    expect(text(decoded!.bytes)).toBe("PNG");
+  });
+
+  it("reads one that carries a media-type parameter", () => {
+    const decoded = decodeDataUrl(
+      `data:text/plain;charset=utf-8;base64,${Buffer.from("hello").toString("base64")}`
+    );
+
+    // The parameter is not part of the type the engine is told about.
+    expect(decoded?.contentType).toBe("text/plain");
+    expect(text(decoded!.bytes)).toBe("hello");
+  });
+
+  it("reads a percent-encoded payload with no base64 marker", () => {
+    const decoded = decodeDataUrl("data:text/plain;charset=utf-8,hello%20there");
+
+    expect(decoded?.contentType).toBe("text/plain");
+    expect(text(decoded!.bytes)).toBe("hello there");
+  });
+
+  it("falls back to a generic type when none is given", () => {
+    const decoded = decodeDataUrl(`data:;base64,${Buffer.from("x").toString("base64")}`);
+
+    expect(decoded?.contentType).toBe("application/octet-stream");
+  });
+
+  it("returns nothing for what is not a data URL at all", () => {
+    expect(decodeDataUrl("https://example.com/cat.png")).toBeNull();
+    expect(decodeDataUrl("blob:http://localhost/abc")).toBeNull();
+    expect(decodeDataUrl("data:image/png;base64,")).toBeNull();
+  });
+});
+
+describe("uploadFilename", () => {
+  const bytes = new Uint8Array([1, 2, 3]);
+
+  it("names the file after the input, the content and its type", () => {
+    const name = uploadFilename("product", "image/png", bytes);
+
+    expect(name).toMatch(/^node-banana-product-[0-9a-f]{16}\.png$/);
+  });
+
+  it("gives the same bytes the same name, and different bytes a different one", () => {
+    // Content-addressed on purpose: the legacy upload overwrites by filename,
+    // so two concurrent runs sharing an input name would clobber each other.
+    expect(uploadFilename("in", "image/png", bytes)).toBe(uploadFilename("in", "image/png", bytes));
+    expect(uploadFilename("in", "image/png", bytes)).not.toBe(
+      uploadFilename("in", "image/png", new Uint8Array([9]))
+    );
+  });
+
+  it("keeps the suffix to the shape of an extension", () => {
+    // It reaches the engine as a filename, so an unbounded or oddly-shaped
+    // subtype is not worth passing through.
+    expect(uploadFilename("in", "image/svg+xml", bytes).endsWith(".svg")).toBe(true);
+    expect(uploadFilename("in", "application/x-a-very-long-subtype", bytes).endsWith(".bin")).toBe(
+      true
+    );
+    expect(uploadFilename("in", "application/vnd.foo bar", bytes).endsWith(".bin")).toBe(true);
+    expect(uploadFilename("in", "notatype", bytes).endsWith(".bin")).toBe(true);
+  });
+});

--- a/src/app/api/comfy/blueprints/route.ts
+++ b/src/app/api/comfy/blueprints/route.ts
@@ -24,6 +24,22 @@ import type { ComfyInspectResponse } from "../inspect/route";
 export const maxDuration = 120;
 export const dynamic = "force-dynamic";
 
+/**
+ * The retry budget has to fit inside {@link maxDuration}.
+ *
+ * `resilientFetch` retries a timeout as readily as a refused connection, so the
+ * worst case is `(retries + 1) × timeoutMs` plus backoff. Left at five attempts
+ * of thirty seconds that is 150 s against a 120 s invocation: the platform kills
+ * the function first and the caller gets a bare platform timeout instead of the
+ * curated `ComfyImportError` this route works to produce.
+ *
+ * `POST` leaves the larger share for the inspection that follows the fetch.
+ */
+const LIST_TIMEOUT_MS = 15_000;
+const LIST_RETRIES = 3; // ≈63 s worst case
+const IMPORT_TIMEOUT_MS = 15_000;
+const IMPORT_RETRIES = 2; // ≈46 s worst case, leaving ~70 s to inspect
+
 /** One entry of the engine's `/api/global_subgraphs` map. */
 interface GlobalSubgraphEntry {
   name?: string;
@@ -61,8 +77,8 @@ async function fetchCatalog(
 ): Promise<Record<string, GlobalSubgraphEntry>> {
   const res = await resilientFetch(`${connection.baseUrl}/api/global_subgraphs`, {
     headers: engineAuthHeaders(connection),
-    timeoutMs: 20_000,
-    retries: 4,
+    timeoutMs: LIST_TIMEOUT_MS,
+    retries: LIST_RETRIES,
     ...(signal ? { signal } : {}),
   });
   if (res.status === 404) {
@@ -118,8 +134,8 @@ export async function POST(request: NextRequest) {
       `${connection.baseUrl}/api/global_subgraphs/${encodeURIComponent(body.id)}`,
       {
         headers: engineAuthHeaders(connection),
-        timeoutMs: 30_000,
-        retries: 4,
+        timeoutMs: IMPORT_TIMEOUT_MS,
+        retries: IMPORT_RETRIES,
         signal: request.signal,
       }
     );

--- a/src/app/api/comfy/inspect/route.ts
+++ b/src/app/api/comfy/inspect/route.ts
@@ -49,7 +49,10 @@ function nameFromFilename(filename: string | undefined): string {
 export async function POST(request: NextRequest) {
   try {
     const raw = await request.text();
-    if (raw.length > MAX_WORKFLOW_BYTES) {
+    // Bytes, not `raw.length`: that counts UTF-16 code units, so a workflow of
+    // three-byte characters would sail past a cap named in bytes at roughly
+    // three times its size.
+    if (Buffer.byteLength(raw, "utf8") > MAX_WORKFLOW_BYTES) {
       return NextResponse.json(
         { success: false, error: "That workflow file is too large to import." },
         { status: 413 }

--- a/src/app/api/comfy/poll/route.ts
+++ b/src/app/api/comfy/poll/route.ts
@@ -67,6 +67,17 @@ export async function POST(request: NextRequest) {
       });
     }
 
+    // Checked after the cancel branch, which needs no contract — but before
+    // anything reads it. `nameFailedOutput` and `collectRun` both do, and a
+    // missing `app` failing inside them surfaces as a bare 500 rather than as
+    // the same curated 400 the run route already gives for this.
+    if (!body.app?.outputs) {
+      return NextResponse.json(
+        { success: false, error: "This node has no ComfyUI workflow attached yet." },
+        { status: 400 }
+      );
+    }
+
     const state = await engine.poll(body.jobId, request.signal);
 
     if (!state.terminal) {

--- a/src/app/api/comfy/preview/route.ts
+++ b/src/app/api/comfy/preview/route.ts
@@ -1,0 +1,81 @@
+/**
+ * Relay a running job's preview images to the browser.
+ *
+ * The engine's event stream is not reachable from the page: it needs an
+ * `Authorization` header, which `EventSource` cannot send, and the key belongs
+ * on this side of the wire anyway. So this route holds the upstream stream open
+ * and forwards only the frames the node draws.
+ *
+ * Newline-delimited JSON rather than SSE, because the client reads it with
+ * `fetch` (the only way to send the engine headers) and NDJSON needs no framing
+ * beyond `split("\n")`. Nothing here is authoritative: previews are decoration
+ * on top of the poll loop, which remains the source of truth for whether a run
+ * finished and what it produced.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { engineFromRequest } from "@/lib/comfy/server";
+import { comfyErrorResponse } from "../shared";
+
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+interface ComfyPreviewRequest {
+  jobId: string;
+}
+
+/** One frame, as the client receives it. */
+export interface ComfyPreviewMessage {
+  nodeId: string;
+  dataUrl: string;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as ComfyPreviewRequest;
+    if (!body?.jobId) {
+      return NextResponse.json({ success: false, error: "No job id" }, { status: 400 });
+    }
+
+    const { engine } = engineFromRequest(request);
+    // A stock ComfyUI has no event stream. Answering "nothing here" is the
+    // honest reply, and the caller simply keeps its spinner.
+    if (!engine.previews) return new NextResponse(null, { status: 204 });
+
+    const frames = engine.previews(body.jobId, request.signal);
+    const encoder = new TextEncoder();
+
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        try {
+          for await (const frame of frames) {
+            controller.enqueue(encoder.encode(`${JSON.stringify(frame)}\n`));
+          }
+        } catch {
+          // A dropped upstream stream ends this one. It says nothing about the
+          // job, which the poll loop is watching regardless, so it is closed
+          // quietly rather than raised as a failure the user would have to read.
+        } finally {
+          controller.close();
+        }
+      },
+      cancel() {
+        // The browser navigated away or the run ended; let the generator's
+        // `finally` close the upstream connection.
+        void frames.return(undefined);
+      },
+    });
+
+    return new NextResponse(stream, {
+      headers: {
+        "Content-Type": "application/x-ndjson",
+        "Cache-Control": "no-store, no-transform",
+        // Proxies that buffer would defeat the point of streaming at all.
+        "X-Accel-Buffering": "no",
+      },
+    });
+  } catch (error) {
+    return comfyErrorResponse(error);
+  }
+}

--- a/src/app/api/comfy/run/route.ts
+++ b/src/app/api/comfy/run/route.ts
@@ -60,6 +60,28 @@ export async function POST(request: NextRequest) {
     const { engine, orgApiKey } = engineFromRequest(request);
     const inputs = body.inputs ?? {};
 
+    // One predicate for both decisions below. Splitting them let an input be
+    // "present" for the required check (anything but `undefined`) and "absent"
+    // for the split loop (anything but a non-empty string), so an empty string
+    // sent for a required input passed validation and then reached the engine
+    // unset — a curated 400 replaced by a render from a stale widget value.
+    const provided = (name: string): boolean => {
+      const value = inputs[name];
+      return typeof value === "string" && value !== "";
+    };
+
+    // Reported before any media is decoded and hashed: there is no point
+    // spending that on a run that cannot be submitted.
+    const missingRequired = app.inputs
+      .filter((input) => input.required && !provided(input.name))
+      .map((input) => input.label);
+    if (missingRequired.length > 0) {
+      return NextResponse.json(
+        { success: false, error: `Missing required input: ${missingRequired.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
     // Split connected inputs by handle type: text is patched straight into the
     // graph, media has to reach the engine's storage first.
     const text: Record<string, string> = {};
@@ -68,7 +90,7 @@ export async function POST(request: NextRequest) {
 
     for (const input of app.inputs) {
       const value = inputs[input.name];
-      if (typeof value !== "string" || value === "") continue;
+      if (!provided(input.name)) continue;
       if (input.type === "text") {
         text[input.name] = value;
         continue;
@@ -92,16 +114,6 @@ export async function POST(request: NextRequest) {
           success: false,
           error: `Could not read the media connected to ${unreadable.join(", ")}.`,
         },
-        { status: 400 }
-      );
-    }
-
-    const missingRequired = app.inputs
-      .filter((input) => input.required && inputs[input.name] === undefined)
-      .map((input) => input.label);
-    if (missingRequired.length > 0) {
-      return NextResponse.json(
-        { success: false, error: `Missing required input: ${missingRequired.join(", ")}` },
         { status: 400 }
       );
     }

--- a/src/app/api/comfy/shared.ts
+++ b/src/app/api/comfy/shared.ts
@@ -75,7 +75,16 @@ export function comfyErrorResponse(error: unknown): NextResponse<ComfyErrorRespo
   );
 }
 
-const DATA_URL = /^data:([^;,]+)?(;base64)?,/;
+/**
+ * `data:` prefix: the media type, then any `;key=value` parameters, then the
+ * optional `;base64` marker.
+ *
+ * The parameters group is not decoration. Without it `data:text/plain;charset=utf-8;base64,…`
+ * matches nothing at all — `(;base64)?` cannot consume `;charset=utf-8`, so the
+ * required comma never matches — and the caller reports a perfectly valid input
+ * as media it could not read.
+ */
+const DATA_URL = /^data:([^;,]+)?((?:;[^;,]*)*?)(;base64)?,/;
 
 /** Decoded media from a `data:` URL. */
 export interface DecodedMedia {
@@ -97,7 +106,7 @@ export function decodeDataUrl(value: string): DecodedMedia | null {
   const contentType = match[1] || "application/octet-stream";
   const payload = value.slice(match[0].length);
   try {
-    const bytes = match[2]
+    const bytes = match[3]
       ? new Uint8Array(Buffer.from(payload, "base64"))
       : new TextEncoder().encode(decodeURIComponent(payload));
     return bytes.length > 0 ? { bytes, contentType } : null;
@@ -116,7 +125,11 @@ export function decodeDataUrl(value: string): DecodedMedia | null {
  * from re-uploading it.
  */
 export function uploadFilename(name: string, contentType: string, bytes: Uint8Array): string {
-  const ext = contentType.split("/")[1]?.split("+")[0] ?? "bin";
+  // The subtype reaches the engine as a filename suffix, so it is held to the
+  // shape of one: anything longer or stranger than a real extension is not
+  // worth guessing at.
+  const subtype = contentType.split("/")[1]?.split("+")[0] ?? "";
+  const ext = /^[a-zA-Z0-9]{1,8}$/.test(subtype) ? subtype.toLowerCase() : "bin";
   const slug = name.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 24) || "input";
   const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
   return `node-banana-${slug}-${hash}.${ext}`;

--- a/src/app/api/comfy/status/route.ts
+++ b/src/app/api/comfy/status/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
     const ping = await engine.ping(request.signal);
     let nodeCount: number | null = null;
     if (ping.ok) {
-      const catalog = await getObjectInfo(engine, { signal: request.signal }).catch(() => null);
+      const catalog = await getObjectInfo(engine).catch(() => null);
       nodeCount = catalog ? Object.keys(catalog).length : null;
     }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -236,24 +236,42 @@ body {
   border-bottom: none !important;
 }
 
-/* Custom scrollbar */
+/* Scrollbars.
+ *
+ * A thumb and nothing else. The groove is chrome nobody asked for, and it drew
+ * a hard grey rule down the side of every panel — most visible where panels
+ * nest, which is most places.
+ *
+ * The thumb is inset by a transparent border rather than by making the bar
+ * narrower: the visible mark is 4px, while the thing you have to hit stays 8px.
+ * Its colour is translucent white rather than a fixed grey so that one rule
+ * reads correctly on all of the surfaces the app stacks — the canvas, panels,
+ * dialogs and the settings drawer are four different darks. */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.16) transparent;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
-::-webkit-scrollbar-track {
-  background: #262626;
-  border-radius: 4px;
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #525252;
-  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.16);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+  border-radius: 999px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #737373;
+  background: rgba(255, 255, 255, 0.32);
+  background-clip: padding-box;
 }
 
 /* Make the multi-selection box pass through pointer events so we can still

--- a/src/components/ConnectionDropMenu.tsx
+++ b/src/components/ConnectionDropMenu.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { NodeType } from "@/types";
+import { useSavedComfyNodes } from "@/hooks/useSavedComfyNodes";
+import type { SavedComfyNode } from "@/lib/comfy/library";
 import { ComfyMark } from "./icons/ComfyMark";
 
 // Actions are special menu items that trigger behavior instead of creating a node
@@ -12,7 +14,16 @@ export interface MenuOption {
   label: string;
   icon: React.ReactNode;
   isAction?: boolean; // true if this is an action, not a node type
+  /**
+   * Set on a saved Comfy node. The type is still `comfyApp` — a saved node is
+   * that node arriving with its workflow already attached, not a new kind of
+   * node — so this is what tells the canvas which one to attach.
+   */
+  savedNodeId?: string;
 }
+
+/** Menu entries repeat node types once saved nodes are in the list. */
+export const optionKey = (option: MenuOption): string => option.savedNodeId ?? option.type;
 
 // Define which nodes can accept which handle types as inputs
 const IMAGE_TARGET_OPTIONS: MenuOption[] = [
@@ -791,11 +802,47 @@ export const ALL_NODE_OPTIONS: MenuOption[] = (() => {
   return all.sort((a, b) => a.label.localeCompare(b.label));
 })();
 
+/** Saved Comfy nodes as menu entries, in the order the library lists them. */
+export function savedComfyOptions(saved: SavedComfyNode[]): MenuOption[] {
+  return saved.map((entry) => ({
+    type: "comfyApp" as NodeType,
+    label: entry.name,
+    icon: <ComfyMark className="w-3.5 h-4" />,
+    savedNodeId: entry.id,
+  }));
+}
+
+/**
+ * The saved nodes that can join a wire of this type.
+ *
+ * Dragging from an output looks for a node that can take it, so the match is
+ * against the saved node's inputs; dragging from an input is the other way
+ * round. This is what makes a saved node behave like a built-in one — it turns
+ * up when it is useful, rather than only when asked for by name.
+ */
+export function savedComfyOptionsFor(
+  saved: SavedComfyNode[],
+  handleType: string,
+  connectionType: "source" | "target"
+): MenuOption[] {
+  return savedComfyOptions(
+    saved.filter((entry) =>
+      connectionType === "source"
+        ? entry.app.inputs.some((input) => input.type === handleType)
+        : entry.app.outputs.some((output) => output.type === handleType)
+    )
+  );
+}
+
 interface ConnectionDropMenuProps {
   position: { x: number; y: number };
   handleType: "image" | "text" | "video" | "audio" | "3d" | "easeCurve" | null;
   connectionType: "source" | "target"; // source = dragging from output, target = dragging from input
-  onSelect: (selection: { type: NodeType | MenuAction; isAction: boolean }) => void;
+  onSelect: (selection: {
+    type: NodeType | MenuAction;
+    isAction: boolean;
+    savedNodeId?: string;
+  }) => void;
   onClose: () => void;
 }
 
@@ -808,25 +855,31 @@ export function ConnectionDropMenu({
 }: ConnectionDropMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const savedNodes = useSavedComfyNodes();
 
   // Get the appropriate node options based on handle type and connection direction
   const getOptions = useCallback((): MenuOption[] => {
     if (!handleType) return [];
+    // Appended rather than interleaved: the built-ins are a fixed list people
+    // learn the shape of, and a saved node dropping into the middle of it would
+    // move everything below it each time one is saved.
+    const saved = savedComfyOptionsFor(savedNodes, handleType, connectionType);
+    const withSaved = (options: MenuOption[]): MenuOption[] => [...options, ...saved];
 
     if (connectionType === "source") {
       // Dragging from a source handle (output), need nodes with target handles (inputs)
-      if (handleType === "video") return VIDEO_TARGET_OPTIONS;
-      if (handleType === "audio") return AUDIO_TARGET_OPTIONS;
-      if (handleType === "3d") return THREE_D_TARGET_OPTIONS;
-      return handleType === "image" ? IMAGE_TARGET_OPTIONS : TEXT_TARGET_OPTIONS;
+      if (handleType === "video") return withSaved(VIDEO_TARGET_OPTIONS);
+      if (handleType === "audio") return withSaved(AUDIO_TARGET_OPTIONS);
+      if (handleType === "3d") return withSaved(THREE_D_TARGET_OPTIONS);
+      return withSaved(handleType === "image" ? IMAGE_TARGET_OPTIONS : TEXT_TARGET_OPTIONS);
     } else {
       // Dragging from a target handle (input), need nodes with source handles (outputs)
-      if (handleType === "video") return VIDEO_SOURCE_OPTIONS;
-      if (handleType === "audio") return AUDIO_SOURCE_OPTIONS;
-      if (handleType === "3d") return THREE_D_SOURCE_OPTIONS;
-      return handleType === "image" ? IMAGE_SOURCE_OPTIONS : TEXT_SOURCE_OPTIONS;
+      if (handleType === "video") return withSaved(VIDEO_SOURCE_OPTIONS);
+      if (handleType === "audio") return withSaved(AUDIO_SOURCE_OPTIONS);
+      if (handleType === "3d") return withSaved(THREE_D_SOURCE_OPTIONS);
+      return withSaved(handleType === "image" ? IMAGE_SOURCE_OPTIONS : TEXT_SOURCE_OPTIONS);
     }
-  }, [handleType, connectionType]);
+  }, [handleType, connectionType, savedNodes]);
 
   const options = getOptions();
 
@@ -845,9 +898,11 @@ export function ConnectionDropMenu({
         case "Enter":
           e.preventDefault();
           if (options[selectedIndex]) {
+            const option = options[selectedIndex];
             onSelect({
-              type: options[selectedIndex].type,
-              isAction: options[selectedIndex].isAction || false,
+              type: option.type,
+              isAction: option.isAction || false,
+              ...(option.savedNodeId ? { savedNodeId: option.savedNodeId } : {}),
             });
           }
           break;
@@ -901,8 +956,14 @@ export function ConnectionDropMenu({
       <div className="py-1">
         {options.map((option, index) => (
           <button
-            key={option.type}
-            onClick={() => onSelect({ type: option.type, isAction: option.isAction || false })}
+            key={optionKey(option)}
+            onClick={() =>
+              onSelect({
+                type: option.type,
+                isAction: option.isAction || false,
+                ...(option.savedNodeId ? { savedNodeId: option.savedNodeId } : {}),
+              })
+            }
             onMouseEnter={() => setSelectedIndex(index)}
             data-tutorial={option.type === "nanoBanana" ? "generate-image-option" : undefined}
             className={`w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 transition-colors ${

--- a/src/components/NodeSearchMenu.tsx
+++ b/src/components/NodeSearchMenu.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { NodeType } from "@/types";
-import { ALL_NODE_OPTIONS } from "./ConnectionDropMenu";
+import { useSavedComfyNodes } from "@/hooks/useSavedComfyNodes";
+import { ALL_NODE_OPTIONS, optionKey, savedComfyOptions } from "./ConnectionDropMenu";
 
 interface NodeSearchMenuProps {
   /** Screen position (clientX/clientY) where the menu should anchor. */
   position: { x: number; y: number };
-  onSelect: (type: NodeType) => void;
+  /** `savedNodeId` is set when the pick is a saved Comfy node. */
+  onSelect: (type: NodeType, savedNodeId?: string) => void;
   onClose: () => void;
 }
 
@@ -28,15 +30,25 @@ export function NodeSearchMenu({ position, onSelect, onClose }: NodeSearchMenuPr
   const [search, setSearch] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
 
+  const savedNodes = useSavedComfyNodes();
+
+  // Saved nodes sit after the built-ins under their own heading rather than
+  // being sorted in among them: the built-in list has a shape people learn, and
+  // it should not shuffle every time a workflow is saved.
+  const options = useMemo(
+    () => [...ALL_NODE_OPTIONS, ...savedComfyOptions(savedNodes)],
+    [savedNodes]
+  );
+
   const filtered = useMemo(() => {
     const query = search.trim().toLowerCase();
-    if (!query) return ALL_NODE_OPTIONS;
-    return ALL_NODE_OPTIONS.filter(
+    if (!query) return options;
+    return options.filter(
       (option) =>
         option.label.toLowerCase().includes(query) ||
         option.type.toLowerCase().includes(query)
     );
-  }, [search]);
+  }, [search, options]);
 
   // Reset the highlight to the top whenever the filtered list changes.
   useEffect(() => {
@@ -93,7 +105,7 @@ export function NodeSearchMenu({ position, onSelect, onClose }: NodeSearchMenuPr
     } else if (e.key === "Enter") {
       e.preventDefault();
       const option = filtered[selectedIndex];
-      if (option) onSelect(option.type as NodeType);
+      if (option) onSelect(option.type as NodeType, option.savedNodeId);
     } else if (e.key === "Escape") {
       e.preventDefault();
       onClose();
@@ -130,10 +142,17 @@ export function NodeSearchMenu({ position, onSelect, onClose }: NodeSearchMenuPr
           </div>
         ) : (
           filtered.map((option, index) => (
+            <Fragment key={optionKey(option)}>
+              {/* Once, above the first of them — the built-ins above are a
+                  fixed set, these are the user's own. */}
+              {option.savedNodeId && !filtered[index - 1]?.savedNodeId && (
+                <div className="px-3 pt-2 pb-1 text-[9px] uppercase tracking-wide text-neutral-500">
+                  Saved nodes
+                </div>
+              )}
             <button
-              key={option.type}
               data-index={index}
-              onClick={() => onSelect(option.type as NodeType)}
+              onClick={() => onSelect(option.type as NodeType, option.savedNodeId)}
               onMouseMove={(e) => {
                 // Only re-select on genuine cursor movement. When keyboard nav
                 // scrolls the list under a stationary cursor, the browser may
@@ -151,8 +170,11 @@ export function NodeSearchMenu({ position, onSelect, onClose }: NodeSearchMenuPr
               }`}
             >
               {option.icon}
-              {option.label}
+              {/* min-w-0, or a long saved-node name pushes the menu wider
+                  instead of ellipsing. */}
+              <span className="min-w-0 truncate">{option.label}</span>
             </button>
+            </Fragment>
           ))
         )}
       </div>

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -62,8 +62,10 @@ import { MultiSelectToolbar } from "./MultiSelectToolbar";
 import { EdgeToolbar } from "./EdgeToolbar";
 import { GlobalImageHistory } from "./GlobalImageHistory";
 import { GroupBackgroundsPortal, GroupControlsOverlay } from "./GroupsOverlay";
-import { NodeType, NanoBananaNodeData, HandleType, PromptNodeData, LLMGenerateNodeData, PromptConstructorNodeData, AvailableVariable } from "@/types";
+import { NodeType, NanoBananaNodeData, HandleType, PromptNodeData, LLMGenerateNodeData, PromptConstructorNodeData, AvailableVariable, WorkflowNodeData } from "@/types";
 import { isComfyWorkflow, isNodeBananaWorkflow } from "@/lib/comfy/detect";
+import { getSavedComfyNode, seedFromSavedComfyNode } from "@/lib/comfy/library";
+import { appInputHandles } from "@/lib/comfy/nodeSchema";
 import { ComfyWordmark } from "./icons/ComfyWordmark";
 import { defaultNodeDimensions } from "@/store/utils/nodeDefaults";
 import { FloatingNodeHeader } from "./nodes/FloatingNodeHeader";
@@ -1340,7 +1342,7 @@ export function WorkflowCanvas() {
 
   // Handle node selection from drop menu
   const handleMenuSelect = useCallback(
-    (selection: { type: NodeType | MenuAction; isAction: boolean }) => {
+    (selection: { type: NodeType | MenuAction; isAction: boolean; savedNodeId?: string }) => {
       if (!connectionDrop) return;
 
       const { flowPosition, sourceNodeId, sourceHandleId, connectionType, handleType } = connectionDrop;
@@ -1357,8 +1359,16 @@ export function WorkflowCanvas() {
       // Regular node creation
       const nodeType = selection.type as NodeType;
 
+      // A saved Comfy node is created with its workflow already on it, which is
+      // what gives it handles for the dropped wire to land on.
+      const saved = selection.savedNodeId ? getSavedComfyNode(selection.savedNodeId) : null;
+
       // Create the new node at the drop position (empty - tutorial will populate after connection)
-      const newNodeId = addNode(nodeType, flowPosition);
+      const newNodeId = addNode(
+        nodeType,
+        flowPosition,
+        saved ? (seedFromSavedComfyNode(saved) as Partial<WorkflowNodeData>) : undefined
+      );
 
       // Tutorial tracking
       if (tutorialActive && nodeType === "nanoBanana") {
@@ -1368,7 +1378,7 @@ export function WorkflowCanvas() {
       // A fresh Comfy app node has no handles until a workflow is attached, so
       // the dropped connection has nothing to land on. Open the import dialog
       // straight away rather than leaving an empty node and a lost wire.
-      if (nodeType === "comfyApp") {
+      if (nodeType === "comfyApp" && !saved) {
         updateNodeData(newNodeId, { _autoOpenImport: true });
       }
 
@@ -1388,7 +1398,14 @@ export function WorkflowCanvas() {
       // Note: New nodes start with default handles (image, text) before a model is selected
 
       // Router accepts and outputs all types — use the connection's handle type
-      if (nodeType === "router") {
+      if (saved) {
+        // Its handles come from the workflow's own contract, so the wire is
+        // matched against that rather than against a table of node types.
+        targetHandleId =
+          appInputHandles(saved.app).find((input) => input.type === handleType)?.handleId ?? null;
+        sourceHandleIdForNewNode =
+          saved.app.outputs.find((output) => output.type === handleType)?.id ?? null;
+      } else if (nodeType === "router") {
         if (handleType) {
           targetHandleId = handleType;
           sourceHandleIdForNewNode = handleType;
@@ -1623,9 +1640,14 @@ export function WorkflowCanvas() {
   );
 
   const handleNodeSearchSelect = useCallback(
-    (type: NodeType) => {
+    (type: NodeType, savedNodeId?: string) => {
       if (nodeSearchMenu) {
-        addNode(type, nodeSearchMenu.flowPosition);
+        const saved = savedNodeId ? getSavedComfyNode(savedNodeId) : null;
+        addNode(
+          type,
+          nodeSearchMenu.flowPosition,
+          saved ? (seedFromSavedComfyNode(saved) as Partial<WorkflowNodeData>) : undefined
+        );
       }
       setNodeSearchMenu(null);
     },

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -745,9 +745,9 @@ export function WorkflowCanvas() {
           const targetNode = nodes.find((n) => n.id === connection.target);
           if (targetNode?.type === "output" || targetNode?.type === "router") return true;
         }
-        if (sourceNode?.type === "comfyApp" || targetNode?.type === "comfyApp") {
-          return sourceType === "audio" && targetType === "audio";
-        }
+        // A Comfy app needs no clause of its own here: audio-to-audio is what
+        // the fallthrough already allows it, and the early return above covers
+        // the only ends that take audio on a differently-typed handle.
         return sourceType === "audio" && targetType === "audio";
       }
 
@@ -966,6 +966,33 @@ export function WorkflowCanvas() {
       ): string | null => {
         // Check for dynamic inputSchema first
         const nodeData = node.data as { inputSchema?: Array<{ name: string; type: string }> };
+
+        // A Comfy app's handles come entirely from its attached workflow, and
+        // its outputs are declared independently of its inputs — a text-to-image
+        // app with nothing to connect has an empty `inputSchema` and a perfectly
+        // good image output. Resolved before the schema check for that reason:
+        // dragging onto such a node used to find nothing and drop the wire.
+        if (node.type === "comfyApp") {
+          if (needInput) {
+            const matching = (nodeData.inputSchema ?? []).filter((i) => i.type === handleType);
+            for (let i = 0; i < matching.length; i += 1) {
+              const candidateHandle = `${handleType}-${i}`;
+              const isOccupied =
+                edges.some(
+                  (edge) => edge.target === node.id && edge.targetHandle === candidateHandle
+                ) || batchUsed?.has(candidateHandle);
+              if (!isOccupied) return candidateHandle;
+            }
+            return null;
+          }
+          // Output handle ids are ComfyUI node ids, so no naming convention
+          // decodes them — and the static list below is a superset kept for
+          // connection *validation*, not a set of handles this node renders.
+          const app = (node.data as { app?: { outputs?: Array<{ id: string; type: string }> } })
+            .app;
+          return app?.outputs?.find((o) => o.type === handleType)?.id ?? null;
+        }
+
         if (nodeData.inputSchema && nodeData.inputSchema.length > 0) {
           if (needInput) {
             // Find input handles matching the type
@@ -989,13 +1016,6 @@ export function WorkflowCanvas() {
             // to the output branch below would hand back an OUTPUT handle as
             // the connection target, so stop here instead.
             return null;
-          }
-          // A Comfy app's outputs are declared by the attached workflow, and
-          // their handle ids are ComfyUI node ids — the generic names below
-          // would produce an edge from a handle that does not exist.
-          if (node.type === "comfyApp") {
-            const app = (node.data as { app?: { outputs?: Array<{ id: string; type: string }> } }).app;
-            return app?.outputs?.find((o) => o.type === handleType)?.id ?? null;
           }
           // Output handle - check for video, 3d, or image type
           if (handleType === "video") return "video";
@@ -1063,13 +1083,6 @@ export function WorkflowCanvas() {
             return "default";
           }
         }
-
-        // A Comfy app node's handles come entirely from its attached workflow.
-        // The static list below is a superset for connection *validation*, not a
-        // set of real handles, so using it here would create an edge bound to a
-        // handle the node never renders — invisible, unselectable, and still
-        // counted as a dependency by the topological sort.
-        if (node.type === "comfyApp") return null;
 
         // Fall back to static handles
         const staticHandles = getNodeHandles(node.type || "");
@@ -2112,7 +2125,14 @@ export function WorkflowCanvas() {
             return;
           }
           if (isNodeBananaWorkflow(parsed)) {
-            await loadWorkflow(parsed as WorkflowFile);
+            // Reported the same way the parse failure above is: without this the
+            // rejection is unhandled and the canvas simply does not change.
+            try {
+              await loadWorkflow(parsed as WorkflowFile);
+            } catch (err) {
+              console.error("Failed to load workflow:", err);
+              alert("Failed to load workflow file");
+            }
             return;
           }
           // A ComfyUI workflow becomes a node rather than replacing the canvas.

--- a/src/components/__tests__/BaseNode.test.tsx
+++ b/src/components/__tests__/BaseNode.test.tsx
@@ -181,13 +181,20 @@ describe("BaseNode", () => {
   describe("the highlight around a node with an open settings panel", () => {
     const settingsPanel = <div data-testid="settings-panel">Settings</div>;
 
-    /** The element carrying a `ring-*` class, and whether it holds the panel. */
-    const ringEnclosesSettings = (container: HTMLElement): boolean => {
-      const ringed = [...container.querySelectorAll<HTMLElement>("*")].filter((el) =>
-        /(^|\s)ring-\d/.test(el.className.toString())
-      );
+    /**
+     * The element whose ring encloses the settings panel.
+     *
+     * Weight is part of the assertion, not decoration: the first fix put a
+     * `ring-1 ring-blue-500/20` here, which satisfies "a ring encloses the
+     * panel" and yet is invisible on the canvas — 1px at 20% opacity over a
+     * near-black background. The bug survived a passing test, so the test now
+     * describes an outline you can actually see.
+     */
+    const enclosingRing = (container: HTMLElement): HTMLElement | undefined => {
       const panel = screen.getByTestId("settings-panel");
-      return ringed.some((el) => el.contains(panel));
+      return [...container.querySelectorAll<HTMLElement>("*")].find(
+        (el) => /(^|\s)ring-\d/.test(el.className.toString()) && el.contains(panel)
+      );
     };
 
     it("encloses the settings panel while the node is running", () => {
@@ -200,7 +207,25 @@ describe("BaseNode", () => {
         </TestWrapper>
       );
 
-      expect(ringEnclosesSettings(container)).toBe(true);
+      const ring = enclosingRing(container);
+      expect(ring).toBeDefined();
+      expect(ring).toHaveClass("ring-1", "ring-blue-500");
+    });
+
+    it("draws that outline once, not once per section", () => {
+      // The body used to keep its own blue border under the wrapper's ring, so
+      // the node wore two lines down its sides and one down the settings.
+      const { container } = render(
+        <TestWrapper>
+          <BaseNode {...defaultProps} isExecuting settingsExpanded settingsPanel={settingsPanel} />
+        </TestWrapper>
+      );
+
+      const ring = enclosingRing(container)!;
+      const blueInside = [...ring.querySelectorAll<HTMLElement>("*")].filter((el) =>
+        /(^|\s)border-blue-500(\s|$)/.test(el.className.toString())
+      );
+      expect(blueInside).toHaveLength(0);
     });
 
     it("encloses it when selected too, as it always did", () => {
@@ -210,10 +235,12 @@ describe("BaseNode", () => {
         </TestWrapper>
       );
 
-      expect(ringEnclosesSettings(container)).toBe(true);
+      const ring = enclosingRing(container);
+      expect(ring).toBeDefined();
+      expect(ring).toHaveClass("ring-2", "ring-blue-500/40");
     });
 
-    it("draws one highlight, not two, when a running node is also selected", () => {
+    it("draws one ring, not two, when a running node is also selected", () => {
       const { container } = render(
         <TestWrapper>
           <BaseNode

--- a/src/components/__tests__/ComfyAppPreview.test.tsx
+++ b/src/components/__tests__/ComfyAppPreview.test.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReactFlowProvider } from "@xyflow/react";
+
+import { ComfyAppNode } from "@/components/nodes/ComfyAppNode";
+import type { ComfyAppDefinition } from "@/lib/comfy/types";
+import type { ComfyAppNodeData } from "@/types";
+
+/**
+ * What a running Comfy node shows.
+ *
+ * The latent where the engine sends one, the spinner everywhere else — the
+ * first seconds of any run, and every run on a stock ComfyUI, which has no
+ * event stream at all.
+ */
+
+const mockUpdateNodeData = vi.fn();
+const mockUseWorkflowStore = vi.fn();
+const mockPreview = vi.fn<() => string | null>(() => null);
+
+vi.mock("@/store/workflowStore", () => ({
+  useWorkflowStore: (selector?: (state: unknown) => unknown) =>
+    selector ? mockUseWorkflowStore(selector) : mockUseWorkflowStore((s: unknown) => s),
+}));
+
+vi.mock("@/hooks/useComfyPreview", () => ({
+  useComfyPreview: () => mockPreview(),
+}));
+
+vi.mock("@xyflow/react", async () => {
+  const actual = await vi.importActual<typeof import("@xyflow/react")>("@xyflow/react");
+  return {
+    ...actual,
+    useUpdateNodeInternals: () => vi.fn(),
+    useReactFlow: () => ({
+      getNodes: vi.fn(() => []),
+      setNodes: vi.fn(),
+      screenToFlowPosition: vi.fn((pos: unknown) => pos),
+    }),
+  };
+});
+
+const app = (): ComfyAppDefinition => ({
+  id: "app-1",
+  name: "Upscale Pass",
+  description: "",
+  source: "upload",
+  graph: {},
+  inputs: [],
+  params: [],
+  outputs: [{ id: "9", label: "Result", type: "image", nodeId: "9", classType: "SaveImage" }],
+  classTypes: [],
+  nodeCount: 2,
+  createdAt: 0,
+});
+
+const nodeData = (over: Partial<ComfyAppNodeData> = {}): ComfyAppNodeData => ({
+  app: app(),
+  paramValues: {},
+  outputs: {},
+  outputImage: null,
+  outputVideo: null,
+  outputAudio: null,
+  outputText: null,
+  output3dUrl: null,
+  status: "loading",
+  runStatus: "running",
+  jobId: "job_1",
+  error: null,
+  ...over,
+});
+
+const tree = (data: ComfyAppNodeData) => (
+  <ReactFlowProvider>
+    <ComfyAppNode
+      id="comfyApp-1"
+      type="comfyApp"
+      data={data}
+      selected={false}
+      dragging={false}
+      draggable
+      selectable
+      deletable
+      zIndex={0}
+      isConnectable
+      positionAbsoluteX={0}
+      positionAbsoluteY={0}
+    />
+  </ReactFlowProvider>
+);
+
+const LATENT = "data:image/jpeg;base64,AAAA";
+
+describe("a running Comfy node", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPreview.mockReturnValue(null);
+    mockUseWorkflowStore.mockImplementation((selector: (state: unknown) => unknown) =>
+      selector({
+        updateNodeData: mockUpdateNodeData,
+        edges: [],
+        removeEdge: vi.fn(),
+        currentNodeIds: [],
+        setHoveredNodeId: vi.fn(),
+      })
+    );
+  });
+
+  it("shows the latent once the engine sends one", () => {
+    mockPreview.mockReturnValue(LATENT);
+    render(tree(nodeData()));
+
+    expect(screen.getByAltText("Rendering")).toHaveAttribute("src", LATENT);
+  });
+
+  it("still says it is running, over the image", () => {
+    // The preview looks like a finished result at a glance, especially late in
+    // a render — without this the node reads as done.
+    mockPreview.mockReturnValue(LATENT);
+    render(tree(nodeData()));
+
+    expect(screen.getByText("Rendering…")).toBeInTheDocument();
+  });
+
+  it("keeps the spinner when no preview has arrived", () => {
+    // Every run starts here, and a stock ComfyUI never leaves it.
+    render(tree(nodeData()));
+
+    expect(screen.queryByAltText("Rendering")).not.toBeInTheDocument();
+    expect(screen.getByText("Rendering…")).toBeInTheDocument();
+  });
+
+  it("shows the real result once the run is done, not the last latent", () => {
+    // The preview is a lossy, half-finished JPEG; the output is the thing the
+    // user asked for, and downstream nodes get that one.
+    mockPreview.mockReturnValue(LATENT);
+    render(
+      tree(
+        nodeData({
+          status: "complete",
+          runStatus: null,
+          jobId: null,
+          outputs: { "9": "data:image/png;base64,FINAL" },
+        })
+      )
+    );
+
+    expect(screen.queryByAltText("Rendering")).not.toBeInTheDocument();
+    expect(screen.getByAltText("Result")).toHaveAttribute(
+      "src",
+      "data:image/png;base64,FINAL"
+    );
+  });
+
+  it("shows the error, not a stale latent, when the run fails", () => {
+    mockPreview.mockReturnValue(LATENT);
+    render(tree(nodeData({ status: "error", error: "Out of credits", runStatus: null })));
+
+    expect(screen.queryByAltText("Rendering")).not.toBeInTheDocument();
+    expect(screen.getByText("Out of credits")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ComfyNodePreview.test.tsx
+++ b/src/components/__tests__/ComfyNodePreview.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ComfyNodePreview } from "@/components/modals/ComfyNodePreview";
+import type { ComfyAppInput, ComfyAppOutput, ComfyAppParam } from "@/lib/comfy/types";
+
+const input = (over: Partial<ComfyAppInput> = {}): ComfyAppInput => ({
+  id: "24:text",
+  name: "prompt",
+  label: "Prompt",
+  type: "text",
+  nodeId: "24",
+  inputKey: "text",
+  required: false,
+  ...over,
+});
+
+const output = (over: Partial<ComfyAppOutput> = {}): ComfyAppOutput => ({
+  id: "9",
+  label: "Result",
+  type: "image",
+  nodeId: "9",
+  classType: "SaveImage",
+  ...over,
+});
+
+const base = {
+  name: "My Workflow",
+  source: "upload" as const,
+  nodeCount: 12,
+  inputs: [],
+  params: [],
+  outputs: [],
+};
+
+/** The coloured circles standing in for React Flow's handles. */
+const dots = (container: HTMLElement) =>
+  [...container.querySelectorAll("span")].filter((el) =>
+    el.className.includes("rounded-full")
+  );
+
+describe("ComfyNodePreview", () => {
+  it("carries one handle per exposed input and output", () => {
+    // This is the question the dialog is really asking — how many things can
+    // be plugged into this node — and it is the one a list of bindings answers
+    // worst.
+    const { container } = render(
+      <ComfyNodePreview
+        {...base}
+        inputs={[input(), input({ id: "16:image", label: "Product", type: "image" })]}
+        outputs={[output()]}
+      />
+    );
+
+    expect(dots(container)).toHaveLength(3);
+    expect(screen.getByText("Prompt")).toBeInTheDocument();
+    expect(screen.getByText("Product")).toBeInTheDocument();
+    expect(screen.getByText("Result")).toBeInTheDocument();
+  });
+
+  it("shows the settings with the values the node will start from", () => {
+    // Not the defaults' placeholder: a node is seeded on attach, so a preview
+    // showing "Default (…)" would be of a node that never exists.
+    const params: ComfyAppParam[] = [
+      { id: "31:steps", label: "Steps", nodeId: "31", inputKey: "steps", type: "integer", default: 20 },
+    ];
+    render(<ComfyNodePreview {...base} params={params} outputs={[output()]} />);
+
+    expect(screen.getByDisplayValue("20")).toBeInTheDocument();
+  });
+
+  it("says so plainly when the workflow exposes nothing to adjust", () => {
+    render(<ComfyNodePreview {...base} outputs={[output()]} />);
+    expect(screen.getByText(/exposes no settings/i)).toBeInTheDocument();
+  });
+
+  it("names the node, and says where it came from", () => {
+    render(<ComfyNodePreview {...base} source="blueprint" outputs={[output()]} />);
+    expect(screen.getByText("My Workflow")).toBeInTheDocument();
+    expect(screen.getByText("Blueprint")).toBeInTheDocument();
+    expect(screen.getByText("12 nodes")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ComfyWorkflowImportModal.test.tsx
+++ b/src/components/__tests__/ComfyWorkflowImportModal.test.tsx
@@ -1,0 +1,194 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { ComfyWorkflowImportModal } from "@/components/modals/ComfyWorkflowImportModal";
+import { invalidateSavedComfyNodes } from "@/hooks/useSavedComfyNodes";
+import { listSavedComfyNodes, saveComfyNode } from "@/lib/comfy/library";
+import type { ComfyAppDefinition, ComfyWorkflowInspection } from "@/lib/comfy/types";
+
+/**
+ * The dialog reached through a node's gear — where a node is kept, and where a
+ * kept one is picked up again.
+ *
+ * Driven in `reconfigure` mode throughout: that path fills the confirm step
+ * from what it was handed, with no engine round-trip, so these exercise the
+ * real component rather than a mocked shell of it.
+ */
+
+const app = (over: Partial<ComfyAppDefinition> = {}): ComfyAppDefinition => ({
+  id: "app-1",
+  name: "Upscale Pass",
+  description: "",
+  source: "upload",
+  graph: { "1": { class_type: "LoadImage", inputs: { image: "x.png" } } },
+  inputs: [],
+  params: [
+    { id: "3:steps", label: "Steps", nodeId: "3", inputKey: "steps", type: "integer", default: 20 },
+  ],
+  outputs: [{ id: "9", label: "Result", type: "image", nodeId: "9", classType: "SaveImage" }],
+  classTypes: ["LoadImage", "SaveImage"],
+  nodeCount: 2,
+  createdAt: 0,
+  ...over,
+});
+
+const inspection = (): ComfyWorkflowInspection => ({
+  nodeCount: 2,
+  classTypes: ["LoadImage", "SaveImage"],
+  imageInputCandidates: [],
+  mediaInputCandidates: [],
+  outputCandidates: [{ nodeId: "9", classType: "SaveImage", label: "Result" }],
+  widgetCandidates: [
+    {
+      nodeId: "3",
+      inputKey: "steps",
+      classType: "KSampler",
+      label: "Steps",
+      valueType: "integer",
+      currentValue: 20,
+      connectableAs: null,
+      fromAppMode: true,
+    },
+  ],
+  hasAppMode: true,
+  appModeOutputNodeIds: ["9"],
+  suggested: { name: "Upscale Pass", inputs: [], params: [], outputs: [] },
+  blueprints: [],
+  warnings: [],
+});
+
+const open = (props: Partial<React.ComponentProps<typeof ComfyWorkflowImportModal>> = {}) =>
+  render(
+    <ComfyWorkflowImportModal
+      isOpen
+      onClose={vi.fn()}
+      onAttach={vi.fn()}
+      reconfigure={{ app: app(), inspection: inspection() }}
+      paramValues={{ "3:steps": 40 }}
+      {...props}
+    />
+  );
+
+describe("saving a Comfy node from the edit dialog", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    invalidateSavedComfyNodes();
+  });
+
+  it("keeps the node in the library", () => {
+    open();
+    fireEvent.click(screen.getByRole("button", { name: "Save as node" }));
+
+    const saved = listSavedComfyNodes();
+    expect(saved).toHaveLength(1);
+    expect(saved[0]!.name).toBe("Upscale Pass");
+  });
+
+  it("keeps the values the node is running, not the workflow's own", () => {
+    // A saved node that came back at the workflow's defaults would be a saved
+    // workflow — the settings are the reason for saving it.
+    open();
+    fireEvent.click(screen.getByRole("button", { name: "Save as node" }));
+
+    const param = listSavedComfyNodes()[0]!.app.params.find((p) => p.id === "3:steps");
+    expect(param?.default).toBe(40);
+  });
+
+  it("says that it saved", () => {
+    // Nothing else about the dialog changes, so without this there is no way
+    // to tell the button did anything.
+    open();
+    fireEvent.click(screen.getByRole("button", { name: "Save as node" }));
+    expect(screen.getByRole("status")).toHaveTextContent("Saved");
+  });
+
+  it("offers to update the entry a node came from", () => {
+    const entry = saveComfyNode({ name: "Upscale Pass", app: app() });
+    open({ savedNodeId: entry.id });
+
+    fireEvent.click(screen.getByRole("button", { name: "Update saved node" }));
+
+    // Updated in place: a second near-identical entry is the thing this avoids.
+    expect(listSavedComfyNodes()).toHaveLength(1);
+    expect(screen.getByRole("status")).toHaveTextContent("Updated");
+  });
+
+  it("does not offer to update an entry that has been deleted", () => {
+    open({ savedNodeId: "gone" });
+
+    expect(screen.queryByRole("button", { name: "Update saved node" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save as node" })).toBeInTheDocument();
+  });
+
+  it("reports a failed save rather than losing it", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    open();
+    fireEvent.click(screen.getByRole("button", { name: "Save as node" }));
+    expect(screen.getByRole("status")).toHaveTextContent(/no room/i);
+
+    setItem.mockRestore();
+  });
+});
+
+describe("the saved-node tab", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    invalidateSavedComfyNodes();
+  });
+
+  const openFresh = (props = {}) =>
+    render(
+      <ComfyWorkflowImportModal isOpen onClose={vi.fn()} onAttach={vi.fn()} {...props} />
+    );
+
+  it("is absent until something has been saved", () => {
+    openFresh();
+    expect(screen.queryByRole("button", { name: "Saved nodes" })).not.toBeInTheDocument();
+  });
+
+  it("lists what is in the library", () => {
+    saveComfyNode({ name: "Upscale 2x", app: app() });
+    openFresh();
+
+    fireEvent.click(screen.getByRole("button", { name: "Saved nodes" }));
+    expect(screen.getByText("Upscale 2x")).toBeInTheDocument();
+    expect(screen.getByText(/0 inputs · 1 setting · 1 output/)).toBeInTheDocument();
+  });
+
+  it("attaches the picked entry, and says which one it was", () => {
+    const entry = saveComfyNode({ name: "Upscale 2x", app: app() });
+    const onAttach = vi.fn();
+    openFresh({ onAttach });
+
+    fireEvent.click(screen.getByRole("button", { name: "Saved nodes" }));
+    fireEvent.click(screen.getByText("Upscale 2x"));
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(onAttach).toHaveBeenCalledTimes(1);
+    const [attached, , meta] = onAttach.mock.calls[0]!;
+    expect(attached.name).toBe("Upscale Pass");
+    expect(meta).toEqual({ savedNodeId: entry.id });
+  });
+
+  it("asks before deleting one", () => {
+    // localStorage keeps no history, so this is the only chance to change
+    // your mind.
+    saveComfyNode({ name: "Upscale 2x", app: app() });
+    openFresh();
+    fireEvent.click(screen.getByRole("button", { name: "Saved nodes" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete Upscale 2x" }));
+    expect(listSavedComfyNodes()).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Keep" }));
+    expect(listSavedComfyNodes()).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete Upscale 2x" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(listSavedComfyNodes()).toHaveLength(0);
+  });
+});

--- a/src/components/__tests__/ConnectionDropMenu.test.tsx
+++ b/src/components/__tests__/ConnectionDropMenu.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ConnectionDropMenu } from "@/components/ConnectionDropMenu";
+import { invalidateSavedComfyNodes } from "@/hooks/useSavedComfyNodes";
+import { saveComfyNode } from "@/lib/comfy/library";
+import type { ComfyAppDefinition } from "@/lib/comfy/types";
 
 describe("ConnectionDropMenu", () => {
   const mockOnSelect = vi.fn();
@@ -260,6 +263,83 @@ describe("ConnectionDropMenu", () => {
       // Should be back on first item (Prompt)
       const firstButton = screen.getByText("Prompt").closest("button");
       expect(firstButton).toHaveClass("bg-neutral-700");
+    });
+  });
+
+  describe("Saved Comfy nodes", () => {
+    // A saved node has to behave like a built-in one: offered when the wire it
+    // would carry matches, absent when it does not, and attachable in one click.
+    beforeEach(() => {
+      window.localStorage.clear();
+      invalidateSavedComfyNodes();
+    });
+
+    const savedApp = (over: Partial<ComfyAppDefinition> = {}): ComfyAppDefinition => ({
+      id: "comfy_1",
+      name: "Upscale 2x",
+      description: "",
+      source: "upload",
+      graph: {},
+      inputs: [
+        {
+          id: "1:image",
+          name: "image",
+          label: "Photo",
+          type: "image",
+          nodeId: "1",
+          inputKey: "image",
+          required: true,
+        },
+      ],
+      params: [],
+      outputs: [{ id: "9", label: "Result", type: "image", nodeId: "9", classType: "SaveImage" }],
+      classTypes: [],
+      nodeCount: 2,
+      createdAt: 1,
+      ...over,
+    });
+
+    it("offers a saved node that can take the wire being dragged", () => {
+      saveComfyNode({ name: "Upscale 2x", app: savedApp() });
+      render(<ConnectionDropMenu {...defaultProps} handleType="image" connectionType="source" />);
+
+      expect(screen.getByText("Upscale 2x")).toBeInTheDocument();
+    });
+
+    it("leaves it out when it has no input of that type", () => {
+      saveComfyNode({ name: "Upscale 2x", app: savedApp() });
+      render(<ConnectionDropMenu {...defaultProps} handleType="text" connectionType="source" />);
+
+      expect(screen.queryByText("Upscale 2x")).not.toBeInTheDocument();
+    });
+
+    it("matches on outputs when the drag started at an input", () => {
+      saveComfyNode({
+        name: "Caption",
+        app: savedApp({
+          inputs: [],
+          outputs: [
+            { id: "9", label: "Text", type: "text", nodeId: "9", classType: "SaveText" },
+          ],
+        }),
+      });
+      render(<ConnectionDropMenu {...defaultProps} handleType="text" connectionType="target" />);
+
+      expect(screen.getByText("Caption")).toBeInTheDocument();
+    });
+
+    it("names which saved node was picked", () => {
+      // Without this the canvas would add an empty Comfy node — the type alone
+      // does not say which workflow was meant.
+      const entry = saveComfyNode({ name: "Upscale 2x", app: savedApp() });
+      render(<ConnectionDropMenu {...defaultProps} handleType="image" connectionType="source" />);
+
+      fireEvent.click(screen.getByText("Upscale 2x"));
+      expect(mockOnSelect).toHaveBeenCalledWith({
+        type: "comfyApp",
+        isAction: false,
+        savedNodeId: entry.id,
+      });
     });
   });
 

--- a/src/components/__tests__/NodeSearchMenu.test.tsx
+++ b/src/components/__tests__/NodeSearchMenu.test.tsx
@@ -1,9 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NodeSearchMenu } from "@/components/NodeSearchMenu";
 import { ALL_NODE_OPTIONS } from "@/components/ConnectionDropMenu";
+import { invalidateSavedComfyNodes } from "@/hooks/useSavedComfyNodes";
+import { saveComfyNode } from "@/lib/comfy/library";
+import type { ComfyAppDefinition } from "@/lib/comfy/types";
 
 const position = { x: 100, y: 100 };
+
+// The library is part of this list now, so every count below depends on it
+// starting empty.
+beforeEach(() => {
+  window.localStorage.clear();
+  invalidateSavedComfyNodes();
+});
 
 // The highlighted option carries the literal `bg-neutral-700` class (hover uses
 // the distinct `hover:bg-neutral-700` token, so this identifies only the
@@ -57,7 +67,67 @@ describe("NodeSearchMenu", () => {
       <NodeSearchMenu position={position} onSelect={onSelect} onClose={vi.fn()} />
     );
     fireEvent.click(screen.getByText("Prompt"));
-    expect(onSelect).toHaveBeenCalledWith("prompt");
+    // The second argument names a saved Comfy node; a built-in has none.
+    expect(onSelect).toHaveBeenCalledWith("prompt", undefined);
+  });
+
+  describe("saved Comfy nodes", () => {
+    const savedApp = (): ComfyAppDefinition => ({
+      id: "comfy_1",
+      name: "Upscale 2x",
+      description: "",
+      source: "upload",
+      graph: {},
+      inputs: [],
+      params: [],
+      outputs: [{ id: "9", label: "Result", type: "image", nodeId: "9", classType: "SaveImage" }],
+      classTypes: [],
+      nodeCount: 2,
+      createdAt: 1,
+    });
+
+    it("lists them after the built-ins, under their own heading", () => {
+      saveComfyNode({ name: "Upscale 2x", app: savedApp() });
+      render(
+        <NodeSearchMenu position={position} onSelect={vi.fn()} onClose={vi.fn()} />
+      );
+
+      expect(screen.getByText("Saved nodes")).toBeInTheDocument();
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(ALL_NODE_OPTIONS.length + 1);
+      expect(buttons[buttons.length - 1]).toHaveTextContent("Upscale 2x");
+    });
+
+    it("finds them by name", () => {
+      saveComfyNode({ name: "Upscale 2x", app: savedApp() });
+      render(
+        <NodeSearchMenu position={position} onSelect={vi.fn()} onClose={vi.fn()} />
+      );
+      fireEvent.change(screen.getByLabelText("Search nodes"), {
+        target: { value: "upscale" },
+      });
+
+      expect(screen.getAllByRole("button")).toHaveLength(1);
+      expect(screen.getByText("Upscale 2x")).toBeInTheDocument();
+    });
+
+    it("says which saved node was picked", () => {
+      const entry = saveComfyNode({ name: "Upscale 2x", app: savedApp() });
+      const onSelect = vi.fn();
+      render(
+        <NodeSearchMenu position={position} onSelect={onSelect} onClose={vi.fn()} />
+      );
+
+      fireEvent.click(screen.getByText("Upscale 2x"));
+      expect(onSelect).toHaveBeenCalledWith("comfyApp", entry.id);
+    });
+
+    it("shows no heading when nothing is saved", () => {
+      render(
+        <NodeSearchMenu position={position} onSelect={vi.fn()} onClose={vi.fn()} />
+      );
+      expect(screen.queryByText("Saved nodes")).not.toBeInTheDocument();
+    });
   });
 
   it("selects the highlighted option on Enter", () => {

--- a/src/components/modals/ComfyNodePreview.tsx
+++ b/src/components/modals/ComfyNodePreview.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+
+import { ComfyWordmark } from "@/components/icons/ComfyWordmark";
+import { ComfyAppParameters } from "@/components/nodes/ComfyAppParameters";
+import type { ComfyAppInput, ComfyAppOutput, ComfyAppParam } from "@/lib/comfy/types";
+
+/**
+ * The node this dialog is about to build, drawn as it will appear.
+ *
+ * The picks on the left are a list of bindings; what the user is actually
+ * deciding is the shape of a node — how many handles it carries, what they are
+ * called, which knobs sit under it. This says that in the only language that
+ * answers it, and updates as they choose.
+ *
+ * Deliberately a replica rather than the node itself: the real one is a React
+ * Flow node wired to the workflow store, and standing an instance of it up here
+ * would mean faking a canvas. The settings are the exception — they are already
+ * a plain controlled component, so the real one is used and the values are live.
+ */
+
+/** Matches `.react-flow__handle[data-handletype]` in globals.css. */
+const HANDLE_FILL: Record<string, string> = {
+  image: "#10b981",
+  text: "#3b82f6",
+  audio: "#a855f7",
+  video: "#ec4899",
+  "3d": "#f97316",
+};
+
+/** Evenly space n handles down an edge — the node's own rule. */
+const handleTop = (index: number, total: number): string =>
+  `${((index + 1) / (total + 1)) * 100}%`;
+
+interface ComfyNodePreviewProps {
+  name: string;
+  source: "blueprint" | "upload";
+  nodeCount: number;
+  inputs: ComfyAppInput[];
+  params: ComfyAppParam[];
+  outputs: ComfyAppOutput[];
+}
+
+export function ComfyNodePreview({
+  name,
+  source,
+  nodeCount,
+  inputs,
+  params,
+  outputs,
+}: ComfyNodePreviewProps) {
+  // Seeded from the defaults, exactly as the node seeds itself on attach —
+  // otherwise every dropdown reads "Default (…)", which is a state the real
+  // node is never in. Edits are kept but not saved: nothing typed in a preview
+  // is, and a control that cannot be moved reads as a broken one.
+  const [edits, setEdits] = useState<Record<string, unknown>>({});
+  const values = useMemo(() => {
+    const seeded: Record<string, unknown> = {};
+    for (const param of params) {
+      if (param.default !== undefined) seeded[param.id] = param.default;
+    }
+    return { ...seeded, ...edits };
+  }, [params, edits]);
+
+  return (
+    <div className="h-full rounded-lg bg-neutral-900/70 ring-1 ring-inset ring-black/40 overflow-auto flex justify-center p-6">
+      {/* The node sits at its real width, so the preview is a measurement and
+          not an impression.
+
+          Centred with `my-auto` rather than `items-center`: a centred flex
+          child in a scroll container has its overflowing top cut off and
+          unreachable, and a node with every widget exposed overflows easily. */}
+      <div className="w-[260px] shrink-0 my-auto">
+        {/* The canvas draws the title above the node, not inside it. */}
+        <div className="flex items-center gap-1.5 mb-1.5 px-0.5">
+          <ComfyWordmark className="h-3 w-auto shrink-0 text-neutral-400" />
+          <span className="text-[11px] text-neutral-400 truncate" title={name}>
+            {name || "Untitled"}
+          </span>
+        </div>
+
+        <div className="relative bg-neutral-800 rounded-lg shadow-lg">
+          <Handles inputs={inputs} outputs={outputs} />
+
+          <div className="rounded-t-lg border border-b-0 border-neutral-700/60 px-3 pb-4">
+            <div className="flex items-center gap-2 pt-2 pb-1.5">
+              <div className="min-w-0 flex-1">
+                <p className="text-[11px] font-medium text-neutral-200 truncate">
+                  {source === "blueprint" ? "Blueprint" : "App workflow"}
+                </p>
+                <p className="text-[9px] text-neutral-500 truncate">
+                  {nodeCount} node{nodeCount === 1 ? "" : "s"}
+                </p>
+              </div>
+            </div>
+            <div className="h-[92px] rounded-md bg-neutral-900/60 flex items-center justify-center">
+              <span className="text-[10px] text-neutral-600">No output yet</span>
+            </div>
+          </div>
+
+          {/* Always open here. Collapsed, the one thing this view exists to
+              show would be a chevron. */}
+          <div className="bg-[#2a2a2a] rounded-b-lg">
+            <div className="w-full flex items-center justify-center gap-1 py-1 text-neutral-500">
+              <span className="text-[10px]">Settings</span>
+              <svg
+                className="w-3 h-3 rotate-180"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </div>
+            <div className="px-3 pb-3 rounded-b-lg">
+              {params.length > 0 ? (
+                <ComfyAppParameters params={params} values={values} onChange={setEdits} />
+              ) : (
+                <span className="text-[9px] text-neutral-500">
+                  This workflow exposes no settings
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Connection points, on the edges they will really sit on. */
+function Handles({
+  inputs,
+  outputs,
+}: {
+  inputs: ComfyAppInput[];
+  outputs: ComfyAppOutput[];
+}) {
+  return (
+    <>
+      {inputs.map((input, index) => (
+        <Dot
+          key={input.id}
+          side="left"
+          top={handleTop(index, inputs.length)}
+          type={input.type}
+          label={input.label}
+        />
+      ))}
+      {outputs.map((output, index) => (
+        <Dot
+          key={output.id}
+          side="right"
+          top={handleTop(index, outputs.length)}
+          type={output.type}
+          label={output.label}
+        />
+      ))}
+    </>
+  );
+}
+
+function Dot({
+  side,
+  top,
+  type,
+  label,
+}: {
+  side: "left" | "right";
+  top: string;
+  type: string;
+  label: string;
+}) {
+  const dot = (
+    <span
+      className="block w-[14px] h-[14px] rounded-full border-2 border-white shrink-0"
+      style={{
+        background: HANDLE_FILL[type] ?? HANDLE_FILL.image,
+        boxShadow: "0 1px 3px rgba(0,0,0,0.15)",
+      }}
+    />
+  );
+  // Outside the node, so a long name never squeezes the body.
+  const text = (
+    <span
+      className="text-[9px] text-neutral-400 whitespace-nowrap max-w-[96px] truncate"
+      title={label}
+    >
+      {label}
+    </span>
+  );
+
+  return (
+    <div
+      className="absolute z-10 flex items-center gap-1.5"
+      style={{
+        top,
+        transform: "translateY(-50%)",
+        // Anchored by the edge the dot sits on, so the label grows away from
+        // the node rather than pushing the dot into it.
+        ...(side === "left"
+          ? { right: "calc(100% - 7px)" }
+          : { left: "calc(100% - 7px)" }),
+      }}
+    >
+      {side === "left" ? (
+        <>
+          {text}
+          {dot}
+        </>
+      ) : (
+        <>
+          {dot}
+          {text}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/modals/ComfyWorkflowImportModal.tsx
+++ b/src/components/modals/ComfyWorkflowImportModal.tsx
@@ -9,8 +9,16 @@ import {
   ComfySettingsTab,
   useComfySettingsDraft,
 } from "@/components/settings/ComfySettingsTab";
+import { useSavedComfyNodes } from "@/hooks/useSavedComfyNodes";
 import { buildComfyApp } from "@/lib/comfy/buildApp";
 import { loaderInputType } from "@/lib/comfy/graph";
+import {
+  instantiateSavedComfyNode,
+  removeSavedComfyNode,
+  saveComfyNode,
+  withDialledValues,
+  type SavedComfyNode,
+} from "@/lib/comfy/library";
 import { inputFromCandidate, inputFromLoader, paramFromCandidate } from "@/lib/comfy/inspect";
 import { withAppLabels } from "@/lib/comfy/reconfigure";
 import {
@@ -48,10 +56,30 @@ export interface ComfyReconfigureTarget {
 interface ComfyWorkflowImportModalProps {
   isOpen: boolean;
   onClose: () => void;
-  /** The confirmed contract, plus the candidate list it was chosen from. */
-  onAttach: (app: ComfyAppDefinition, inspection: ComfyWorkflowInspection) => void;
+  /**
+   * The confirmed contract, plus the candidate list it was chosen from.
+   *
+   * A saved node carries no candidate list when it was stored without one —
+   * better to pass nothing and let the node re-read the graph than to hand it
+   * an empty list, which reads as "this workflow exposes nothing".
+   */
+  onAttach: (
+    app: ComfyAppDefinition,
+    inspection: ComfyWorkflowInspection | undefined,
+    meta?: { savedNodeId?: string }
+  ) => void;
   /** Shown as the "replacing" hint when the node already has a workflow. */
   existingName?: string;
+  /**
+   * The library entry this node was created from, which turns the save action
+   * into an update of that entry.
+   */
+  savedNodeId?: string;
+  /**
+   * The node's current settings. Folded into the defaults when saving, so a
+   * saved node arrives dialled in rather than back at the workflow's own values.
+   */
+  paramValues?: Record<string, unknown>;
   /**
    * Set to skip the file/blueprint step and edit an attached workflow's picks
    * directly. The node's current selection is what gets pre-filled, not the
@@ -102,6 +130,11 @@ const APP_MODE_DOCS = "https://docs.comfy.org/interface/app-mode";
 const PRIMARY_BUTTON =
   "px-4 py-2 text-sm rounded-lg bg-neutral-100 text-neutral-900 font-medium hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed transition-[background-color,scale] duration-150 active:scale-[0.96] disabled:active:scale-100";
 
+/** Beside it: keeping this node is a different act from attaching it, and a
+ *  second filled button would make the dialog ask twice which one you meant. */
+const SECONDARY_BUTTON =
+  "px-3 py-2 text-sm rounded-lg bg-neutral-700/60 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 disabled:opacity-40 disabled:cursor-not-allowed transition-[background-color,color,scale] duration-150 active:scale-[0.96] disabled:active:scale-100";
+
 /**
  * Import a ComfyUI workflow and confirm what it exposes.
  *
@@ -115,10 +148,12 @@ export function ComfyWorkflowImportModal({
   onClose,
   onAttach,
   existingName,
+  savedNodeId,
+  paramValues,
   reconfigure,
   upload,
 }: ComfyWorkflowImportModalProps) {
-  const [tab, setTab] = useState<"file" | "blueprints">("file");
+  const [tab, setTab] = useState<"file" | "blueprints" | "saved">("file");
   const [inspection, setInspection] = useState<Inspection | null>(null);
   const [source, setSource] = useState<"upload" | "blueprint">("upload");
   const [busy, setBusy] = useState(false);
@@ -136,6 +171,12 @@ export function ComfyWorkflowImportModal({
   const [blueprints, setBlueprints] = useState<BlueprintListItem[] | null>(null);
   const [blueprintError, setBlueprintError] = useState<string | null>(null);
   const [blueprintId, setBlueprintId] = useState("");
+
+  // Saved-node library
+  const savedNodes = useSavedComfyNodes();
+  const [savedPick, setSavedPick] = useState("");
+  /** The outcome of the last save, shown where the button is. */
+  const [saveResult, setSaveResult] = useState<{ ok: boolean; message: string } | null>(null);
 
   // The two panels that take over the body: how to prepare a workflow, and
   // where it runs. Settings live here because this dialog is where a missing
@@ -227,7 +268,14 @@ export function ComfyWorkflowImportModal({
     setRoles({});
     setBusy(false);
     setDragOver(false);
+    setSaveResult(null);
   }, []);
+
+  // The tab only exists while there is a library to show, so deleting the last
+  // entry has to put the dialog back on a step that still exists.
+  useEffect(() => {
+    if (tab === "saved" && savedNodes.length === 0) setTab("file");
+  }, [tab, savedNodes.length]);
 
   useEffect(() => {
     if (!isOpen) setView("main");
@@ -497,15 +545,19 @@ export function ComfyWorkflowImportModal({
     [inspection, roles]
   );
 
-  const attach = useCallback(() => {
-    if (!inspection) return;
+  /**
+   * The contract as the picks currently stand — what Add, Save changes and
+   * Save as node all commit, so the three cannot disagree about it.
+   */
+  const buildContract = useCallback(() => {
+    if (!inspection) return null;
     // The candidate list travels back to the node so the picks can be revisited.
     // The graph is dropped (the app already carries it), as are the blueprint
     // listing and the import-time warnings — both describe the upload, not the
     // contract, and replaying "could not reach the engine" weeks later misleads.
     const { graph: _graph, ...snapshot } = inspection;
-    onAttach(
-      buildComfyApp({
+    return {
+      app: buildComfyApp({
         name,
         source: source === "blueprint" ? "blueprint" : "upload",
         graph: inspection.graph,
@@ -513,9 +565,60 @@ export function ComfyWorkflowImportModal({
         params,
         outputs,
       }),
-      { ...snapshot, blueprints: [], warnings: [] }
-    );
-  }, [inspection, params, name, source, inputs, outputs, onAttach]);
+      inspection: { ...snapshot, blueprints: [], warnings: [] } as ComfyWorkflowInspection,
+    };
+  }, [inspection, params, name, source, inputs, outputs]);
+
+  const attach = useCallback(() => {
+    const built = buildContract();
+    if (built) onAttach(built.app, built.inspection);
+  }, [buildContract, onAttach]);
+
+  /**
+   * Keep this node, as configured, in the library.
+   *
+   * The values the node is running are folded into the defaults, which is the
+   * whole point: a saved node arrives set up, not merely attached. Updating
+   * overwrites the entry it came from; anything else adds one.
+   */
+  const saveToLibrary = useCallback(
+    (mode: "new" | "update") => {
+      const built = buildContract();
+      if (!built) return;
+      try {
+        saveComfyNode({
+          ...(mode === "update" && savedNodeId ? { id: savedNodeId } : {}),
+          name,
+          app: withDialledValues(built.app, paramValues ?? {}),
+          inspection: built.inspection,
+        });
+        setSaveResult({ ok: true, message: mode === "update" ? "Updated" : "Saved" });
+      } catch (err) {
+        setSaveResult({
+          ok: false,
+          message: err instanceof Error ? err.message : "Could not save this node.",
+        });
+      }
+    },
+    [buildContract, name, paramValues, savedNodeId]
+  );
+
+  // A confirmation that stayed put would still be sitting there after the next
+  // change, claiming that change was saved too.
+  useEffect(() => {
+    if (!saveResult?.ok) return;
+    const timer = setTimeout(() => setSaveResult(null), 2500);
+    return () => clearTimeout(timer);
+  }, [saveResult]);
+
+  /** Attach a library entry straight to the node — nothing to inspect. */
+  const addSaved = useCallback(
+    (entry: SavedComfyNode) => {
+      const { app, inspection: stored } = instantiateSavedComfyNode(entry);
+      onAttach(app, stored, { savedNodeId: entry.id });
+    },
+    [onAttach]
+  );
 
   if (!isOpen) return null;
 
@@ -539,6 +642,12 @@ export function ComfyWorkflowImportModal({
         : null;
   const showBlueprintAdd =
     !reconfigure && tab === "blueprints" && blueprints !== null && blueprints.length > 0;
+  const showSavedAdd = !reconfigure && tab === "saved" && savedNodes.length > 0;
+  // Only offer to update an entry that is still there — the node keeps its
+  // `savedNodeId` after the library entry has been deleted.
+  const canUpdateSaved = Boolean(
+    savedNodeId && savedNodes.some((entry) => entry.id === savedNodeId)
+  );
   // The preview is of the node being built, so it belongs to that step alone —
   // not to the file picker, the connection settings or the help text.
   const showPreview = Boolean(isMain && inspection);
@@ -650,6 +759,13 @@ export function ComfyWorkflowImportModal({
               <TabButton active={tab === "blueprints"} onClick={() => setTab("blueprints")}>
                 Blueprints
               </TabButton>
+              {/* Absent until there is something in it — an empty tab for a
+                  feature you have not used yet is a dead end with a label. */}
+              {savedNodes.length > 0 && (
+                <TabButton active={tab === "saved"} onClick={() => setTab("saved")}>
+                  Saved nodes
+                </TabButton>
+              )}
             </div>
           )}
         </div>
@@ -714,6 +830,19 @@ export function ComfyWorkflowImportModal({
               onRetry={loadBlueprints}
               onAdd={() => void importBlueprint(blueprintId)}
               busy={busy}
+            />
+          )}
+
+          {isMain && !reconfigure && !inspection && tab === "saved" && (
+            <SavedNodePicker
+              nodes={savedNodes}
+              selected={savedPick}
+              onSelect={setSavedPick}
+              onAdd={addSaved}
+              onDelete={(entryId) => {
+                removeSavedComfyNode(entryId);
+                setSavedPick((current) => (current === entryId ? "" : current));
+              }}
             />
           )}
 
@@ -782,8 +911,54 @@ export function ComfyWorkflowImportModal({
               Save connection
             </button>
           ) : inspection ? (
-            <button type="button" onClick={attach} disabled={!canAttach} className={PRIMARY_BUTTON}>
-              {reconfigure ? "Save changes" : "Add to node"}
+            <div className="flex items-center gap-2 shrink-0">
+              {/* Saving is otherwise invisible — the dialog stays exactly as it
+                  was, so without this there is no way to tell it worked. */}
+              {saveResult && (
+                <span
+                  role="status"
+                  className={`text-[11px] ${
+                    saveResult.ok ? "text-emerald-400" : "text-red-400"
+                  }`}
+                >
+                  {saveResult.message}
+                </span>
+              )}
+              {canUpdateSaved && (
+                <button
+                  type="button"
+                  onClick={() => saveToLibrary("update")}
+                  disabled={!canAttach}
+                  title="Overwrite the saved node this one came from"
+                  className={SECONDARY_BUTTON}
+                >
+                  Update saved node
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => saveToLibrary("new")}
+                disabled={!canAttach}
+                title="Keep this node, as configured, in the node menus"
+                className={SECONDARY_BUTTON}
+              >
+                {canUpdateSaved ? "Save as new" : "Save as node"}
+              </button>
+              <button type="button" onClick={attach} disabled={!canAttach} className={PRIMARY_BUTTON}>
+                {reconfigure ? "Save changes" : "Add to node"}
+              </button>
+            </div>
+          ) : showSavedAdd ? (
+            <button
+              type="button"
+              onClick={() => {
+                const entry = savedNodes.find((n) => n.id === savedPick);
+                if (entry) addSaved(entry);
+              }}
+              disabled={!savedPick}
+              className={PRIMARY_BUTTON}
+            >
+              Add
             </button>
           ) : (
             // The Blueprint list confirms from here too, so the dialog has one
@@ -1035,6 +1210,123 @@ function BlueprintPicker({
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * The saved-node library.
+ *
+ * Each entry is a workflow someone already confirmed and dialled in, so there
+ * is nothing to read and nothing to choose — picking one attaches it. What the
+ * row has to answer is which one this is, hence the handle counts: two saves of
+ * the same workflow usually differ by what they expose, not by name.
+ */
+function SavedNodePicker({
+  nodes,
+  selected,
+  onSelect,
+  onAdd,
+  onDelete,
+}: {
+  nodes: SavedComfyNode[];
+  selected: string;
+  onSelect: (id: string) => void;
+  onAdd: (entry: SavedComfyNode) => void;
+  onDelete: (id: string) => void;
+}) {
+  // Deleting is not undoable — localStorage keeps no history — so it asks,
+  // inline rather than through a system dialog stacked on top of this one.
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  if (nodes.length === 0) {
+    return (
+      <p className="text-xs text-neutral-500 py-8 text-center">
+        Nothing saved yet. Confirm a workflow&rsquo;s inputs and outputs, then
+        &ldquo;Save as node&rdquo;.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="rounded-lg border border-neutral-700 bg-neutral-900 overflow-hidden divide-y divide-neutral-800/80 max-h-[320px] overflow-y-auto">
+      {nodes.map((entry) => {
+        const isSelected = entry.id === selected;
+        const { app } = entry;
+        const handles = [
+          `${app.inputs.length} input${app.inputs.length === 1 ? "" : "s"}`,
+          `${app.params.length} setting${app.params.length === 1 ? "" : "s"}`,
+          `${app.outputs.length} output${app.outputs.length === 1 ? "" : "s"}`,
+        ].join(" · ");
+
+        return (
+          <li key={entry.id} className={isSelected ? "bg-neutral-700" : "hover:bg-neutral-800"}>
+            <div className="flex items-center">
+              <button
+                type="button"
+                onClick={() => onSelect(entry.id)}
+                onDoubleClick={() => onAdd(entry)}
+                className="flex-1 min-w-0 text-left px-3 py-2.5 transition-[scale] duration-150 active:scale-[0.99]"
+              >
+                <p
+                  className={`text-sm truncate ${
+                    isSelected ? "text-white" : "text-neutral-300"
+                  }`}
+                >
+                  {entry.name}
+                </p>
+                <p className="text-[10px] text-neutral-500 truncate">
+                  {app.source === "blueprint" ? "Blueprint" : "App workflow"} · {handles}
+                </p>
+              </button>
+
+              {confirming === entry.id ? (
+                <div className="flex items-center gap-1 pr-2 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onDelete(entry.id);
+                      setConfirming(null);
+                    }}
+                    className="px-2 py-1 text-[11px] rounded bg-red-500/15 text-red-300 hover:bg-red-500/25 transition-colors"
+                  >
+                    Delete
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirming(null)}
+                    className="px-2 py-1 text-[11px] text-neutral-400 hover:text-neutral-200 transition-colors"
+                  >
+                    Keep
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirming(entry.id)}
+                  title={`Delete "${entry.name}"`}
+                  aria-label={`Delete ${entry.name}`}
+                  className="shrink-0 w-10 h-10 flex items-center justify-center text-neutral-600 hover:text-red-400 transition-colors"
+                >
+                  <svg
+                    className="w-3.5 h-3.5"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M3 6h18" />
+                    <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+                    <path d="M19 6v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 

--- a/src/components/modals/ComfyWorkflowImportModal.tsx
+++ b/src/components/modals/ComfyWorkflowImportModal.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom";
 
 import { ComfyMark } from "@/components/icons/ComfyMark";
+import { ComfyNodePreview } from "./ComfyNodePreview";
 import {
   ComfySettingsTab,
   useComfySettingsDraft,
@@ -486,11 +487,18 @@ export function ComfyWorkflowImportModal({
     []
   );
 
+  // Derived once, so the preview shows the settings that will actually be
+  // attached rather than a second guess at them.
+  const params = useMemo(
+    () =>
+      (inspection?.widgetCandidates ?? [])
+        .filter((c) => roles[bindingKey(c.nodeId, c.inputKey)] === "setting")
+        .map(paramFromCandidate),
+    [inspection, roles]
+  );
+
   const attach = useCallback(() => {
     if (!inspection) return;
-    const params = inspection.widgetCandidates
-      .filter((c) => roles[bindingKey(c.nodeId, c.inputKey)] === "setting")
-      .map(paramFromCandidate);
     // The candidate list travels back to the node so the picks can be revisited.
     // The graph is dropped (the app already carries it), as are the blueprint
     // listing and the import-time warnings — both describe the upload, not the
@@ -507,7 +515,7 @@ export function ComfyWorkflowImportModal({
       }),
       { ...snapshot, blueprints: [], warnings: [] }
     );
-  }, [inspection, roles, name, source, inputs, outputs, onAttach]);
+  }, [inspection, params, name, source, inputs, outputs, onAttach]);
 
   if (!isOpen) return null;
 
@@ -531,6 +539,9 @@ export function ComfyWorkflowImportModal({
         : null;
   const showBlueprintAdd =
     !reconfigure && tab === "blueprints" && blueprints !== null && blueprints.length > 0;
+  // The preview is of the node being built, so it belongs to that step alone —
+  // not to the file picker, the connection settings or the help text.
+  const showPreview = Boolean(isMain && inspection);
 
   const dialog = (
     <div
@@ -546,7 +557,11 @@ export function ComfyWorkflowImportModal({
         aria-modal="true"
         aria-labelledby="comfy-import-title"
         tabIndex={-1}
-        className="bg-neutral-800 rounded-xl w-[600px] border border-neutral-700 shadow-2xl overflow-clip flex flex-col max-h-[82vh] focus:outline-none animate-dialog-panel"
+        // Wider only where there is a second column to hold: every other step
+        // is a single list, and stretching it would leave a hall of empty grey.
+        className={`bg-neutral-800 rounded-xl border border-neutral-700 shadow-2xl overflow-clip flex flex-col max-h-[82vh] focus:outline-none animate-dialog-panel transition-[width] duration-200 ${
+          showPreview ? "w-[880px]" : "w-[600px]"
+        }`}
         onKeyDown={trapFocus}
       >
         <div className="px-4 pt-4 pb-0 shrink-0 animate-dialog-section">
@@ -639,11 +654,14 @@ export function ComfyWorkflowImportModal({
           )}
         </div>
 
+        {/* Two columns while a node is being built: the picks scroll on the
+            left, the node they describe stands still on the right. */}
+        <div className="flex-1 min-h-0 flex">
         {/* The vertical padding lives on the inner wrapper, not here: a sticky
             heading inside a padded scroller stops at the *content* edge, and
             rows then scroll through the padding band above it in full view. */}
         <div
-          className="flex-1 min-h-0 overflow-y-auto px-4 animate-dialog-section"
+          className="flex-1 min-w-0 overflow-y-auto px-4 animate-dialog-section"
           style={{ animationDelay: "80ms" }}
         >
           <div className="py-4">
@@ -715,6 +733,24 @@ export function ComfyWorkflowImportModal({
             />
           )}
           </div>
+        </div>
+
+        {showPreview && inspection && (
+          // 8px to the dialog's outer edge on the three sides it can reach.
+          <div
+            className="w-[400px] shrink-0 py-2 pr-2 animate-dialog-section"
+            style={{ animationDelay: "120ms" }}
+          >
+            <ComfyNodePreview
+              name={name}
+              source={source === "blueprint" ? "blueprint" : "upload"}
+              nodeCount={inspection.nodeCount}
+              inputs={inputs}
+              params={params}
+              outputs={outputs}
+            />
+          </div>
+        )}
         </div>
 
         <div

--- a/src/components/modals/ComfyWorkflowImportModal.tsx
+++ b/src/components/modals/ComfyWorkflowImportModal.tsx
@@ -1278,8 +1278,12 @@ function ConfirmStep({
                       <div key={nodeId}>
                         {/* A band, not a row: the node a widget belongs to is a
                             heading over the list, and at row weight the two
-                            were being read as the same kind of thing. */}
-                        <div className="flex items-baseline gap-2 px-2.5 py-1 bg-neutral-950/80 border-y border-neutral-800">
+                            were being read as the same kind of thing.
+
+                            Weighted to the top, because a heading belongs to
+                            what follows it — evenly padded, it floated between
+                            two groups and read as ending the one above. */}
+                        <div className="flex items-baseline gap-2 px-2.5 pt-2.5 pb-1 bg-neutral-950/80 border-y border-neutral-800">
                           <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
                             {group.classType}
                           </span>

--- a/src/components/modals/ComfyWorkflowImportModal.tsx
+++ b/src/components/modals/ComfyWorkflowImportModal.tsx
@@ -20,7 +20,7 @@ import {
   type SavedComfyNode,
 } from "@/lib/comfy/library";
 import { inputFromCandidate, inputFromLoader, paramFromCandidate } from "@/lib/comfy/inspect";
-import { withAppLabels } from "@/lib/comfy/reconfigure";
+import { bindingKey, withAppLabels } from "@/lib/comfy/reconfigure";
 import {
   buildComfyHeaders,
   comfyConfigError,
@@ -121,7 +121,6 @@ const OUTPUT_TYPE_LABEL: Record<ComfyOutputType, string> = {
   "3d": "3D",
 };
 
-const bindingKey = (nodeId: string, inputKey: string): string => `${nodeId}:${inputKey}`;
 
 /** ComfyUI's own guide to preparing a workflow for this — inputs, outputs, saving. */
 const APP_MODE_DOCS = "https://docs.comfy.org/interface/app-mode";
@@ -403,7 +402,10 @@ export function ComfyWorkflowImportModal({
         });
         if (cancelled) return;
         if (!response.ok) {
-          setError(await readError(response, "Could not re-read this workflow."));
+          // Re-checked: `readError` awaits the body, and the dialog can be
+          // closed during that await. The success path below already does this.
+          const message = await readError(response, "Could not re-read this workflow.");
+          if (!cancelled) setError(message);
           return;
         }
         const result = (await response.json()) as Inspection;
@@ -1037,7 +1039,11 @@ function FileDropZone({
   onFile: (file: File) => void;
 }) {
   return (
-    <div
+    // A button, not a div: dropping a file needs a pointer, but *picking* one
+    // should not — and the Blueprints tab is a different task, not an
+    // equivalent keyboard path to importing a local file.
+    <button
+      type="button"
       onDragOver={(e) => {
         e.preventDefault();
         onDragOver(true);
@@ -1050,7 +1056,7 @@ function FileDropZone({
         if (file) onFile(file);
       }}
       onClick={onPick}
-      className={`flex flex-col items-center justify-center gap-3 py-12 rounded-xl border border-dashed cursor-pointer transition-colors ${
+      className={`w-full flex flex-col items-center justify-center gap-3 py-12 rounded-xl border border-dashed cursor-pointer transition-colors ${
         dragOver
           ? "border-blue-500 bg-blue-500/5"
           : "border-neutral-600 hover:border-neutral-500 bg-neutral-900/40"
@@ -1058,7 +1064,7 @@ function FileDropZone({
     >
       {busy ? (
         <>
-          <div className="w-5 h-5 border-2 border-neutral-600 border-t-blue-500 rounded-full animate-spin" />
+          <span className="w-5 h-5 border-2 border-neutral-600 border-t-blue-500 rounded-full animate-spin" />
           <span className="text-xs text-neutral-400">Reading workflow…</span>
         </>
       ) : (
@@ -1076,15 +1082,16 @@ function FileDropZone({
             <path d="m7 10 5-5 5 5" />
             <path d="M12 5v12" />
           </svg>
-          <div className="text-center">
-            <p className="text-sm text-neutral-300">Drop a workflow JSON here</p>
-            <p className="text-[11px] text-neutral-500 mt-0.5">
+          {/* Spans, not p/div: a button may only hold phrasing content. */}
+          <span className="block text-center">
+            <span className="block text-sm text-neutral-300">Drop a workflow JSON here</span>
+            <span className="block text-[11px] text-neutral-500 mt-0.5">
               Saved or API-format exports both work
-            </p>
-          </div>
+            </span>
+          </span>
         </>
       )}
-    </div>
+    </button>
   );
 }
 

--- a/src/components/nodes/BaseNode.tsx
+++ b/src/components/nodes/BaseNode.tsx
@@ -296,11 +296,16 @@ export function BaseNode({
         // body. Selection already did this; the running outline did not, and
         // stopped short of the settings — the same node looked like two
         // different shapes depending on why it was highlighted.
+        // The running outline lives here, at full opacity and 1px, because this
+        // is the only element that encloses the settings panel as well as the
+        // body. It has to be the *only* blue line: the body drops its own
+        // border below, or the node wears two of them down its sides and one
+        // down the settings.
         ? `relative flex flex-col w-full h-full overflow-visible bg-neutral-800 rounded-lg ${
             selected
               ? "ring-2 ring-blue-500/40 shadow-lg shadow-blue-500/25"
               : running
-                ? "ring-1 ring-blue-500/20"
+                ? "ring-1 ring-blue-500"
                 : ""
           }`
         : "contents"}
@@ -324,10 +329,11 @@ export function BaseNode({
           ${fullBleed
             ? ""
             : running
-              // The wrapper above carries the ring when it exists, so drawing
-              // one here too would trace the body's edge through the middle of
-              // the node. Mirrors what selection does two lines down.
-              ? (hasExpandedSettings ? "border-blue-500" : "border-blue-500 ring-1 ring-blue-500/20")
+              // Transparent, not neutral, when the wrapper is outlining the
+              // whole node: a dark hairline just inside the blue one reads as
+              // a gap, and a blue one reads as a second outline that stops
+              // where the settings start.
+              ? (hasExpandedSettings ? "border-transparent" : "border-blue-500 ring-1 ring-blue-500/20")
               : "border-neutral-700/60"}
           ${fullBleed ? "" : (hasError ? "border-red-500" : "")}
           ${fullBleed && selected && !settingsExpanded ? "ring-2 ring-blue-500/40 shadow-lg shadow-blue-500/25" : ""}

--- a/src/components/nodes/ComfyAppNode.tsx
+++ b/src/components/nodes/ComfyAppNode.tsx
@@ -16,7 +16,7 @@ import { ComfyWordmark } from "@/components/icons/ComfyWordmark";
 import { useShowHandleLabels } from "@/hooks/useShowHandleLabels";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { outputsToNodeData } from "@/store/execution/comfyAppExecutor";
-import { appToInputSchema } from "@/lib/comfy/nodeSchema";
+import { appInputHandles, appToInputSchema } from "@/lib/comfy/nodeSchema";
 import { mergeParamValues } from "@/lib/comfy/reconfigure";
 import type {
   ComfyAppDefinition,
@@ -42,10 +42,6 @@ function handleTop(index: number, total: number): string {
   return `${((index + 1) / (total + 1)) * 100}%`;
 }
 
-/** Handle id for a connectable input — indexed per type, as the store expects. */
-function inputHandleId(type: ComfyInputType, indexWithinType: number): string {
-  return `${type}-${indexWithinType}`;
-}
 
 export function ComfyAppNode({ id, data, selected }: NodeProps<ComfyAppNodeType>) {
   const nodeData = data;
@@ -93,15 +89,7 @@ export function ComfyAppNode({ id, data, selected }: NodeProps<ComfyAppNodeType>
   }, [app, id, nodeData.inputSchema, updateNodeData]);
 
   /** Input handles, grouped by type so ids stay `image-0`, `text-0`, … */
-  const inputHandles = useMemo(() => {
-    if (!app) return [];
-    const counters: Record<string, number> = {};
-    return app.inputs.map((input) => {
-      const index = counters[input.type] ?? 0;
-      counters[input.type] = index + 1;
-      return { ...input, handleId: inputHandleId(input.type, index) };
-    });
-  }, [app]);
+  const inputHandles = useMemo(() => (app ? appInputHandles(app) : []), [app]);
 
   const outputHandles = useMemo(() => app?.outputs ?? [], [app]);
 
@@ -132,16 +120,7 @@ export function ComfyAppNode({ id, data, selected }: NodeProps<ComfyAppNodeType>
    */
   const pruneStaleEdges = useCallback(
     (attached: ComfyAppDefinition) => {
-      const inputHandleIds = new Set(
-        (() => {
-          const counters: Record<string, number> = {};
-          return attached.inputs.map((input) => {
-            const index = counters[input.type] ?? 0;
-            counters[input.type] = index + 1;
-            return inputHandleId(input.type, index);
-          });
-        })()
-      );
+      const inputHandleIds = new Set(appInputHandles(attached).map((input) => input.handleId));
       const outputHandleIds = new Set(attached.outputs.map((o) => o.id));
       for (const edge of edges) {
         if (edge.target === id && edge.targetHandle && !inputHandleIds.has(edge.targetHandle)) {
@@ -155,11 +134,19 @@ export function ComfyAppNode({ id, data, selected }: NodeProps<ComfyAppNodeType>
   );
 
   const handleAttach = useCallback(
-    (attached: ComfyAppDefinition, inspection: ComfyWorkflowInspection) => {
+    (
+      attached: ComfyAppDefinition,
+      inspection: ComfyWorkflowInspection | undefined,
+      meta?: { savedNodeId?: string }
+    ) => {
       pruneStaleEdges(attached);
       updateNodeData(id, {
         app: attached,
         inspection,
+        // Cleared unless this came from the library: a node that has been given
+        // a different workflow is no longer the saved one, and offering to
+        // "update" that entry with it would overwrite something else entirely.
+        savedNodeId: meta?.savedNodeId,
         inputSchema: appToInputSchema(attached),
         // A new contract invalidates the previous run entirely — old parameter
         // ids point at nodes the new graph may not even have.
@@ -193,7 +180,7 @@ export function ComfyAppNode({ id, data, selected }: NodeProps<ComfyAppNodeType>
    * on a setting they kept must survive being shown the list again.
    */
   const handleReconfigure = useCallback(
-    (attached: ComfyAppDefinition, inspection: ComfyWorkflowInspection) => {
+    (attached: ComfyAppDefinition, inspection: ComfyWorkflowInspection | undefined) => {
       pruneStaleEdges(attached);
       const paramValues = mergeParamValues(attached.params, nodeData.paramValues ?? {});
       // Results are keyed by output handle id, so a dropped output's value has
@@ -361,6 +348,8 @@ export function ComfyAppNode({ id, data, selected }: NodeProps<ComfyAppNodeType>
         }}
         onAttach={modal === "edit" ? handleReconfigure : handleAttach}
         {...(app ? { existingName: app.name } : {})}
+        {...(nodeData.savedNodeId ? { savedNodeId: nodeData.savedNodeId } : {})}
+        paramValues={nodeData.paramValues ?? {}}
         {...(reconfigureTarget ? { reconfigure: reconfigureTarget } : {})}
         {...(dropped && modal === "replace" ? { upload: dropped } : {})}
       />

--- a/src/components/nodes/ComfyAppNode.tsx
+++ b/src/components/nodes/ComfyAppNode.tsx
@@ -13,6 +13,7 @@ import {
   type ComfyUpload,
 } from "@/components/modals/ComfyWorkflowImportModal";
 import { ComfyWordmark } from "@/components/icons/ComfyWordmark";
+import { useComfyPreview } from "@/hooks/useComfyPreview";
 import { useShowHandleLabels } from "@/hooks/useShowHandleLabels";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { outputsToNodeData } from "@/store/execution/comfyAppExecutor";
@@ -243,6 +244,9 @@ export function ComfyAppNode({ id, data, selected }: NodeProps<ComfyAppNodeType>
     ) : undefined;
 
   const isRunning = nodeData.status === "loading";
+  // The latent as it forms. Only the v2 engines emit these, so it stays null
+  // on a stock ComfyUI and the node keeps its spinner.
+  const livePreview = useComfyPreview(nodeData.jobId, isRunning);
 
   return (
     <>
@@ -332,6 +336,7 @@ export function ComfyAppNode({ id, data, selected }: NodeProps<ComfyAppNodeType>
                 <Preview
                   preview={primaryPreview}
                   isRunning={isRunning}
+                  livePreview={livePreview}
                   error={nodeData.status === "error" ? nodeData.error : null}
                 />
               </div>
@@ -494,16 +499,19 @@ function HeaderButton({
   );
 }
 
-function Preview({
-  preview,
-  isRunning,
-  error,
-}: {
-  preview: { type: ComfyOutputType; value: string; label: string } | null;
-  isRunning: boolean;
-  error: string | null;
-}) {
-  if (isRunning) {
+/**
+ * A node mid-render.
+ *
+ * Where the engine sends previews, the latent itself — which says more about
+ * what is happening than any number Comfy Cloud currently reports, since its
+ * progress carries no node name, no step counts, and a fraction that reaches
+ * 100% several times before the job ends.
+ *
+ * The spinner stays for everything else: the first seconds of any run, and
+ * every run on a stock ComfyUI, which has no event stream at all.
+ */
+function Rendering({ livePreview }: { livePreview: string | null }) {
+  if (!livePreview) {
     return (
       <div className="flex flex-col items-center gap-2 text-neutral-500">
         <div className="w-5 h-5 border-2 border-neutral-600 border-t-blue-500 rounded-full animate-spin" />
@@ -511,6 +519,39 @@ function Preview({
       </div>
     );
   }
+
+  return (
+    <div className="relative w-full h-full">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={livePreview}
+        alt="Rendering"
+        // Each frame replaces the last; a fade would cross-blend two states of
+        // the same image into something neither of them looked like.
+        className="w-full h-full object-contain"
+      />
+      {/* Over the image, not beside it: the preview fills the node, and this
+          has to stay legible on whatever the latent happens to look like. */}
+      <div className="absolute bottom-1.5 left-1/2 -translate-x-1/2 flex items-center gap-1.5 px-2 py-1 rounded-full bg-black/60 backdrop-blur-sm">
+        <div className="w-2.5 h-2.5 border-2 border-neutral-500 border-t-blue-400 rounded-full animate-spin" />
+        <span className="text-[9px] text-neutral-200">Rendering…</span>
+      </div>
+    </div>
+  );
+}
+
+function Preview({
+  preview,
+  isRunning,
+  livePreview,
+  error,
+}: {
+  preview: { type: ComfyOutputType; value: string; label: string } | null;
+  isRunning: boolean;
+  livePreview: string | null;
+  error: string | null;
+}) {
+  if (isRunning) return <Rendering livePreview={livePreview} />;
   if (error) {
     return (
       <div className="px-3 py-2 max-h-full overflow-y-auto nowheel">

--- a/src/components/nodes/ComfyAppNode.tsx
+++ b/src/components/nodes/ComfyAppNode.tsx
@@ -397,15 +397,22 @@ function EmptyState({
         if (!file) return;
         e.preventDefault();
         e.stopPropagation();
-        void file.text().then((text) => {
-          try {
-            onDropWorkflow({ workflow: JSON.parse(text), filename: file.name });
-          } catch {
-            // The dialog is where a bad file gets explained; it reports the
-            // same way whether the JSON or the workflow inside it is at fault.
-            onDropWorkflow({ workflow: text, filename: file.name });
-          }
-        });
+        void file
+          .text()
+          .then((text) => {
+            try {
+              onDropWorkflow({ workflow: JSON.parse(text), filename: file.name });
+            } catch {
+              // The dialog is where a bad file gets explained; it reports the
+              // same way whether the JSON or the workflow inside it is at fault.
+              onDropWorkflow({ workflow: text, filename: file.name });
+            }
+          })
+          .catch(() => {
+            // A file the browser could not read at all. Still the dialog's to
+            // report — without this the drop does nothing and says nothing.
+            onDropWorkflow({ workflow: null, filename: file.name });
+          });
       }}
       className={`nodrag nopan flex-1 flex flex-col items-center justify-center gap-4 rounded-xl border border-dashed transition-colors ${
         dragOver

--- a/src/components/nodes/ComfyAppParameters.tsx
+++ b/src/components/nodes/ComfyAppParameters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { ComfyCurveEditor } from "./ComfyCurveEditor";
 import type { ComfyAppParam } from "@/lib/comfy/types";
@@ -112,6 +112,10 @@ interface ComfyParameterInputProps {
  */
 function ComfyParameterInputInner({ param, value, onChange }: ComfyParameterInputProps) {
   const label = shortLabel(param);
+  // Pairs each label with its control, so a screen reader announces the field
+  // by name and a click on the label focuses it. Generated rather than derived
+  // from `param.id`, which repeats across two nodes running the same workflow.
+  const controlId = useId();
   const [local, setLocal] = useState<string>(() =>
     value === undefined || value === null ? "" : String(value)
   );
@@ -158,10 +162,15 @@ function ComfyParameterInputInner({ param, value, onChange }: ComfyParameterInpu
   if (param.enum && param.enum.length > 0) {
     return (
       <div className="flex items-center gap-2">
-        <label className="text-[11px] text-neutral-400 shrink-0" title={param.description}>
+        <label
+          htmlFor={controlId}
+          className="text-[11px] text-neutral-400 shrink-0"
+          title={param.description}
+        >
           {label}
         </label>
         <select
+          id={controlId}
           value={(value as string) ?? ""}
           onChange={(e) => onChange(param.id, e.target.value || undefined)}
           className="nodrag nopan flex-1 min-w-0 text-[11px] py-1 px-2 rounded-md bg-[#1a1a1a] focus:outline-none focus:ring-1 focus:ring-neutral-600 text-white"
@@ -200,10 +209,11 @@ function ComfyParameterInputInner({ param, value, onChange }: ComfyParameterInpu
   if (param.multiline) {
     return (
       <div className="flex flex-col gap-1">
-        <label className="text-[11px] text-neutral-400" title={param.description}>
+        <label htmlFor={controlId} className="text-[11px] text-neutral-400" title={param.description}>
           {label}
         </label>
         <textarea
+          id={controlId}
           value={local}
           rows={3}
           placeholder={param.default !== undefined ? String(param.default) : undefined}
@@ -230,11 +240,16 @@ function ComfyParameterInputInner({ param, value, onChange }: ComfyParameterInpu
   return (
     <div className="flex flex-col gap-0.5">
       <div className="flex items-center gap-2">
-        <label className="text-[11px] text-neutral-400 shrink-0" title={param.description}>
+        <label
+          htmlFor={controlId}
+          className="text-[11px] text-neutral-400 shrink-0"
+          title={param.description}
+        >
           {label}
         </label>
         <div className="flex-1 min-w-0 flex items-center gap-1">
           <input
+            id={controlId}
             type={isNumber ? "number" : "text"}
             value={local}
             placeholder={param.default !== undefined ? String(param.default) : undefined}

--- a/src/components/nodes/ComfyCurveEditor.tsx
+++ b/src/components/nodes/ComfyCurveEditor.tsx
@@ -140,7 +140,12 @@ function ComfyCurveEditorInner({ label, value, onChange, description }: ComfyCur
           const locked = index === 0 || index === curve.points.length - 1;
           return (
             <circle
-              key={`${index}-${point[0]}`}
+              // By index alone. Keying on the moving x remounted the circle on
+              // every drag frame, and the browser drops pointer capture with
+              // the element it was set on — so a drag stopped tracking the
+              // moment the pointer left the SVG. The point count only changes
+              // on add and remove, where a remount is what should happen.
+              key={index}
               cx={cx}
               cy={cy}
               r={dragging === index ? 6 : 4.5}

--- a/src/components/settings/ComfySettingsTab.tsx
+++ b/src/components/settings/ComfySettingsTab.tsx
@@ -45,11 +45,23 @@ export function ComfySettingsTab({ settings, onChange }: ComfySettingsTabProps) 
 
   const configError = comfyConfigError(settings);
 
-  // A different endpoint invalidates the previous probe, so clear it rather
-  // than leaving a green tick against a URL that was never tested.
+  // A different endpoint — or credential, or transport — invalidates the
+  // previous probe, so clear it rather than leaving a green tick against a
+  // configuration that was never tested. Every field the probe depends on
+  // belongs here, including the two API-v2 toggles, which change the routes it
+  // calls entirely.
   useEffect(() => {
     setResult(null);
-  }, [settings.mode, settings.cloudApiKey, settings.localUrl, settings.remoteUrl, settings.cloudUrl]);
+  }, [
+    settings.mode,
+    settings.cloudApiKey,
+    settings.cloudUrl,
+    settings.localUrl,
+    settings.localUsesApiV2,
+    settings.remoteUrl,
+    settings.remoteApiKey,
+    settings.remoteUsesApiV2,
+  ]);
 
   const update = useCallback(
     (patch: Partial<ComfySettings>) => onChange({ ...settings, ...patch }),

--- a/src/hooks/useComfyPreview.ts
+++ b/src/hooks/useComfyPreview.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { buildComfyHeaders, getComfySettings } from "@/lib/comfy/settings";
+
+/**
+ * The latest preview image for a running Comfy job.
+ *
+ * Held in component state rather than in the workflow store, deliberately. A
+ * preview is a 70–80KB JPEG of a half-finished latent: it belongs to the run,
+ * not to the node, and node data is what gets written into saved workflow
+ * files. Keeping it here means there is no cleanup to get wrong — the run ends,
+ * the component stops asking, the image goes.
+ *
+ * Returns null whenever there is nothing to show, which is the normal case for
+ * a stock ComfyUI (no event stream) and for the first seconds of any run.
+ */
+export function useComfyPreview(jobId: string | null | undefined, active: boolean): string | null {
+  const [preview, setPreview] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active || !jobId) {
+      setPreview(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    void (async () => {
+      // The stream ends on its own when the job finishes, and the route is
+      // bounded by its own maxDuration — so reopen while the run is still
+      // going rather than treating the first close as the end.
+      while (!cancelled) {
+        try {
+          const response = await fetch("/api/comfy/preview", {
+            method: "POST",
+            headers: buildComfyHeaders(getComfySettings()),
+            body: JSON.stringify({ jobId }),
+            signal: controller.signal,
+          });
+          // 204 is this engine saying it has no previews at all. Reconnecting
+          // would be a pointless request every few seconds, forever.
+          if (response.status === 204 || !response.ok || !response.body) return;
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffered = "";
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done || cancelled) break;
+            buffered += decoder.decode(value, { stream: true });
+            const lines = buffered.split("\n");
+            // The last piece may be half a frame; keep it for the next chunk.
+            buffered = lines.pop() ?? "";
+            for (const line of lines) {
+              if (!line.trim()) continue;
+              try {
+                const frame = JSON.parse(line) as { dataUrl?: string };
+                if (frame.dataUrl) setPreview(frame.dataUrl);
+              } catch {
+                // A truncated frame is not worth failing the stream over.
+              }
+            }
+          }
+        } catch {
+          // Aborted, or the connection dropped. The loop condition decides
+          // whether that was the end.
+        }
+        if (cancelled) return;
+        // Don't hammer a route that is refusing instantly.
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [jobId, active]);
+
+  // Cleared on the way out so the next run never opens on the last one's latent.
+  useEffect(() => {
+    if (!active) setPreview(null);
+  }, [active]);
+
+  return preview;
+}

--- a/src/hooks/useSavedComfyNodes.ts
+++ b/src/hooks/useSavedComfyNodes.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import {
+  listSavedComfyNodes,
+  subscribeSavedComfyNodes,
+  type SavedComfyNode,
+} from "@/lib/comfy/library";
+
+/**
+ * The saved-node library, kept current.
+ *
+ * `useSyncExternalStore` rather than an effect because the menus that list
+ * these are mounted while the dialog that writes them is open — an effect would
+ * read once and then go stale the moment something was saved.
+ */
+export function useSavedComfyNodes(): SavedComfyNode[] {
+  return useSyncExternalStore(subscribeSavedComfyNodes, read, empty);
+}
+
+/**
+ * The snapshot must be referentially stable between writes: `listSavedComfyNodes`
+ * parses localStorage afresh each call, and returning a new array from every
+ * read would put `useSyncExternalStore` in an infinite loop.
+ *
+ * Invalidation is registered once at module scope, not per subscriber, so a
+ * write that happens while nothing is mounted still marks the cache stale.
+ */
+let snapshot: SavedComfyNode[] = [];
+let dirty = true;
+
+if (typeof window !== "undefined") {
+  subscribeSavedComfyNodes(() => {
+    dirty = true;
+  });
+}
+
+function read(): SavedComfyNode[] {
+  if (dirty) {
+    snapshot = listSavedComfyNodes();
+    dirty = false;
+  }
+  return snapshot;
+}
+
+const EMPTY: SavedComfyNode[] = [];
+/** The server renders no library at all; localStorage is a browser thing. */
+const empty = (): SavedComfyNode[] => EMPTY;
+
+/** Force the next read to hit storage. Exported for tests, which write to
+ *  localStorage directly rather than through the library. */
+export function invalidateSavedComfyNodes(): void {
+  dirty = true;
+}

--- a/src/lib/comfy/__tests__/curve.test.ts
+++ b/src/lib/comfy/__tests__/curve.test.ts
@@ -179,6 +179,31 @@ describe("editing", () => {
     expect(moved.points.map((p) => p[0])).toEqual([...moved.points.map((p) => p[0])].sort((a, b) => a - b));
   });
 
+  it("keeps the order when an imported curve crowds a point", () => {
+    // `normalizeCurve` only drops duplicates within 1e-6, so a workflow can
+    // carry neighbours closer together than two MIN_POINT_GAPs. The clamp
+    // range is then empty, and clamping into an empty range lands *below* the
+    // previous point — an unsorted list that `sampleCurve` reads as ascending,
+    // so the drawn curve stops matching the stored value.
+    const crowded = {
+      points: [
+        [0, 0],
+        [0.5, 0.5],
+        [0.51, 0.6],
+        [0.52, 0.7],
+        [1, 1],
+      ] as Array<[number, number]>,
+    };
+
+    const moved = moveCurvePoint(crowded, 2, 0, 0.9);
+    const xs = moved.points.map((p) => p[0]);
+
+    expect(xs).toEqual([...xs].sort((a, b) => a - b));
+    // Held where it was on x, but still free to move vertically.
+    expect(moved.points[2]![0]).toBe(0.51);
+    expect(moved.points[2]![1]).toBe(0.9);
+  });
+
   it("removes an interior point and keeps the endpoints", () => {
     const three = addCurvePoint(IDENTITY_CURVE, 0.5, 0.8);
     expect(removeCurvePoint(three, 1).points).toEqual(IDENTITY_CURVE.points);

--- a/src/lib/comfy/__tests__/engineErrors.test.ts
+++ b/src/lib/comfy/__tests__/engineErrors.test.ts
@@ -83,6 +83,18 @@ describe("errorCode", () => {
     expect(errorCode(fetchFailed("ECONNRESET"))).toBe("ECONNRESET");
     expect(errorCode(new Error("plain"))).toBe(null);
   });
+
+  it("keeps looking past a cause that carries no code", () => {
+    // Both shapes at once: a bare cause and one coded entry per address. A
+    // search that stopped at the cause reported no code at all, and no code
+    // means no connect-phase retry for a request that was safe to repeat.
+    const coded = new Error("connect ECONNREFUSED");
+    (coded as { code?: string }).code = "ECONNREFUSED";
+    const aggregate = new AggregateError([coded], "");
+    (aggregate as { cause?: unknown }).cause = new Error("no code here");
+
+    expect(errorCode(aggregate)).toBe("ECONNREFUSED");
+  });
 });
 
 describe("createEngineFetch", () => {
@@ -161,15 +173,87 @@ describe("createEngineFetch", () => {
     const starts: number[] = [];
     stubStalledFetch(starts);
 
-    const engineFetch = createEngineFetch({ retryBaseMs: 0, requestTimeoutMs: 40 });
+    // 200ms rather than 40: the deadline is two timeouts and it is only checked
+    // between attempts, so the expected elapsed time is 2-3x the timeout either
+    // way — but at 40ms the margin left over is small enough that one GC pause
+    // on a loaded CI runner fails a test that found nothing wrong.
+    const engineFetch = createEngineFetch({ retryBaseMs: 0, requestTimeoutMs: 200 });
     const began = Date.now();
     await expect(engineFetch("https://cloud.comfy.org/api/v2/jobs/job-1")).rejects.toThrow();
 
     // Bounded by elapsed time, not by the retry count: four retries of one
     // timeout would be five times the wait, and the caller checks its own
     // deadline only between requests.
-    expect(Date.now() - began).toBeLessThan(40 * 4);
+    expect(Date.now() - began).toBeLessThan(200 * 4);
     expect(starts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("holds a connect failure to the same deadline once it costs a timeout", async () => {
+    // `ETIMEDOUT` is a connect failure — nothing was sent, so repeating is safe
+    // — but unlike a refused connection it costs the whole timeout. Bounding
+    // that branch by the retry count alone let five attempts against an
+    // unreachable dual-stack host run for minutes on an asset route.
+    const starts: number[] = [];
+    vi.stubGlobal("fetch", (_url: string, init: RequestInit) => {
+      starts.push(Date.now());
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(noAddressAnswered()), { once: true });
+      });
+    });
+
+    const engineFetch = createEngineFetch({ retryBaseMs: 0, requestTimeoutMs: 200, retries: 4 });
+    const began = Date.now();
+    await expect(engineFetch("https://cloud.comfy.org/api/v2/jobs/job-1")).rejects.toThrow();
+
+    expect(Date.now() - began).toBeLessThan(200 * 4);
+    expect(starts.length).toBeLessThanOrEqual(3);
+  });
+
+  it("still spends its whole retry count on connect failures that cost nothing", async () => {
+    // The reason the count exists: a refused connection fails in milliseconds,
+    // and roughly two Comfy Cloud submits in five needed a second attempt.
+    let calls = 0;
+    vi.stubGlobal("fetch", async () => {
+      calls += 1;
+      if (calls <= 4) throw fetchFailed("ECONNREFUSED");
+      return new Response("{}", { status: 200 });
+    });
+
+    const engineFetch = createEngineFetch({ retryBaseMs: 0, retries: 4 });
+    expect((await engineFetch("https://cloud.comfy.org/api/v2/jobs")).status).toBe(200);
+    expect(calls).toBe(5);
+  });
+
+  it("releases the body of a response it is about to throw away", async () => {
+    // An unread body holds its socket until the collector gets to it, so a run
+    // that retries a 429 several times leaks one connection per attempt.
+    const cancelled: string[] = [];
+    let calls = 0;
+    vi.stubGlobal("fetch", async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: new Headers(),
+          body: {
+            cancel: async () => {
+              cancelled.push("first");
+            },
+          },
+        } as unknown as Response;
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const { resilientFetch } = await import("../server/fetch");
+    const res = await resilientFetch("https://cloud.comfy.org/api/v2/jobs", {
+      retries: 1,
+      retryBaseMs: 0,
+    });
+
+    expect(res.status).toBe(200);
+    expect(cancelled).toEqual(["first"]);
   });
 
   it("gives an asset transfer longer than a poll", async () => {

--- a/src/lib/comfy/__tests__/inspect.test.ts
+++ b/src/lib/comfy/__tests__/inspect.test.ts
@@ -168,6 +168,33 @@ describe("inspectWorkflow with App Mode", () => {
   });
 });
 
+describe("a boundary slot the author wired to more than one node", () => {
+  it("keeps every binding when the slot becomes a handle", () => {
+    // A Blueprint's `STRING` boundary slot is declared connectable, so it lands
+    // on a handle rather than in the settings — and a prompt slot feeding two
+    // text encoders is still one connection point. Carrying the extra bindings
+    // only on parameters silently dropped them here, leaving the second encoder
+    // on the workflow's own saved text.
+    const inspection = inspectWorkflow(graph(), {
+      appMode: {
+        inputs: [
+          {
+            nodeId: "24",
+            widget: "text",
+            connectAs: "text",
+            alsoBind: [{ nodeId: "9", widget: "filename_prefix" }],
+          },
+        ],
+        outputNodeIds: ["9"],
+      },
+    });
+
+    const prompt = inspection.suggested.inputs.find((i) => i.id === "24:text");
+    expect(prompt?.type).toBe("text");
+    expect(prompt?.alsoBind).toEqual([{ nodeId: "9", inputKey: "filename_prefix" }]);
+  });
+});
+
 describe("inspectWorkflow with App Mode and an uncurated loader", () => {
   it("still exposes a media loader App Mode does not mention", () => {
     // A blueprint's boundary inputs are not widgets, so they never appear in a

--- a/src/lib/comfy/__tests__/library.test.ts
+++ b/src/lib/comfy/__tests__/library.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+import {
+  getSavedComfyNode,
+  instantiateSavedComfyNode,
+  listSavedComfyNodes,
+  removeSavedComfyNode,
+  renameSavedComfyNode,
+  saveComfyNode,
+  seedFromSavedComfyNode,
+  withDialledValues,
+} from "@/lib/comfy/library";
+import { COMFY_APPS_KEY } from "@/lib/comfy/settings";
+import type { ComfyAppDefinition } from "@/lib/comfy/types";
+
+const app = (over: Partial<ComfyAppDefinition> = {}): ComfyAppDefinition => ({
+  id: "comfy_1",
+  name: "Upscale 2x",
+  description: "",
+  source: "upload",
+  graph: { "1": { class_type: "LoadImage", inputs: {} } },
+  inputs: [
+    {
+      id: "1:image",
+      name: "image",
+      label: "Photo",
+      type: "image",
+      nodeId: "1",
+      inputKey: "image",
+      required: true,
+    },
+  ],
+  params: [
+    { id: "3:steps", label: "Steps", nodeId: "3", inputKey: "steps", type: "integer", default: 20 },
+    { id: "3:seed", label: "Seed", nodeId: "3", inputKey: "seed", type: "integer", default: 0, isSeed: true },
+  ],
+  outputs: [
+    { id: "9", label: "Result", type: "image", nodeId: "9", classType: "SaveImage" },
+  ],
+  classTypes: ["LoadImage", "SaveImage"],
+  nodeCount: 2,
+  createdAt: 1,
+  ...over,
+});
+
+describe("the saved-node library", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("keeps a saved node and gives it back", () => {
+    const entry = saveComfyNode({ name: "Upscale 2x", app: app() });
+
+    expect(listSavedComfyNodes()).toHaveLength(1);
+    expect(getSavedComfyNode(entry.id)?.name).toBe("Upscale 2x");
+    expect(getSavedComfyNode(entry.id)?.app.outputs).toHaveLength(1);
+  });
+
+  it("overwrites the entry it was given, rather than adding another", () => {
+    // Otherwise "update" leaves a pile of near-identical entries, which is the
+    // failure this whole id exists to prevent.
+    const first = saveComfyNode({ name: "Upscale", app: app() });
+    saveComfyNode({ id: first.id, name: "Upscale (better)", app: app() });
+
+    const all = listSavedComfyNodes();
+    expect(all).toHaveLength(1);
+    expect(all[0]!.name).toBe("Upscale (better)");
+  });
+
+  it("does not hand out the library's own objects", () => {
+    // A node editing its picks must not rewrite the saved entry as it goes.
+    const entry = saveComfyNode({ name: "Upscale", app: app() });
+    const taken = instantiateSavedComfyNode(entry);
+    taken.app.outputs.pop();
+    taken.app.name = "mangled";
+
+    expect(getSavedComfyNode(entry.id)?.app.outputs).toHaveLength(1);
+    expect(getSavedComfyNode(entry.id)?.app.name).toBe("Upscale 2x");
+  });
+
+  it("skips an entry it cannot use instead of losing the whole library", () => {
+    window.localStorage.setItem(
+      COMFY_APPS_KEY,
+      JSON.stringify([{ id: "broken", name: "Broken" }, null, "nonsense"])
+    );
+    expect(listSavedComfyNodes()).toEqual([]);
+  });
+
+  it("survives storage holding something that is not a list", () => {
+    window.localStorage.setItem(COMFY_APPS_KEY, "{oh dear");
+    expect(listSavedComfyNodes()).toEqual([]);
+  });
+
+  it("removes and renames", () => {
+    const entry = saveComfyNode({ name: "Upscale", app: app() });
+    renameSavedComfyNode(entry.id, "Enhance");
+    expect(getSavedComfyNode(entry.id)?.name).toBe("Enhance");
+
+    removeSavedComfyNode(entry.id);
+    expect(listSavedComfyNodes()).toEqual([]);
+  });
+
+  it("reports a full library rather than dropping the save", () => {
+    // A save that silently did nothing is worse than one that refuses.
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+    expect(() => saveComfyNode({ name: "Upscale", app: app() })).toThrow(/no room/i);
+    setItem.mockRestore();
+  });
+});
+
+describe("withDialledValues", () => {
+  it("folds the values the node is running into the defaults", () => {
+    // This is what makes it a saved *node*: it comes back set up.
+    const folded = withDialledValues(app(), { "3:steps": 40 });
+    expect(folded.params.find((p) => p.id === "3:steps")?.default).toBe(40);
+  });
+
+  it("leaves seeds where they were", () => {
+    // Pinning a seed would make every copy of the node produce one picture.
+    const folded = withDialledValues(app(), { "3:seed": 12345 });
+    expect(folded.params.find((p) => p.id === "3:seed")?.default).toBe(0);
+  });
+
+  it("does not touch the app it was given", () => {
+    const original = app();
+    withDialledValues(original, { "3:steps": 40 });
+    expect(original.params.find((p) => p.id === "3:steps")?.default).toBe(20);
+  });
+});
+
+describe("seedFromSavedComfyNode", () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it("produces a node that already has its workflow, handles and settings", () => {
+    const entry = saveComfyNode({
+      name: "Upscale",
+      app: withDialledValues(app(), { "3:steps": 40 }),
+    });
+
+    const seed = seedFromSavedComfyNode(entry);
+
+    expect((seed.app as ComfyAppDefinition).name).toBe("Upscale 2x");
+    expect(seed.savedNodeId).toBe(entry.id);
+    // The handle map has to be there on arrival — it is what a dropped wire
+    // lands on, and nothing else builds it for a node created from a menu.
+    expect(seed.inputSchema).toEqual([
+      { name: "image", type: "image", required: true, label: "Photo" },
+    ]);
+    expect(seed.paramValues).toEqual({ "3:steps": 40 });
+  });
+
+  it("leaves the seed unset so repeat runs still vary", () => {
+    const entry = saveComfyNode({ name: "Upscale", app: app() });
+    expect(seedFromSavedComfyNode(entry).paramValues).not.toHaveProperty("3:seed");
+  });
+});

--- a/src/lib/comfy/__tests__/previews.test.ts
+++ b/src/lib/comfy/__tests__/previews.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+
+import { SdkComfyEngine, envelopeNodeId, previewImage } from "@/lib/comfy/server/sdkEngine";
+import type { ComfyConnection } from "@/lib/comfy/types";
+
+/**
+ * Turning the engine's event stream into the frames a node can draw.
+ *
+ * The payload is **not** the bare JPEG the SDK's types describe ("SSE `preview`
+ * event payload (JPEG, base64, throttled)"). ComfyUI wraps preview images in a
+ * binary envelope, and taking that at face value put a broken-image icon in the
+ * middle of the node — caught by looking at a real render, not by any test.
+ * These lock the real shape down.
+ */
+
+const connection: ComfyConnection = {
+  mode: "cloud",
+  baseUrl: "https://cloud.comfy.org",
+  apiKey: "comfyui-test",
+  useSdk: true,
+  jobTimeoutMs: 60_000,
+};
+
+const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x01, 0x02]);
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+
+/**
+ * The shape Comfy Cloud actually sends, verified against a live render:
+ * `[uint32 kind=4][uint32 jsonLength][JSON metadata][image bytes]`.
+ */
+function withMetadata(image: Uint8Array, meta: Record<string, unknown>): Uint8Array {
+  const json = Buffer.from(JSON.stringify(meta), "utf8");
+  const out = new Uint8Array(8 + json.length + image.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, 4);
+  view.setUint32(4, json.length);
+  out.set(json, 8);
+  out.set(image, 8 + json.length);
+  return out;
+}
+
+/** ComfyUI's older shape: `[uint32 kind=1][uint32 format][image bytes]`. */
+function classic(image: Uint8Array): Uint8Array {
+  const out = new Uint8Array(8 + image.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, 1);
+  view.setUint32(4, 1);
+  out.set(image, 8);
+  return out;
+}
+
+function engineYielding(events: Array<{ event: string; data: Record<string, unknown> }>) {
+  const engine = new SdkComfyEngine(connection);
+  const generator = async function* () {
+    for (const event of events) yield event;
+  };
+  Object.defineProperty(engine, "low", {
+    get: () => ({ getJobEvents: () => generator() }),
+    configurable: true,
+  });
+  return engine;
+}
+
+const collect = async (engine: SdkComfyEngine) => {
+  const frames = [];
+  for await (const frame of engine.previews("job_1")) frames.push(frame);
+  return frames;
+};
+
+const preview = (bytes: Uint8Array) => ({
+  event: "preview",
+  data: { node_id: "", data_base64: Buffer.from(bytes).toString("base64") },
+});
+
+describe("previewImage", () => {
+  it("digs the image out of the envelope Comfy Cloud sends", () => {
+    const found = previewImage(
+      withMetadata(JPEG_BYTES, { node_id: "114:81", image_type: "image/jpeg" })
+    );
+    expect(found?.mime).toBe("image/jpeg");
+    expect(found?.bytes).toEqual(JPEG_BYTES);
+  });
+
+  it("handles the older envelope a self-hosted engine may send", () => {
+    const found = previewImage(classic(PNG_BYTES));
+    expect(found?.mime).toBe("image/png");
+    expect(found?.bytes).toEqual(PNG_BYTES);
+  });
+
+  it("passes through bytes that are already an image", () => {
+    const found = previewImage(JPEG_BYTES);
+    expect(found?.mime).toBe("image/jpeg");
+    expect(found?.bytes).toEqual(JPEG_BYTES);
+  });
+
+  it("finds nothing in something that is not image-shaped", () => {
+    // A broken-image icon in the middle of the node is worse than the spinner
+    // it replaced, so an unrecognised payload has to read as "no preview".
+    expect(previewImage(new Uint8Array([1, 2, 3]))).toBeNull();
+    expect(previewImage(withMetadata(new Uint8Array([9, 9, 9]), {}))).toBeNull();
+  });
+
+  it("does not read past the end of a truncated envelope", () => {
+    const bytes = new Uint8Array(12);
+    new DataView(bytes.buffer).setUint32(0, 4);
+    new DataView(bytes.buffer).setUint32(4, 9999);
+    expect(previewImage(bytes)).toBeNull();
+  });
+});
+
+describe("envelopeNodeId", () => {
+  it("reads the node id the frame itself leaves empty", () => {
+    const bytes = withMetadata(JPEG_BYTES, { node_id: "114:81" });
+    expect(envelopeNodeId(bytes)).toBe("114:81");
+  });
+
+  it("returns nothing when there is no metadata to read", () => {
+    expect(envelopeNodeId(classic(JPEG_BYTES))).toBeNull();
+    expect(envelopeNodeId(JPEG_BYTES)).toBeNull();
+  });
+});
+
+describe("previews", () => {
+  it("yields a data URL an img can show, and the node it came from", async () => {
+    const frames = await collect(
+      engineYielding([preview(withMetadata(JPEG_BYTES, { node_id: "114:81" }))])
+    );
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.nodeId).toBe("114:81");
+    expect(frames[0]!.dataUrl).toBe(
+      `data:image/jpeg;base64,${Buffer.from(JPEG_BYTES).toString("base64")}`
+    );
+  });
+
+  it("ignores everything that is not a preview", async () => {
+    // Progress in particular: it rides the same stream, and it is the thing we
+    // deliberately do not draw.
+    const frames = await collect(
+      engineYielding([
+        { event: "progress", data: { value: 0.5 } },
+        { event: "status", data: { status: "running" } },
+        { event: "log", data: { level: "info", message: "hello" } },
+        preview(withMetadata(JPEG_BYTES, { node_id: "9" })),
+      ])
+    );
+
+    expect(frames).toHaveLength(1);
+  });
+
+  it("drops a frame it cannot make an image of", async () => {
+    const frames = await collect(
+      engineYielding([
+        { event: "preview", data: { node_id: "9", data_base64: "" } },
+        preview(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9])),
+      ])
+    );
+
+    expect(frames).toEqual([]);
+  });
+});

--- a/src/lib/comfy/__tests__/run.test.ts
+++ b/src/lib/comfy/__tests__/run.test.ts
@@ -65,6 +65,9 @@ describe("hashSeed", () => {
     expect(hashSeed("run-1")).not.toBe(hashSeed("run-2"));
     // ComfyUI declares seed maxima up to 2^64-1, which JSON cannot round-trip.
     expect(hashSeed("anything")).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
+    // And ComfyUI rejects a negative seed, so the floor matters as much.
+    expect(hashSeed("anything")).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(hashSeed("anything"))).toBe(true);
   });
 });
 
@@ -328,6 +331,36 @@ describe("a setting the author tied to several nodes", () => {
 
     expect(graph["99"]).toBeDefined();
     expect(graph["99"]?.inputs.filename_prefix).toBe("flux.safetensors");
+  });
+
+  it("does the same when the author's control became a handle", () => {
+    // A Blueprint's STRING boundary slot becomes a connectable input, not a
+    // setting — and one prompt slot can feed two text encoders. Carrying the
+    // extra bindings only on params left the second encoder rendering the
+    // workflow's own saved text while the first got the user's.
+    const graph = buildRunGraph({
+      app: app({
+        inputs: [
+          {
+            id: "24:text",
+            name: "prompt",
+            label: "Prompt",
+            type: "text",
+            nodeId: "24",
+            inputKey: "text",
+            required: false,
+            alsoBind: [{ nodeId: "99", inputKey: "filename_prefix" }],
+          },
+        ],
+      }),
+      text: { prompt: "a running fox" },
+      uploads: {},
+      params: {},
+    });
+
+    expect(graph["24"]?.inputs.text).toBe("a running fox");
+    // Reached only through the extra binding, so it also proves the prune kept it.
+    expect(graph["99"]?.inputs.filename_prefix).toBe("a running fox");
   });
 });
 

--- a/src/lib/comfy/curve.ts
+++ b/src/lib/comfy/curve.ts
@@ -195,7 +195,12 @@ export function moveCurvePoint(curve: ComfyCurve, index: number, x: number, y: n
   if (!isEnd) {
     const lower = points[index - 1]![0] + MIN_POINT_GAP;
     const upper = points[index + 1]![0] - MIN_POINT_GAP;
-    point[0] = Math.min(Math.max(clamp01(x), lower), upper);
+    // An imported curve is only de-duplicated at 1e-6, so its neighbours can sit
+    // closer together than two gaps. The range is then empty, and clamping into
+    // an empty range lands *below* the previous point — an unsorted list, which
+    // `sampleCurve` and `curvePath` both read as ascending. Such a point is
+    // x-locked instead; it can still move vertically.
+    if (lower <= upper) point[0] = Math.min(Math.max(clamp01(x), lower), upper);
   }
   return { ...curve, points };
 }

--- a/src/lib/comfy/editor.ts
+++ b/src/lib/comfy/editor.ts
@@ -648,7 +648,11 @@ function outputEntryId(entry: unknown): string | null {
  *   segments are `encodeURIComponent`-escaped.
  *
  * Returns the node id plus, for the `WidgetId` form, the widget name it
- * carries — which is authoritative over element `[1]` when they disagree.
+ * carries. That name is a *fallback*: element `[1]` of the tuple is the field
+ * the frontend writes when it renames or re-promotes a control, and it is also
+ * the boundary slot name that {@link promotedBindings} needs when the id turns
+ * out to name a subgraph instance. The name inside the id is only reached when
+ * element `[1]` is absent.
  */
 export function parseAppModeInputId(
   raw: unknown

--- a/src/lib/comfy/inspect.ts
+++ b/src/lib/comfy/inspect.ts
@@ -304,16 +304,18 @@ export function inspectWorkflow(
       // The author declaring this a boundary input outranks the name-shaped
       // guess, which only ever recognises prompts.
       const connectAs = entry.connectAs ?? candidate.connectableAs;
+      // One boundary slot can drive several inner widgets. The author exposed
+      // one control, so the run must write all of them from it — whether that
+      // control ended up a handle or a setting.
+      const alsoBind = entry.alsoBind?.map((b) => ({
+        nodeId: b.nodeId,
+        inputKey: b.widget,
+      }));
       if (connectAs) {
-        inputs.push(inputFromCandidate(candidate, connectAs, taken));
+        const input = inputFromCandidate(candidate, connectAs, taken);
+        inputs.push(alsoBind?.length ? { ...input, alsoBind } : input);
       } else {
         const param = paramFromCandidate(candidate);
-        // One boundary slot can drive several inner widgets. The author exposed
-        // one control, so the run must write all of them from it.
-        const alsoBind = entry.alsoBind?.map((b) => ({
-          nodeId: b.nodeId,
-          inputKey: b.widget,
-        }));
         params.push(alsoBind?.length ? { ...param, alsoBind } : param);
       }
     }

--- a/src/lib/comfy/library.ts
+++ b/src/lib/comfy/library.ts
@@ -1,0 +1,208 @@
+/**
+ * The saved-node library.
+ *
+ * A Comfy app node is a workflow plus a contract plus the values you dialled
+ * into it. Saving one keeps all three, so it can be dropped onto the canvas
+ * from the ordinary node menus and be ready — not merely attached, but set up
+ * the way it was when you decided it was worth keeping.
+ *
+ * Entries live in localStorage beside the other Comfy settings. That caps the
+ * library at the browser's ~5MB, shared with everything else Node Banana keeps
+ * there, which is why a failed write is reported rather than swallowed: a save
+ * that quietly did nothing is worse than no save at all.
+ */
+
+import { appToInputSchema } from "./nodeSchema";
+import { COMFY_APPS_KEY } from "./settings";
+import type { ComfyAppDefinition, ComfyAppParam, ComfyWorkflowInspection } from "./types";
+
+/** A workflow kept as a reusable node. */
+export interface SavedComfyNode {
+  /** Library id — distinct from `app.id`, which changes on every re-import. */
+  id: string;
+  /** The label shown in the node menus. */
+  name: string;
+  /** The contract, with the saved values folded into the parameter defaults. */
+  app: ComfyAppDefinition;
+  /**
+   * The candidate list from the original import, so the picks stay editable
+   * after the node is instantiated. Re-deriving it from the graph works but
+   * loses the author's App Mode curation, which only exists in the upload.
+   */
+  inspection?: ComfyWorkflowInspection;
+  savedAt: number;
+}
+
+/** Deep copy via JSON — the stored shapes are plain data, and this keeps a node
+ *  editing its own app from reaching back into the library's copy. */
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const isBrowser = (): boolean => typeof window !== "undefined" && !!window.localStorage;
+
+/** Entries that survive a shape check — a half-written app would break a node. */
+function parse(raw: string | null): SavedComfyNode[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is SavedComfyNode => {
+      if (!entry || typeof entry !== "object") return false;
+      const candidate = entry as Partial<SavedComfyNode>;
+      return (
+        typeof candidate.id === "string" &&
+        typeof candidate.name === "string" &&
+        !!candidate.app &&
+        Array.isArray(candidate.app.outputs)
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** Newest first — the one you just saved is the one you are looking for. */
+export function listSavedComfyNodes(): SavedComfyNode[] {
+  if (!isBrowser()) return [];
+  return parse(window.localStorage.getItem(COMFY_APPS_KEY)).sort(
+    (a, b) => b.savedAt - a.savedAt
+  );
+}
+
+export function getSavedComfyNode(id: string): SavedComfyNode | null {
+  return listSavedComfyNodes().find((entry) => entry.id === id) ?? null;
+}
+
+/**
+ * Fold the values a node is currently running into its parameter defaults.
+ *
+ * This is what separates a saved *node* from a saved workflow: the model,
+ * the prompt and the step count come back the way you left them. Seeds are
+ * left alone — they are re-randomised per run, so pinning one would make every
+ * copy of the node produce the same picture.
+ */
+export function withDialledValues(
+  app: ComfyAppDefinition,
+  values: Record<string, unknown>
+): ComfyAppDefinition {
+  const params: ComfyAppParam[] = app.params.map((param) => {
+    const value = values[param.id];
+    if (param.isSeed || value === undefined) return param;
+    return { ...param, default: value as ComfyAppParam["default"] };
+  });
+  return { ...app, params };
+}
+
+function write(entries: SavedComfyNode[]): void {
+  try {
+    window.localStorage.setItem(COMFY_APPS_KEY, JSON.stringify(entries));
+  } catch {
+    // Almost always the storage quota. Nothing here can free space safely —
+    // the other keys are the user's projects and costs — so it is reported.
+    throw new Error(
+      "There is no room left to save this node. Delete a saved node and try again."
+    );
+  }
+  notify();
+}
+
+/** Save a new entry, or overwrite `id` when replacing an existing one. */
+export function saveComfyNode(entry: {
+  id?: string;
+  name: string;
+  app: ComfyAppDefinition;
+  inspection?: ComfyWorkflowInspection;
+}): SavedComfyNode {
+  const saved: SavedComfyNode = {
+    id: entry.id ?? `saved_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+    name: entry.name.trim() || entry.app.name || "Comfy node",
+    app: clone(entry.app),
+    ...(entry.inspection ? { inspection: clone(entry.inspection) } : {}),
+    savedAt: Date.now(),
+  };
+  const existing = listSavedComfyNodes();
+  const index = existing.findIndex((e) => e.id === saved.id);
+  if (index >= 0) existing[index] = saved;
+  else existing.push(saved);
+  write(existing);
+  return saved;
+}
+
+export function removeSavedComfyNode(id: string): void {
+  write(listSavedComfyNodes().filter((entry) => entry.id !== id));
+}
+
+export function renameSavedComfyNode(id: string, name: string): void {
+  write(
+    listSavedComfyNodes().map((entry) =>
+      entry.id === id ? { ...entry, name: name.trim() || entry.name } : entry
+    )
+  );
+}
+
+/**
+ * A private copy of a saved entry's contract, for a node about to use it.
+ *
+ * The library's own objects are handed out by reference — a node editing its
+ * picks would otherwise rewrite the saved entry as a side effect.
+ */
+export function instantiateSavedComfyNode(saved: SavedComfyNode): {
+  app: ComfyAppDefinition;
+  inspection?: ComfyWorkflowInspection;
+} {
+  return {
+    app: clone(saved.app),
+    ...(saved.inspection ? { inspection: clone(saved.inspection) } : {}),
+  };
+}
+
+/**
+ * The node data a saved entry becomes when it is dropped onto the canvas.
+ *
+ * Mirrors what attaching a workflow produces, plus `savedNodeId` — which
+ * records where it came from, so the dialog can offer to update that entry
+ * rather than leaving another near-identical one as the only way back.
+ */
+export function seedFromSavedComfyNode(saved: SavedComfyNode): Record<string, unknown> {
+  const { app, inspection } = instantiateSavedComfyNode(saved);
+  return {
+    app,
+    ...(inspection ? { inspection } : {}),
+    inputSchema: appToInputSchema(app),
+    savedNodeId: saved.id,
+    // Seeds are excluded exactly as they are on a fresh attach: leaving one
+    // unset is what lets the executor randomise it per run.
+    paramValues: Object.fromEntries(
+      app.params
+        .filter((param) => param.default !== undefined && !param.isSeed)
+        .map((param) => [param.id, param.default])
+    ),
+  };
+}
+
+/* ── change notification ───────────────────────────────────────── */
+
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Watch the library.
+ *
+ * Saving happens inside a dialog while the menus that list saved nodes are
+ * mounted elsewhere, so a plain read of localStorage would go stale until a
+ * reload. The `storage` event covers the same app open in a second tab, which
+ * never fires for the tab that made the change — hence both.
+ */
+export function subscribeSavedComfyNodes(listener: () => void): () => void {
+  listeners.add(listener);
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === COMFY_APPS_KEY) listener();
+  };
+  if (isBrowser()) window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(listener);
+    if (isBrowser()) window.removeEventListener("storage", onStorage);
+  };
+}

--- a/src/lib/comfy/nodeSchema.ts
+++ b/src/lib/comfy/nodeSchema.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ModelInputDef } from "@/types/nodes";
-import type { ComfyAppDefinition } from "./types";
+import type { ComfyAppDefinition, ComfyAppInput } from "./types";
 
 /**
  * The `inputSchema` a Comfy app node should carry.
@@ -26,4 +26,22 @@ export function appToInputSchema(app: ComfyAppDefinition): ModelInputDef[] {
     label: input.label,
     ...(input.description ? { description: input.description } : {}),
   }));
+}
+
+/**
+ * Each input paired with the handle id it is rendered as.
+ *
+ * Ids are indexed per type — `image-0`, `image-1`, `text-0` — which the store
+ * relies on to map a handle back to its slot. Anything that needs to name one
+ * of these handles has to count the same way, so they all count here.
+ */
+export function appInputHandles(
+  app: ComfyAppDefinition
+): Array<ComfyAppInput & { handleId: string }> {
+  const counters: Record<string, number> = {};
+  return app.inputs.map((input) => {
+    const index = counters[input.type] ?? 0;
+    counters[input.type] = index + 1;
+    return { ...input, handleId: `${input.type}-${index}` };
+  });
 }

--- a/src/lib/comfy/reconfigure.ts
+++ b/src/lib/comfy/reconfigure.ts
@@ -8,7 +8,14 @@
 
 import type { ComfyAppDefinition, ComfyAppParam, ComfyWidgetCandidate } from "./types";
 
-const bindingKey = (nodeId: string, inputKey: string): string => `${nodeId}:${inputKey}`;
+/**
+ * The key both this module and the import dialog address a binding by.
+ *
+ * Exported because they must agree exactly: {@link withAppLabels} writes it and
+ * the dialog's `roles` map reads it, so two copies that drift would silently
+ * stop matching each other's entries.
+ */
+export const bindingKey = (nodeId: string, inputKey: string): string => `${nodeId}:${inputKey}`;
 
 /**
  * Carry the node's own names onto a candidate list.

--- a/src/lib/comfy/server/connection.ts
+++ b/src/lib/comfy/server/connection.ts
@@ -7,11 +7,13 @@
  * variables act as a fallback for a headless / shared deployment.
  */
 
-import { COMFY_HEADERS, COMFY_CLOUD_URL, COMFY_DEFAULT_JOB_TIMEOUT_MS } from "../settings";
+import {
+  clampJobTimeoutMs,
+  COMFY_HEADERS,
+  COMFY_CLOUD_URL,
+  COMFY_DEFAULT_JOB_TIMEOUT_MS,
+} from "../settings";
 import type { ComfyBackendMode, ComfyConnection } from "../types";
-
-const MIN_JOB_TIMEOUT_MS = 60_000;
-const MAX_JOB_TIMEOUT_MS = 3_600_000;
 
 export class ComfyConfigError extends Error {
   readonly status: number;
@@ -99,9 +101,7 @@ export function connectionFromRequest(request: Request): ComfyConnection {
     // headless deployment where no browser supplies one.
     apiKey: headers.get(COMFY_HEADERS.apiKey) || process.env.COMFY_API_KEY?.trim() || null,
     useSdk: headers.get(COMFY_HEADERS.apiV2) === "1",
-    jobTimeoutMs: Number.isFinite(timeout)
-      ? Math.min(MAX_JOB_TIMEOUT_MS, Math.max(MIN_JOB_TIMEOUT_MS, timeout))
-      : COMFY_DEFAULT_JOB_TIMEOUT_MS,
+    jobTimeoutMs: clampJobTimeoutMs(timeout),
   };
 }
 

--- a/src/lib/comfy/server/engine.ts
+++ b/src/lib/comfy/server/engine.ts
@@ -64,6 +64,19 @@ export interface ComfyJobState {
   raw: unknown;
 }
 
+/**
+ * A partial image an engine emitted mid-run — the latent as it forms.
+ *
+ * Throttled and lossy by design: it is a glimpse of work in progress, never a
+ * result, and is deliberately kept out of anything that persists.
+ */
+export interface ComfyPreviewFrame {
+  /** Graph node that produced it. */
+  nodeId: string;
+  /** Data URL, ready to put in an `<img>`. */
+  dataUrl: string;
+}
+
 /** One finished output, already downloaded. */
 export interface ComfyOutputAsset {
   /** Graph node that produced it. */
@@ -112,6 +125,15 @@ export interface ComfyEngine {
 
   /** Best-effort stop. Must never throw. */
   cancel(jobId: string, signal?: AbortSignal): Promise<void>;
+
+  /**
+   * Partial images while the job runs, if this engine can produce them.
+   *
+   * Optional because only the v2 surface has an event stream: a stock ComfyUI
+   * says nothing at all until `/history` fills in, so there is no honest
+   * implementation to give it. Callers must treat its absence as normal.
+   */
+  previews?(jobId: string, signal?: AbortSignal): AsyncGenerator<ComfyPreviewFrame, void, void>;
 }
 
 /** An engine-reported failure that should be shown to the user verbatim. */

--- a/src/lib/comfy/server/engine.ts
+++ b/src/lib/comfy/server/engine.ts
@@ -189,7 +189,13 @@ export function errorCode(error: unknown): string | null {
   const self = (error as { code?: unknown }).code;
   if (typeof self === "string") return self;
   const cause = (error as { cause?: unknown }).cause;
-  if (cause) return errorCode(cause);
+  if (cause) {
+    // A cause that carries no code is not an answer — an AggregateError can
+    // hold both a bare cause and one coded entry per address tried, and
+    // stopping here would report no code at all for it.
+    const fromCause = errorCode(cause);
+    if (fromCause) return fromCause;
+  }
   const nested = (error as { errors?: unknown }).errors;
   if (Array.isArray(nested)) {
     for (const inner of nested) {

--- a/src/lib/comfy/server/fetch.ts
+++ b/src/lib/comfy/server/fetch.ts
@@ -59,6 +59,10 @@ export async function resilientFetch(
     try {
       const res = await fetch(url, { ...init, signal: controller.signal });
       if (RETRYABLE_STATUS.has(res.status) && attempt < retries) {
+        // Nothing reads this response, and an unread body holds its socket
+        // until the collector gets to it — several retries of a 429 would
+        // otherwise leave one open connection each.
+        await res.body?.cancel().catch(() => undefined);
         await sleep(retryBaseMs * 2 ** attempt);
         continue;
       }
@@ -197,7 +201,12 @@ export function createEngineFetch(options: EngineFetchOptions = {}): typeof fetc
         const code = errorCode(error);
         const neverConnected = code !== null && CONNECT_FAILURE.test(code);
         const worthRetrying = neverConnected || (repeatable && engineNeverAnswered(error));
-        const budgetLeft = neverConnected ? attempt < retries : Date.now() < deadline;
+        // The count bounds the cheap case and the deadline bounds the expensive
+        // one. A refused connect costs milliseconds, so four of them fit inside
+        // the budget easily; `ETIMEDOUT` is also a connect failure and costs a
+        // whole timeout, and repeating *that* four times is exactly the wait
+        // the deadline above exists to forbid.
+        const budgetLeft = Date.now() < deadline && (neverConnected ? attempt < retries : true);
         if (!worthRetrying || !budgetLeft) throw error;
         await sleep(retryBaseMs * 2 ** Math.min(attempt, 4));
       }

--- a/src/lib/comfy/server/import.ts
+++ b/src/lib/comfy/server/import.ts
@@ -81,7 +81,7 @@ export async function prepareWorkflow(
     // so an unreachable engine degrades rather than blocking the import.
     let objectInfo: ComfyObjectInfo | undefined;
     if (engine) {
-      objectInfo = await getObjectInfo(engine, { signal: options.signal }).catch(() => undefined);
+      objectInfo = await getObjectInfo(engine).catch(() => undefined);
       if (!objectInfo) {
         warnings.push(
           "Could not reach the ComfyUI engine, so dropdown options and value limits are unavailable."
@@ -102,7 +102,7 @@ export async function prepareWorkflow(
 
   let objectInfo: ComfyObjectInfo;
   try {
-    objectInfo = await getObjectInfo(engine, { signal: options.signal });
+    objectInfo = await getObjectInfo(engine);
   } catch (error) {
     throw new ComfyImportError(
       `Could not read the node catalog from ${engine.label}, which is needed to interpret a saved workflow. ${
@@ -119,7 +119,7 @@ export async function prepareWorkflow(
     // The catalog is cached for minutes, so a user who installs the missing
     // node pack and retries would keep hitting the same stale answer. Re-read
     // once before reporting a failure they cannot clear.
-    objectInfo = await getObjectInfo(engine, { force: true, signal: options.signal }).catch(
+    objectInfo = await getObjectInfo(engine, { force: true }).catch(
       () => objectInfo
     );
     missing = editorNodeTypes(file).filter((type) => !objectInfo[type]);
@@ -128,7 +128,11 @@ export async function prepareWorkflow(
   if (options.blueprintId) {
     const { workflow, instanceNodeId, skippedOutputs, unsupportedInputs } =
       blueprintToWorkflowFile(file, options.blueprintId);
-    const graph = convert(workflow, objectInfo, missing, engine.label);
+    // Only the chosen blueprint is converted, so only its own node types are
+    // its problem — a file carrying several would otherwise tell the user to
+    // install a pack for a blueprint they did not pick.
+    const blueprintMissing = editorNodeTypes(workflow).filter((type) => !objectInfo[type]);
+    const graph = convert(workflow, objectInfo, blueprintMissing, engine.label);
     for (const skipped of skippedOutputs) {
       warnings.push(`Output "${skipped}" has no displayable type and was left unbound.`);
     }

--- a/src/lib/comfy/server/index.ts
+++ b/src/lib/comfy/server/index.ts
@@ -62,10 +62,14 @@ const catalogCache = new Map<string, CatalogEntry>();
  * it, so refetching per request would dominate import latency. The cache is
  * keyed by base URL — two users pointing at the same engine share it, which is
  * safe because the catalog is a property of the engine, not of the caller.
+ *
+ * There is deliberately no `signal`: the fetch is shared, so no one caller may
+ * abort it, and taking a signal only to ignore it advertises a cancellation
+ * that cannot happen.
  */
 export async function getObjectInfo(
   engine: ComfyEngine,
-  options: { force?: boolean; signal?: AbortSignal } = {}
+  options: { force?: boolean } = {}
 ): Promise<ComfyObjectInfo> {
   const key = engine.connection.baseUrl;
   const cached = catalogCache.get(key);

--- a/src/lib/comfy/server/legacyEngine.ts
+++ b/src/lib/comfy/server/legacyEngine.ts
@@ -67,7 +67,7 @@ export function collectOutputText(
 ): Array<{ nodeId: string; text: string }> {
   const results: Array<{ nodeId: string; text: string }> = [];
   for (const [nodeId, node] of Object.entries(outputs ?? {})) {
-    const raw = (node as { text?: unknown }).text;
+    const raw = (node as { text?: unknown } | null)?.text;
     if (!Array.isArray(raw)) continue;
     const text = raw.filter((t) => typeof t === "string").join("").trim();
     if (text.length > 0) results.push({ nodeId, text });

--- a/src/lib/comfy/server/run.ts
+++ b/src/lib/comfy/server/run.ts
@@ -18,14 +18,18 @@ import type {
 import type { ComfyEngine, ComfyOutputAsset } from "./engine";
 import { ComfyEngineError } from "./engine";
 
-/** Seeds must stay inside the range JSON can round-trip without precision loss. */
-const MAX_SEED = Number.MAX_SAFE_INTEGER;
-
-/** A deterministic seed derived from a run key. */
+/**
+ * A deterministic seed derived from a run key.
+ *
+ * Seeds must stay inside the range JSON round-trips without precision loss, and
+ * the `| 0` does that on its own: the accumulator never leaves signed 32-bit,
+ * which is far below `Number.MAX_SAFE_INTEGER`. Non-negative too, because
+ * ComfyUI rejects a negative seed.
+ */
 export function hashSeed(key: string): number {
   let h = 0;
   for (let i = 0; i < key.length; i += 1) h = (Math.imul(h, 31) + key.charCodeAt(i)) | 0;
-  return Math.abs(h) % MAX_SEED;
+  return Math.abs(h);
 }
 
 /**
@@ -82,6 +86,11 @@ export function buildRunGraph(options: BuildRunGraphOptions): ComfyGraph {
       const value = text[input.name];
       if (value !== undefined) {
         assignments.push({ nodeId: input.nodeId, inputKey: input.inputKey, value });
+        // A boundary slot wired to two text encoders is one connection point;
+        // writing only the first would leave the second on the author's text.
+        for (const extra of input.alsoBind ?? []) {
+          assignments.push({ nodeId: extra.nodeId, inputKey: extra.inputKey, value });
+        }
       }
       continue;
     }
@@ -118,6 +127,7 @@ export function buildRunGraph(options: BuildRunGraphOptions): ComfyGraph {
   const keepRoots = [
     ...outputNodeIds,
     ...app.inputs.map((i) => i.nodeId),
+    ...app.inputs.flatMap((i) => (i.alsoBind ?? []).map((b) => b.nodeId)),
     ...app.params.map((p) => p.nodeId),
     ...app.params.flatMap((p) => (p.alsoBind ?? []).map((b) => b.nodeId)),
   ];

--- a/src/lib/comfy/server/sdkEngine.ts
+++ b/src/lib/comfy/server/sdkEngine.ts
@@ -20,6 +20,7 @@ import {
   Unauthorized,
   WorkflowFormatUi,
 } from "@comfyorg/sdk";
+import { ComfyLow } from "@comfyorg/sdk/low";
 
 import { mediaTypeForFilename, mimeForFilename } from "../graph";
 import type { ComfyConnection, ComfyGraph, ComfyObjectInfo, ComfyOutputType } from "../types";
@@ -30,6 +31,7 @@ import {
   type ComfyEngine,
   type ComfyJobState,
   type ComfyOutputAsset,
+  type ComfyPreviewFrame,
   type ComfySubmitOptions,
   type ComfyUploadInput,
   type ComfyUploadRef,
@@ -53,6 +55,76 @@ const SDK_TIMEOUT_MS = 300_000;
 const TERMINAL = new Set(["succeeded", "canceled", "failed", "expired"]);
 const SUCCESS = "succeeded";
 
+/** Magic numbers, for deciding what a preview's bytes actually are. */
+const JPEG = [0xff, 0xd8];
+const PNG = [0x89, 0x50, 0x4e, 0x47];
+const startsWith = (bytes: Uint8Array, magic: number[]): boolean =>
+  magic.every((byte, index) => bytes[index] === byte);
+
+/**
+ * The image inside a preview payload.
+ *
+ * The payload is not the bare JPEG the SDK's types imply. ComfyUI wraps preview
+ * images in a binary envelope, and Comfy Cloud sends the newer of its two
+ * shapes — measured on a live render:
+ *
+ *   [uint32 kind=4][uint32 jsonLength][JSON metadata][image bytes]
+ *
+ * The classic shape (`kind=1`, then a format word, then the image) is handled
+ * too, since a self-hosted engine behind `comfy-api-proxy` may send it. Anything
+ * that already looks like an image is passed straight through, so an engine that
+ * skips the envelope entirely still works.
+ *
+ * Returns null when nothing image-shaped can be found — better a spinner than a
+ * broken-image icon in the middle of the node.
+ */
+export function previewImage(bytes: Uint8Array): { mime: string; bytes: Uint8Array } | null {
+  const sniff = (candidate: Uint8Array): { mime: string; bytes: Uint8Array } | null => {
+    if (startsWith(candidate, JPEG)) return { mime: "image/jpeg", bytes: candidate };
+    if (startsWith(candidate, PNG)) return { mime: "image/png", bytes: candidate };
+    return null;
+  };
+
+  const bare = sniff(bytes);
+  if (bare) return bare;
+  if (bytes.length < 8) return null;
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const kind = view.getUint32(0);
+  const second = view.getUint32(4);
+
+  // Metadata-carrying: the second word is the length of a JSON header.
+  if (kind === 4 && 8 + second <= bytes.length) {
+    return sniff(bytes.subarray(8 + second));
+  }
+  // Classic: the second word names the format, and the image follows it.
+  if (kind === 1) return sniff(bytes.subarray(8));
+  return null;
+}
+
+/**
+ * The graph node a preview belongs to, read from the envelope's metadata.
+ *
+ * Worth digging out because the SSE frame's own `node_id` field arrives empty
+ * from Comfy Cloud, while the envelope names it (`"114:81"` — the namespaced
+ * id of a node inside an expanded subgraph).
+ */
+export function envelopeNodeId(bytes: Uint8Array): string | null {
+  if (bytes.length < 8) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (view.getUint32(0) !== 4) return null;
+  const jsonLength = view.getUint32(4);
+  if (8 + jsonLength > bytes.length) return null;
+  try {
+    const meta = JSON.parse(Buffer.from(bytes.subarray(8, 8 + jsonLength)).toString("utf8")) as {
+      node_id?: unknown;
+    };
+    return typeof meta.node_id === "string" && meta.node_id ? meta.node_id : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Map the v2 output type onto a Node Banana handle type.
  *
@@ -72,9 +144,30 @@ function handleTypeFor(type: string, contentType: string, filename: string): Com
 export class SdkComfyEngine implements ComfyEngine {
   readonly label: string;
   private client: Comfy | null = null;
+  private lowClient: ComfyLow | null = null;
 
   constructor(readonly connection: ComfyConnection) {
     this.label = connection.mode === "cloud" ? "Comfy Cloud" : "ComfyUI (API v2)";
+  }
+
+  /**
+   * The generated transport, for the one thing the wrapper does not expose in a
+   * usable form: the raw event stream. Built with the same base URL, key and
+   * resilient fetch as {@link sdk}.
+   */
+  private get low(): ComfyLow {
+    if (!this.lowClient) {
+      this.lowClient = new ComfyLow(
+        this.connection.baseUrl,
+        this.connection.apiKey ?? undefined,
+        {
+          clientInfo: "node-banana",
+          timeoutMs: SDK_TIMEOUT_MS,
+          fetch: createEngineFetch(),
+        }
+      );
+    }
+    return this.lowClient;
   }
 
   private get sdk(): Comfy {
@@ -192,6 +285,47 @@ export class SdkComfyEngine implements ComfyEngine {
       return { status: job.status, terminal: true, error: null, raw: { jobId } };
     } catch (error) {
       throw toEngineError(error, `Could not read the job from ${this.label}`, this.label);
+    }
+  }
+
+  /**
+   * The engine's live event stream, reduced to the previews.
+   *
+   * Only `preview` frames are forwarded. The stream also carries progress, but
+   * Comfy Cloud fills it thinly — no node name, no step counts, and a fraction
+   * computed against a node total that grows as the graph expands, so it
+   * reaches 100% several times before the job ends. A picture of the latent is
+   * both truthful and more use.
+   *
+   * One connection, no reconnect: a dropped stream costs a stale thumbnail,
+   * and the caller reopens while the job is still running.
+   */
+  async *previews(
+    jobId: string,
+    signal?: AbortSignal
+  ): AsyncGenerator<ComfyPreviewFrame, void, void> {
+    // No idle timeout: a long sampling step legitimately emits nothing, and
+    // erroring the stream there would throw away the run's remaining previews.
+    const events = this.low.getJobEvents(jobId, {
+      ...(signal ? { signal } : {}),
+      timeoutMs: null,
+    });
+    for await (const event of events) {
+      if (event.event !== "preview") continue;
+      const data = event.data as { node_id?: unknown; data_base64?: unknown };
+      const base64 = typeof data.data_base64 === "string" ? data.data_base64 : "";
+      if (!base64) continue;
+
+      const payload = Buffer.from(base64, "base64");
+      const image = previewImage(new Uint8Array(payload));
+      if (!image) continue;
+
+      yield {
+        // The frame's own `node_id` comes through empty on Comfy Cloud; the
+        // envelope's metadata carries the real one.
+        nodeId: envelopeNodeId(payload) ?? String(data.node_id ?? ""),
+        dataUrl: `data:${image.mime};base64,${Buffer.from(image.bytes).toString("base64")}`,
+      };
     }
   }
 

--- a/src/lib/comfy/settings.ts
+++ b/src/lib/comfy/settings.ts
@@ -32,6 +32,20 @@ export const COMFY_DEFAULT_JOB_TIMEOUT_MS = 1_800_000; // 30 minutes
 const MIN_JOB_TIMEOUT_MS = 60_000;
 const MAX_JOB_TIMEOUT_MS = 3_600_000;
 
+/**
+ * A job timeout the user (or a request header) supplied, brought into range.
+ *
+ * Shared with the server side so the two cannot drift: a browser storing one
+ * bound and a route enforcing another would cancel a render the settings pane
+ * said was still allowed.
+ */
+export function clampJobTimeoutMs(value: unknown): number {
+  const ms = Number(value);
+  return Number.isFinite(ms)
+    ? Math.min(MAX_JOB_TIMEOUT_MS, Math.max(MIN_JOB_TIMEOUT_MS, ms))
+    : COMFY_DEFAULT_JOB_TIMEOUT_MS;
+}
+
 export interface ComfySettings {
   /** Backend used for Comfy app nodes. Cloud is the default. */
   mode: ComfyBackendMode;
@@ -91,7 +105,6 @@ export function normalizeComfySettings(raw: unknown): ComfySettings {
     stored.mode === "local" || stored.mode === "remote" || stored.mode === "cloud"
       ? stored.mode
       : defaultComfySettings.mode;
-  const timeout = Number(stored.jobTimeoutMs);
   return {
     ...defaultComfySettings,
     ...stored,
@@ -99,9 +112,7 @@ export function normalizeComfySettings(raw: unknown): ComfySettings {
     cloudUrl: trimTrailingSlash(stored.cloudUrl || COMFY_CLOUD_URL) || COMFY_CLOUD_URL,
     localUrl: trimTrailingSlash(stored.localUrl || COMFY_LOCAL_URL) || COMFY_LOCAL_URL,
     remoteUrl: trimTrailingSlash(stored.remoteUrl || ""),
-    jobTimeoutMs: Number.isFinite(timeout)
-      ? Math.min(MAX_JOB_TIMEOUT_MS, Math.max(MIN_JOB_TIMEOUT_MS, timeout))
-      : COMFY_DEFAULT_JOB_TIMEOUT_MS,
+    jobTimeoutMs: clampJobTimeoutMs(stored.jobTimeoutMs),
   };
 }
 

--- a/src/lib/comfy/types.ts
+++ b/src/lib/comfy/types.ts
@@ -67,6 +67,17 @@ export interface ComfyAppInput {
   inputKey: string;
   required: boolean;
   description?: string;
+  /**
+   * Extra graph bindings this one handle also writes.
+   *
+   * The same story as {@link ComfyAppParam.alsoBind}: a Blueprint's `STRING`
+   * boundary slot can reach several inner widgets — one prompt feeding two text
+   * encoders — and the author exposed one connection point for all of them.
+   * Because a boundary slot becomes a *handle* rather than a setting, the
+   * carry-through has to exist on both shapes or the secondary encoders keep
+   * the workflow's saved text while the primary one gets the user's.
+   */
+  alsoBind?: Array<{ nodeId: string; inputKey: string }>;
 }
 
 /**

--- a/src/store/execution/comfyAppExecutor.ts
+++ b/src/store/execution/comfyAppExecutor.ts
@@ -115,6 +115,9 @@ function isAbort(error: unknown, signal?: AbortSignal): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
+/** How long a best-effort cancel may take before the node stops waiting on it. */
+const CANCEL_TIMEOUT_MS = 10_000;
+
 /** Best-effort stop for an engine job. Never throws. */
 async function cancelJob(
   headers: Record<string, string>,
@@ -127,6 +130,10 @@ async function cancelJob(
       method: "POST",
       headers,
       body: JSON.stringify({ jobId, app, cancel: true }),
+      // Its own bound, unrelated to the run's: cancelling is what *unblocks*
+      // the node, so a stalled route must not be able to hold the user's Stop
+      // — or the job-timeout path — waiting forever for a best-effort request.
+      signal: AbortSignal.timeout(CANCEL_TIMEOUT_MS),
     });
   } catch {
     // A cancel must never fail the cancel.

--- a/src/types/nodes.ts
+++ b/src/types/nodes.ts
@@ -676,6 +676,16 @@ export interface ComfyAppNodeData extends BaseNodeData {
    * them — because that lives in the uploaded file, not the runnable graph.
    */
   inspection?: ComfyWorkflowInspection;
+  /**
+   * The library entry this node was created from, when it came from a saved
+   * node rather than an import.
+   *
+   * Saving is a snapshot, so this node and that entry drift apart the moment
+   * either is changed. Knowing which entry it was lets the dialog offer to
+   * update that one, instead of leaving "save again" as the only way back and
+   * a pile of near-identical entries as the result.
+   */
+  savedNodeId?: string;
   /** Values for `app.params`, keyed by param id. */
   paramValues: Record<string, unknown>;
   /** Derived from `app.inputs` — drives dynamic handles and `dynamicInputs`. */

--- a/src/utils/__tests__/comfyOutputStorage.test.ts
+++ b/src/utils/__tests__/comfyOutputStorage.test.ts
@@ -1,0 +1,150 @@
+/**
+ * A Comfy node's outputs surviving a save and a reload.
+ *
+ * A Comfy app can produce several outputs at once, each under its own handle,
+ * and they are not all images. The bug this pins down: every one of them was
+ * written through the image store while hydration read video and audio back out
+ * of the generation store — so a workflow saved with a video output reopened
+ * with that output empty, and the node looked like it had never run.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { externalizeWorkflowMedia, hydrateWorkflowMedia } from "../mediaStorage";
+import type { WorkflowFile } from "@/types";
+
+const IMAGE = "data:image/png;base64,aW1hZ2U=";
+const VIDEO = "data:video/mp4;base64,dmlkZW8=";
+const AUDIO = "data:audio/mpeg;base64,YXVkaW8=";
+
+/** What each store was handed, so the save side can be read back per type. */
+const written = { images: new Map<string, string>(), generations: new Map<string, string>() };
+
+const app = {
+  id: "app-1",
+  name: "App",
+  description: "",
+  source: "upload",
+  graph: {},
+  inputs: [],
+  params: [],
+  outputs: [
+    { id: "9", label: "Image", type: "image", nodeId: "9", classType: "SaveImage" },
+    { id: "10", label: "Video", type: "video", nodeId: "10", classType: "SaveVideo" },
+    { id: "11", label: "Audio", type: "audio", nodeId: "11", classType: "SaveAudio" },
+    { id: "12", label: "Notes", type: "text", nodeId: "12", classType: "ShowText" },
+  ],
+  classTypes: [],
+  nodeCount: 4,
+  createdAt: 0,
+};
+
+const workflow = (outputs: Record<string, string>): WorkflowFile =>
+  ({
+    nodes: [
+      {
+        id: "comfy-1",
+        type: "comfyApp",
+        position: { x: 0, y: 0 },
+        data: { app, outputs },
+      },
+    ],
+    edges: [],
+  }) as unknown as WorkflowFile;
+
+const nodeData = (file: WorkflowFile) =>
+  file.nodes[0]!.data as {
+    outputs?: Record<string, string>;
+    outputRefs?: Record<string, string>;
+    outputVideo?: string | null;
+    outputAudio?: string | null;
+    outputImage?: string | null;
+  };
+
+beforeEach(() => {
+  written.images.clear();
+  written.generations.clear();
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, string>) : {};
+
+      if (url.startsWith("/api/workflow-images?")) {
+        const id = new URLSearchParams(url.split("?")[1]).get("imageId")!;
+        const image = written.images.get(id);
+        return new Response(JSON.stringify(image ? { success: true, image } : { success: false }));
+      }
+      if (url === "/api/workflow-images") {
+        written.images.set(body.imageId!, body.imageData!);
+        return new Response(JSON.stringify({ success: true, imageId: body.imageId }));
+      }
+      if (url === "/api/save-generation") {
+        written.generations.set(body.imageId!, body.video ?? body.audio ?? "");
+        return new Response(JSON.stringify({ success: true, imageId: body.imageId }));
+      }
+      if (url === "/api/load-generation") {
+        const stored = written.generations.get(body.imageId!);
+        if (!stored) return new Response(JSON.stringify({ success: false, notFound: true }));
+        return new Response(
+          JSON.stringify({ success: true, video: stored, audio: stored })
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("a Comfy node's outputs across save and reload", () => {
+  it("puts each type in the store hydration reads it back from", async () => {
+    const saved = await externalizeWorkflowMedia(
+      workflow({ "9": IMAGE, "10": VIDEO, "11": AUDIO, "12": "some notes" }),
+      "/tmp/project"
+    );
+    const data = nodeData(saved);
+
+    // Externalized, so nothing heavy is left inline…
+    expect(data.outputs).toEqual({ "12": "some notes" });
+    expect(Object.keys(data.outputRefs ?? {}).sort()).toEqual(["10", "11", "9"]);
+
+    // …and each one landed in its own store.
+    expect(written.images.get(data.outputRefs!["9"]!)).toBe(IMAGE);
+    expect(written.generations.get(data.outputRefs!["10"]!)).toBe(VIDEO);
+    expect(written.generations.get(data.outputRefs!["11"]!)).toBe(AUDIO);
+  });
+
+  it("brings all three back, and rebuilds the typed mirrors", async () => {
+    const saved = await externalizeWorkflowMedia(
+      workflow({ "9": IMAGE, "10": VIDEO, "11": AUDIO, "12": "some notes" }),
+      "/tmp/project"
+    );
+    const reloaded = nodeData(await hydrateWorkflowMedia(saved, "/tmp/project"));
+
+    expect(reloaded.outputs).toEqual({
+      "9": IMAGE,
+      "10": VIDEO,
+      "11": AUDIO,
+      "12": "some notes",
+    });
+    expect(reloaded.outputImage).toBe(IMAGE);
+    expect(reloaded.outputVideo).toBe(VIDEO);
+    expect(reloaded.outputAudio).toBe(AUDIO);
+  });
+
+  it("leaves text and remote URLs inline rather than storing them", async () => {
+    // A text output is small, and a file per run would be waste; an http URL
+    // is already somewhere else and has nothing to externalize.
+    const saved = await externalizeWorkflowMedia(
+      workflow({ "12": "some notes", "9": "https://example.com/cat.png" }),
+      "/tmp/project"
+    );
+    const data = nodeData(saved);
+
+    expect(data.outputs).toEqual({ "12": "some notes", "9": "https://example.com/cat.png" });
+    expect(data.outputRefs).toEqual({});
+  });
+});

--- a/src/utils/mediaStorage.ts
+++ b/src/utils/mediaStorage.ts
@@ -584,19 +584,29 @@ async function externalizeNodeMedia(
       // externalized under its own handle id. Text outputs stay inline —
       // they are small, and a text file per run would be wasteful.
       const outputs = d.outputs ?? {};
-      const textHandles = new Set(
-        (d.app?.outputs ?? []).filter((o) => o.type === "text").map((o) => o.id)
-      );
+      const declaredType = new Map((d.app?.outputs ?? []).map((o) => [o.id, o.type]));
       const refs: Record<string, string> = { ...(d.outputRefs ?? {}) };
       const remaining: Record<string, string> = {};
       for (const [handleId, value] of Object.entries(outputs)) {
-        if (textHandles.has(handleId) || !isDataUrl(value)) {
+        const type = declaredType.get(handleId);
+        if (type === "text" || !isDataUrl(value)) {
           remaining[handleId] = value;
           continue;
         }
-        if (!refs[handleId]) {
-          refs[handleId] = await saveImageAndGetId(value, workflowPath, savedImageIds, "generations");
-        }
+        if (refs[handleId]) continue;
+        // Each type into the store hydration reads it back from. Saving a video
+        // through the image store and loading it from the video store is how an
+        // output survived the save and came back empty.
+        const ref =
+          type === "video"
+            ? await saveVideoAndGetRef(value, workflowPath, savedMediaIds)
+            : type === "audio"
+              ? await saveAudioAndGetRef(value, workflowPath, savedMediaIds)
+              : await saveImageAndGetId(value, workflowPath, savedImageIds, "generations");
+        // A store that declined the value leaves it inline rather than losing
+        // it to a ref that points at nothing.
+        if (ref) refs[handleId] = ref;
+        else remaining[handleId] = value;
       }
       newData = {
         ...d,


### PR DESCRIPTION
Carries the last three feature commits on this branch — saved Comfy nodes, the one-outline-while-running fix, and live latent previews — plus a pass over the CodeRabbit review on #138.

## Fixed

**Transport** — `createEngineFetch` bounded connect failures by attempt count alone, and `ETIMEDOUT` is a connect failure that costs a whole timeout, so five of them ran for 150s on a poll and ~25 min on an asset route, past the two-timeout bound the code documents. `resilientFetch` leaked one socket per retried 429. `errorCode` stopped at a code-less `cause` and so reported nothing for an `AggregateError` that carried both. The blueprint routes allowed a 150s retry budget inside a 120s invocation.

**Routes** — the run route's required-input check and its patch loop disagreed on "present", so `{ prompt: "" }` for a required input passed validation, was skipped by the loop, and submitted a job with nothing patched in. `decodeDataUrl` rejected any data URL carrying a media-type parameter. The poll route validates `app` instead of failing inside `collectRun` as a 500. The workflow size cap counts bytes, not UTF-16 code units.

**Contract** — `alsoBind` existed only on parameters, but a Blueprint's `STRING` boundary slot becomes a *handle*; one prompt slot feeding two encoders drove only the first.

**Canvas + persistence** — a Comfy app with outputs but no connectable inputs could never receive a dropped wire. Video and audio outputs were saved through the image store and hydrated from the generation store, so they came back empty after a reload.

**UI** — the curve editor lost pointer capture on every drag frame (key included the moving x) and could invert its own clamp on a crowded imported curve. The import dialog's drop zone had no keyboard path, parameter labels named no control, and the settings probe kept its green tick across changes to `remoteApiKey` and both API-v2 toggles.

## Not fixed

Replied inline on #138 with reasons. The short version: a byte cap on `/api/comfy/run` would reject legitimate multi-megabyte media payloads; keyboard *editing* for the curve widget is a feature, not a fix; the catalog fixture is a recording of what Comfy Cloud actually returned and hand-editing it would make the hermetic test assert a fiction; an empty parameter field means "use the default" by design, since the default is its placeholder.

## Verification

2594 tests across 121 files, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save, rename, delete, and reuse ComfyUI nodes from a local library.
  * Preview ComfyUI workflows with metadata, editable parameters, and live execution images.
  * Select saved nodes from search and connection menus.
  * Support workflow import by drag-and-drop or `Shift + C`.

* **Bug Fixes**
  * Improved required-input validation, workflow size checks, retries, cancellation, and output persistence.
  * Preserved graph connections and curve ordering during editing.

* **Style & Accessibility**
  * Refined cross-browser scrollbars, running-node highlights, and form label associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->