### PR TITLE
fix(comfy): second and third CodeRabbit passes

### DIFF
--- a/scripts/comfy-smoke.mjs
+++ b/scripts/comfy-smoke.mjs
@@ -248,11 +248,12 @@ function textFor(input) {
   return "a cinematic photo of a red car on a coastal road at sunset";
 }
 
-async function nb(path, body) {
+async function nb(path, body, timeoutMs) {
   const res = await fetch(`${NB_BASE}${path}`, {
     method: "POST",
     headers: nbHeaders(),
     body: JSON.stringify(body),
+    ...(timeoutMs ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
   });
   const text = await res.text();
   let json = null;
@@ -262,6 +263,17 @@ async function nb(path, body) {
     /* not JSON — surfaced below */
   }
   return { res, json, text };
+}
+
+/**
+ * Stop a job we are walking away from. Bounded and never throws.
+ *
+ * Best-effort, but not unbounded: this runs on the path that reports why the
+ * run failed, so a `/api/comfy/poll` that stalls here would swallow the reason
+ * as surely as it holds the credits.
+ */
+async function cancelRun(jobId, app) {
+  await nb("/api/comfy/poll", { jobId, app, cancel: true }, 15_000).catch(() => {});
 }
 
 /** Import, feed, submit, poll, and check the result is usable. */
@@ -315,7 +327,7 @@ async function runOne(id, timeoutMs) {
 
   for (;;) {
     if (Date.now() > deadline) {
-      await nb("/api/comfy/poll", { jobId, app, cancel: true });
+      await cancelRun(jobId, app);
       return { id, ok: false, stage: "timeout", error: `gave up after ${Math.round(timeoutMs / 60000)} min` };
     }
     await new Promise((r) => setTimeout(r, interval));
@@ -328,7 +340,7 @@ async function runOne(id, timeoutMs) {
       if (polled.json?.transient) continue;
       // Giving up locally does not stop the render — and it is billed. The
       // timeout branch above already cancels; so must this one.
-      await nb("/api/comfy/poll", { jobId, app, cancel: true }).catch(() => {});
+      await cancelRun(jobId, app);
       return { id, ok: false, stage: "run", error: polled.json?.error ?? polled.text.slice(0, 200) };
     }
     if (polled.json.polling) continue;

--- a/src/app/api/comfy/__tests__/run.route.test.ts
+++ b/src/app/api/comfy/__tests__/run.route.test.ts
@@ -100,8 +100,14 @@ describe("POST /api/comfy/run", () => {
   it("reports the missing input before spending anything on uploads", async () => {
     // Decoding and hashing media for a run that cannot be submitted is work
     // thrown away, and on a large image it is not cheap work.
-    await call({});
+    //
+    // The successful call comes first on purpose: "was not called" says nothing
+    // unless the mock is known to be reached when the route does get that far.
+    await call({ prompt: "a dog" });
+    expect(uploadInputs).toHaveBeenCalledOnce();
 
+    uploadInputs.mockClear();
+    await call({});
     expect(uploadInputs).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/comfy/preview/route.ts
+++ b/src/app/api/comfy/preview/route.ts
@@ -93,7 +93,9 @@ export async function POST(request: NextRequest) {
         closed = true;
         // The browser navigated away or the run ended; let the generator's
         // `finally` close the upstream connection.
-        void frames.return(undefined);
+        // Caught: the cleanup is a promise, and a rejection from it on a
+        // disconnect would be as unhandled as the double close above.
+        void frames.return(undefined).catch(() => undefined);
       },
     });
 

--- a/src/app/api/comfy/preview/route.ts
+++ b/src/app/api/comfy/preview/route.ts
@@ -57,6 +57,17 @@ export async function POST(request: NextRequest) {
     const frames = engine.previews(body.jobId, request.signal);
     const encoder = new TextEncoder();
 
+    // The platform calls `cancel()` when the browser disconnects, and the
+    // controller is closed from that moment. Closing it again throws
+    // `TypeError: Invalid state` out of a promise nothing awaits — an unhandled
+    // rejection in the server log every time someone navigates away mid-render.
+    let closed = false;
+    const close = (controller: ReadableStreamDefaultController<Uint8Array>) => {
+      if (closed) return;
+      closed = true;
+      controller.close();
+    };
+
     const stream = new ReadableStream<Uint8Array>({
       // One frame per pull, not a loop that drains the engine as fast as it
       // emits. `enqueue` never blocks, so draining upstream would pile frames
@@ -67,7 +78,7 @@ export async function POST(request: NextRequest) {
         try {
           const next = await frames.next();
           if (next.done) {
-            controller.close();
+            close(controller);
             return;
           }
           controller.enqueue(encoder.encode(`${JSON.stringify(next.value)}\n`));
@@ -75,10 +86,11 @@ export async function POST(request: NextRequest) {
           // A dropped upstream stream ends this one. It says nothing about the
           // job, which the poll loop is watching regardless, so it is closed
           // quietly rather than raised as a failure the user would have to read.
-          controller.close();
+          close(controller);
         }
       },
       cancel() {
+        closed = true;
         // The browser navigated away or the run ended; let the generator's
         // `finally` close the upstream connection.
         void frames.return(undefined);

--- a/src/app/api/comfy/preview/route.ts
+++ b/src/app/api/comfy/preview/route.ts
@@ -16,6 +16,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { engineFromRequest } from "@/lib/comfy/server";
+import type { ComfyPreviewFrame } from "@/lib/comfy/server/engine";
 import { comfyErrorResponse } from "../shared";
 
 export const maxDuration = 300;
@@ -25,19 +26,29 @@ interface ComfyPreviewRequest {
   jobId: string;
 }
 
-/** One frame, as the client receives it. */
-export interface ComfyPreviewMessage {
-  nodeId: string;
-  dataUrl: string;
-}
+/**
+ * One frame, as the client receives it.
+ *
+ * An alias rather than a second declaration: the route forwards what the engine
+ * yields verbatim, so a field added on one side has to appear on the other.
+ */
+export type ComfyPreviewMessage = ComfyPreviewFrame;
 
 export async function POST(request: NextRequest) {
+  // Outside the try: a body that is not JSON, or a job id that is not a string,
+  // is the caller's mistake. Left to `comfyErrorResponse` the `SyntaxError`
+  // becomes a 500, which reads as "the engine broke".
+  let body: ComfyPreviewRequest;
   try {
-    const body = (await request.json()) as ComfyPreviewRequest;
-    if (!body?.jobId) {
-      return NextResponse.json({ success: false, error: "No job id" }, { status: 400 });
-    }
+    body = (await request.json()) as ComfyPreviewRequest;
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (typeof body?.jobId !== "string" || body.jobId === "") {
+    return NextResponse.json({ success: false, error: "No job id" }, { status: 400 });
+  }
 
+  try {
     const { engine } = engineFromRequest(request);
     // A stock ComfyUI has no event stream. Answering "nothing here" is the
     // honest reply, and the caller simply keeps its spinner.
@@ -47,16 +58,23 @@ export async function POST(request: NextRequest) {
     const encoder = new TextEncoder();
 
     const stream = new ReadableStream<Uint8Array>({
-      async start(controller) {
+      // One frame per pull, not a loop that drains the engine as fast as it
+      // emits. `enqueue` never blocks, so draining upstream would pile frames
+      // up in server memory whenever the browser reads slower than the render
+      // produces — a backgrounded tab, say — and each one is ~100KB of base64
+      // on a route that stays open for minutes.
+      async pull(controller) {
         try {
-          for await (const frame of frames) {
-            controller.enqueue(encoder.encode(`${JSON.stringify(frame)}\n`));
+          const next = await frames.next();
+          if (next.done) {
+            controller.close();
+            return;
           }
+          controller.enqueue(encoder.encode(`${JSON.stringify(next.value)}\n`));
         } catch {
           // A dropped upstream stream ends this one. It says nothing about the
           // job, which the poll loop is watching regardless, so it is closed
           // quietly rather than raised as a failure the user would have to read.
-        } finally {
           controller.close();
         }
       },

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -1380,7 +1380,7 @@ export function WorkflowCanvas() {
       const newNodeId = addNode(
         nodeType,
         flowPosition,
-        saved ? (seedFromSavedComfyNode(saved) as Partial<WorkflowNodeData>) : undefined
+        saved ? seedFromSavedComfyNode(saved) : undefined
       );
 
       // Tutorial tracking
@@ -1659,7 +1659,7 @@ export function WorkflowCanvas() {
         addNode(
           type,
           nodeSearchMenu.flowPosition,
-          saved ? (seedFromSavedComfyNode(saved) as Partial<WorkflowNodeData>) : undefined
+          saved ? seedFromSavedComfyNode(saved) : undefined
         );
       }
       setNodeSearchMenu(null);

--- a/src/components/__tests__/ComfyAppPreview.test.tsx
+++ b/src/components/__tests__/ComfyAppPreview.test.tsx
@@ -17,7 +17,7 @@ import type { ComfyAppNodeData } from "@/types";
 
 const mockUpdateNodeData = vi.fn();
 const mockUseWorkflowStore = vi.fn();
-const mockPreview = vi.fn<() => string | null>(() => null);
+const mockPreview = vi.fn<(jobId?: string | null, active?: boolean) => string | null>(() => null);
 
 vi.mock("@/store/workflowStore", () => ({
   useWorkflowStore: (selector?: (state: unknown) => unknown) =>
@@ -25,7 +25,10 @@ vi.mock("@/store/workflowStore", () => ({
 }));
 
 vi.mock("@/hooks/useComfyPreview", () => ({
-  useComfyPreview: () => mockPreview(),
+  // Arguments forwarded, not dropped: the node deciding *when* to stream, and
+  // for which job, is the half of this worth asserting.
+  useComfyPreview: (jobId: string | null | undefined, active: boolean) =>
+    mockPreview(jobId, active),
 }));
 
 vi.mock("@xyflow/react", async () => {
@@ -105,6 +108,18 @@ describe("a running Comfy node", () => {
         setHoveredNodeId: vi.fn(),
       })
     );
+  });
+
+  it("streams for the job it is running, and only while it runs", () => {
+    // The half the mock used to swallow. A node that asked for previews of the
+    // wrong job — or kept asking after the run ended — would still have shown
+    // whatever the hook returned, so every test below would pass regardless.
+    render(tree(nodeData()));
+    expect(mockPreview).toHaveBeenCalledWith("job_1", true);
+
+    mockPreview.mockClear();
+    render(tree(nodeData({ status: "success", runStatus: null })));
+    expect(mockPreview).toHaveBeenCalledWith("job_1", false);
   });
 
   it("shows the latent once the engine sends one", () => {

--- a/src/components/__tests__/ComfyWorkflowImportModal.test.tsx
+++ b/src/components/__tests__/ComfyWorkflowImportModal.test.tsx
@@ -126,11 +126,16 @@ describe("saving a Comfy node from the edit dialog", () => {
       throw new Error("QuotaExceededError");
     });
 
-    open();
-    fireEvent.click(screen.getByRole("button", { name: "Save as node" }));
-    expect(screen.getByRole("status")).toHaveTextContent(/no room/i);
-
-    setItem.mockRestore();
+    // Restored in a `finally`: a failed assertion here would otherwise leave
+    // every later test in this file writing through a throwing `setItem`, and
+    // they would fail for a reason that has nothing to do with them.
+    try {
+      open();
+      fireEvent.click(screen.getByRole("button", { name: "Save as node" }));
+      expect(screen.getByRole("status")).toHaveTextContent(/no room/i);
+    } finally {
+      setItem.mockRestore();
+    }
   });
 });
 

--- a/src/components/modals/ComfyWorkflowImportModal.tsx
+++ b/src/components/modals/ComfyWorkflowImportModal.tsx
@@ -1274,16 +1274,19 @@ function SavedNodePicker({
                 onDoubleClick={() => onAdd(entry)}
                 className="flex-1 min-w-0 text-left px-3 py-2.5 transition-[scale] duration-150 active:scale-[0.99]"
               >
-                <p
-                  className={`text-sm truncate ${
+                {/* Spans, as in `FileDropZone`: a button holds phrasing content
+                    only, and a browser reparenting a `p` out of one takes the
+                    row's layout with it. */}
+                <span
+                  className={`block text-sm truncate ${
                     isSelected ? "text-white" : "text-neutral-300"
                   }`}
                 >
                   {entry.name}
-                </p>
-                <p className="text-[10px] text-neutral-500 truncate">
+                </span>
+                <span className="block text-[10px] text-neutral-500 truncate">
                   {app.source === "blueprint" ? "Blueprint" : "App workflow"} · {handles}
-                </p>
+                </span>
               </button>
 
               {confirming === entry.id ? (

--- a/src/components/nodes/BaseNode.tsx
+++ b/src/components/nodes/BaseNode.tsx
@@ -333,12 +333,19 @@ export function BaseNode({
               // whole node: a dark hairline just inside the blue one reads as
               // a gap, and a blue one reads as a second outline that stops
               // where the settings start.
+              //
+              // Running beats selected here, and the selected-and-expanded
+              // clause below says so explicitly. Both branches emit a
+              // border-colour utility, and which one wins is decided by the
+              // order Tailwind emits them in — not by their order in this
+              // string. Selecting a running node was landing on whichever that
+              // happened to be, and half the time it was the doubled line.
               ? (hasExpandedSettings ? "border-transparent" : "border-blue-500 ring-1 ring-blue-500/20")
               : "border-neutral-700/60"}
           ${fullBleed ? "" : (hasError ? "border-red-500" : "")}
           ${fullBleed && selected && !settingsExpanded ? "ring-2 ring-blue-500/40 shadow-lg shadow-blue-500/25" : ""}
           ${!fullBleed && selected && !settingsExpanded ? "border-blue-500 ring-2 ring-blue-500/40 shadow-lg shadow-blue-500/25" : ""}
-          ${!fullBleed && selected && settingsExpanded ? "border-blue-500" : ""}
+          ${!fullBleed && selected && settingsExpanded && !running ? "border-blue-500" : ""}
           ${className}
         `}
         data-tutorial={!hasExpandedSettings ? dataTutorial : undefined}

--- a/src/components/settings/ComfySettingsTab.tsx
+++ b/src/components/settings/ComfySettingsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   COMFY_CLOUD_URL,
@@ -50,7 +50,15 @@ export function ComfySettingsTab({ settings, onChange }: ComfySettingsTabProps) 
   // configuration that was never tested. Every field the probe depends on
   // belongs here, including the two API-v2 toggles, which change the routes it
   // calls entirely.
+  //
+  // The counter is bumped alongside, so a probe still in flight can tell its
+  // answer is about a configuration the user has moved on from. Clearing
+  // `result` alone is not enough — the in-flight call captured the old settings
+  // and would set its own result on top afterwards.
+  const probeGeneration = useRef(0);
+
   useEffect(() => {
+    probeGeneration.current += 1;
     setResult(null);
   }, [
     settings.mode,
@@ -69,6 +77,10 @@ export function ComfySettingsTab({ settings, onChange }: ComfySettingsTabProps) 
   );
 
   const test = useCallback(async () => {
+    const generation = probeGeneration.current;
+    const commit = (next: ConnectionResult) => {
+      if (probeGeneration.current === generation) setResult(next);
+    };
     setTesting(true);
     setResult(null);
     try {
@@ -81,14 +93,14 @@ export function ComfySettingsTab({ settings, onChange }: ComfySettingsTabProps) 
         | ({ success: true } & ConnectionResult)
         | { success: false; error: string };
       if ("success" in body && body.success) {
-        setResult({
+        commit({
           connected: body.connected,
           detail: body.detail,
           nodeCount: body.nodeCount,
           apiV2: body.apiV2,
         });
       } else {
-        setResult({
+        commit({
           connected: false,
           detail: "error" in body ? body.error : "Could not reach ComfyUI",
           nodeCount: null,
@@ -96,14 +108,14 @@ export function ComfySettingsTab({ settings, onChange }: ComfySettingsTabProps) 
         });
       }
     } catch (error) {
-      setResult({
+      commit({
         connected: false,
         detail: error instanceof Error ? error.message : "Could not reach ComfyUI",
         nodeCount: null,
         apiV2: false,
       });
     } finally {
-      setTesting(false);
+      if (probeGeneration.current === generation) setTesting(false);
     }
   }, [settings]);
 

--- a/src/components/settings/ComfySettingsTab.tsx
+++ b/src/components/settings/ComfySettingsTab.tsx
@@ -59,6 +59,10 @@ export function ComfySettingsTab({ settings, onChange }: ComfySettingsTabProps) 
 
   useEffect(() => {
     probeGeneration.current += 1;
+    // Released here, not only in the probe's own `finally` — which is skipped
+    // once the generation has moved on, and skipping it left the Test button
+    // disabled with nothing able to re-enable it.
+    setTesting(false);
     setResult(null);
   }, [
     settings.mode,

--- a/src/hooks/useComfyPreview.ts
+++ b/src/hooks/useComfyPreview.ts
@@ -20,6 +20,9 @@ export function useComfyPreview(jobId: string | null | undefined, active: boolea
   const [preview, setPreview] = useState<string | null>(null);
 
   useEffect(() => {
+    // Cleared here on the way out too, so the next run never opens on the last
+    // one's latent. The effect re-runs on both `active` and `jobId`, so this is
+    // the only place that needs to do it.
     if (!active || !jobId) {
       setPreview(null);
       return;
@@ -79,11 +82,6 @@ export function useComfyPreview(jobId: string | null | undefined, active: boolea
       controller.abort();
     };
   }, [jobId, active]);
-
-  // Cleared on the way out so the next run never opens on the last one's latent.
-  useEffect(() => {
-    if (!active) setPreview(null);
-  }, [active]);
 
   return preview;
 }

--- a/src/lib/comfy/__tests__/engineErrors.test.ts
+++ b/src/lib/comfy/__tests__/engineErrors.test.ts
@@ -305,6 +305,28 @@ describe("createEngineFetch", () => {
     expect(assetTook).toBeGreaterThan(pollTook * 2);
   }, 20_000);
 
+  it("stops the moment the caller cancels, without waiting out the backoff", async () => {
+    // Cancelling during a wait has to land when the user asks. Left to run, the
+    // backoff finishes first — Stop appears to do nothing for a second or two,
+    // and the loop then opens another attempt with a signal already aborted.
+    const controller = new AbortController();
+    let calls = 0;
+    vi.stubGlobal("fetch", async () => {
+      calls += 1;
+      setTimeout(() => controller.abort(), 20);
+      throw noAddressAnswered();
+    });
+
+    const engineFetch = createEngineFetch({ retryBaseMs: 10_000, retries: 4 });
+    const began = Date.now();
+    await expect(
+      engineFetch("https://cloud.comfy.org/api/queue", { signal: controller.signal })
+    ).rejects.toThrow();
+
+    expect(Date.now() - began).toBeLessThan(1_000);
+    expect(calls).toBe(1);
+  });
+
   it("stops when the caller cancels", async () => {
     const controller = new AbortController();
     vi.stubGlobal("fetch", async () => {

--- a/src/lib/comfy/__tests__/engineErrors.test.ts
+++ b/src/lib/comfy/__tests__/engineErrors.test.ts
@@ -224,6 +224,31 @@ describe("createEngineFetch", () => {
     expect(calls).toBe(5);
   });
 
+  it("counts the backoff against the same budget the requests spend", async () => {
+    // The check that a retry is allowed happens *before* the sleep, so a large
+    // configured backoff could cross the deadline and still start another full
+    // attempt — the budget the comment promises, spent twice over.
+    const starts: number[] = [];
+    vi.stubGlobal("fetch", (_url: string, init: RequestInit) => {
+      starts.push(Date.now());
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(noAddressAnswered()), { once: true });
+      });
+    });
+
+    const engineFetch = createEngineFetch({
+      requestTimeoutMs: 150,
+      retryBaseMs: 5_000,
+      retries: 4,
+    });
+    const began = Date.now();
+    await expect(engineFetch("https://cloud.comfy.org/api/v2/jobs/job-1")).rejects.toThrow();
+
+    // One attempt, then a backoff clipped to what is left of the deadline.
+    expect(Date.now() - began).toBeLessThan(150 * 4);
+    expect(starts.length).toBe(1);
+  });
+
   it("releases the body of a response it is about to throw away", async () => {
     // An unread body holds its socket until the collector gets to it, so a run
     // that retries a 429 several times leaks one connection per attempt.

--- a/src/lib/comfy/__tests__/library.test.ts
+++ b/src/lib/comfy/__tests__/library.test.ts
@@ -86,6 +86,24 @@ describe("the saved-node library", () => {
     expect(listSavedComfyNodes()).toEqual([]);
   });
 
+  it("skips an app missing any of the three arrays a node reads", () => {
+    // Not just the outputs. The connection menu calls `app.inputs.some(...)` on
+    // every entry as it renders and the picker reads `app.params.length`, so an
+    // entry from an older build would pass a check that only looked at outputs
+    // and then throw in the middle of a render.
+    window.localStorage.setItem(
+      COMFY_APPS_KEY,
+      JSON.stringify([
+        { id: "a", name: "No inputs", savedAt: 1, app: { ...app(), inputs: undefined } },
+        { id: "b", name: "No params", savedAt: 2, app: { ...app(), params: undefined } },
+        { id: "c", name: "No outputs", savedAt: 3, app: { ...app(), outputs: undefined } },
+        { id: "d", name: "Whole", savedAt: 4, app: app() },
+      ])
+    );
+
+    expect(listSavedComfyNodes().map((entry) => entry.id)).toEqual(["d"]);
+  });
+
   it("survives storage holding something that is not a list", () => {
     window.localStorage.setItem(COMFY_APPS_KEY, "{oh dear");
     expect(listSavedComfyNodes()).toEqual([]);

--- a/src/lib/comfy/__tests__/previews.test.ts
+++ b/src/lib/comfy/__tests__/previews.test.ts
@@ -133,6 +133,26 @@ describe("previews", () => {
     );
   });
 
+  it("falls back to the frame's own node id when the envelope carries none", async () => {
+    // The classic envelope has no metadata to read, so the frame field is all
+    // there is. On Cloud it arrives empty and the metadata wins; on a
+    // self-hosted engine it is the other way round.
+    const frames = await collect(
+      engineYielding([
+        {
+          event: "preview",
+          data: {
+            node_id: "42",
+            data_base64: Buffer.from(classic(JPEG_BYTES)).toString("base64"),
+          },
+        },
+      ])
+    );
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.nodeId).toBe("42");
+  });
+
   it("ignores everything that is not a preview", async () => {
     // Progress in particular: it rides the same stream, and it is the thing we
     // deliberately do not draw.

--- a/src/lib/comfy/__tests__/settings.test.ts
+++ b/src/lib/comfy/__tests__/settings.test.ts
@@ -4,6 +4,7 @@ import {
   COMFY_CLOUD_URL,
   COMFY_HEADERS,
   buildComfyHeaders,
+  clampJobTimeoutMs,
   comfyConfigError,
   defaultComfySettings,
   getComfySettings,
@@ -66,6 +67,35 @@ describe("normalizeComfySettings", () => {
     expect(normalizeComfySettings({ jobTimeoutMs: 5 }).jobTimeoutMs).toBe(60_000);
     expect(normalizeComfySettings({ jobTimeoutMs: 99_999_999 }).jobTimeoutMs).toBe(3_600_000);
     expect(normalizeComfySettings({ jobTimeoutMs: NaN }).jobTimeoutMs).toBe(1_800_000);
+  });
+});
+
+describe("clampJobTimeoutMs", () => {
+  it("keeps a value that is already in range", () => {
+    expect(clampJobTimeoutMs(900_000)).toBe(900_000);
+    expect(clampJobTimeoutMs("900000")).toBe(900_000);
+  });
+
+  it("brings an out-of-range value to the nearest bound", () => {
+    expect(clampJobTimeoutMs(5)).toBe(60_000);
+    expect(clampJobTimeoutMs(99_999_999)).toBe(3_600_000);
+  });
+
+  it("treats a value that was never supplied as absent, not as zero", () => {
+    // `headers.get()` answers `null` for a header that is not there, and
+    // `Number(null)` is 0 — which is finite, so it used to clamp to the *lower
+    // bound*. A request without the header ran on a one-minute job timeout
+    // instead of thirty, and every long render was cancelled part-way through.
+    expect(clampJobTimeoutMs(null)).toBe(1_800_000);
+    expect(clampJobTimeoutMs(undefined)).toBe(1_800_000);
+    expect(clampJobTimeoutMs("")).toBe(1_800_000);
+    expect(clampJobTimeoutMs("not a number")).toBe(1_800_000);
+  });
+
+  it("still honours a deliberate zero by bringing it into range", () => {
+    // Explicitly asking for none of it is a value, not an omission.
+    expect(clampJobTimeoutMs(0)).toBe(60_000);
+    expect(clampJobTimeoutMs("0")).toBe(60_000);
   });
 });
 

--- a/src/lib/comfy/library.ts
+++ b/src/lib/comfy/library.ts
@@ -14,6 +14,7 @@
 
 import { appToInputSchema } from "./nodeSchema";
 import { COMFY_APPS_KEY } from "./settings";
+import type { ComfyAppNodeData } from "@/types/nodes";
 import type { ComfyAppDefinition, ComfyAppParam, ComfyWorkflowInspection } from "./types";
 
 /** A workflow kept as a reusable node. */
@@ -48,10 +49,17 @@ function parse(raw: string | null): SavedComfyNode[] {
     return parsed.filter((entry): entry is SavedComfyNode => {
       if (!entry || typeof entry !== "object") return false;
       const candidate = entry as Partial<SavedComfyNode>;
+      // All three arrays, not just the outputs. The connection menu calls
+      // `app.inputs.some(...)` on every entry as it renders, and the picker
+      // reads `app.params.length` — so an entry written by an older build, or
+      // edited by hand in localStorage, would pass this check and then throw
+      // inside a render, which is exactly what the check exists to prevent.
       return (
         typeof candidate.id === "string" &&
         typeof candidate.name === "string" &&
         !!candidate.app &&
+        Array.isArray(candidate.app.inputs) &&
+        Array.isArray(candidate.app.params) &&
         Array.isArray(candidate.app.outputs)
       );
     });
@@ -162,7 +170,7 @@ export function instantiateSavedComfyNode(saved: SavedComfyNode): {
  * records where it came from, so the dialog can offer to update that entry
  * rather than leaving another near-identical one as the only way back.
  */
-export function seedFromSavedComfyNode(saved: SavedComfyNode): Record<string, unknown> {
+export function seedFromSavedComfyNode(saved: SavedComfyNode): Partial<ComfyAppNodeData> {
   const { app, inspection } = instantiateSavedComfyNode(saved);
   return {
     app,

--- a/src/lib/comfy/library.ts
+++ b/src/lib/comfy/library.ts
@@ -101,8 +101,16 @@ export function withDialledValues(
 }
 
 function write(entries: SavedComfyNode[]): void {
+  if (!isBrowser()) {
+    // Loudly, not silently: a save that quietly did nothing is the one failure
+    // this module exists to avoid.
+    throw new Error("Saved nodes are only available in the browser.");
+  }
+  // Serialised outside the try, so a value that cannot be stringified is not
+  // reported as a storage problem the user could fix by deleting something.
+  const payload = JSON.stringify(entries);
   try {
-    window.localStorage.setItem(COMFY_APPS_KEY, JSON.stringify(entries));
+    window.localStorage.setItem(COMFY_APPS_KEY, payload);
   } catch {
     // Almost always the storage quota. Nothing here can free space safely —
     // the other keys are the user's projects and costs — so it is reported.

--- a/src/lib/comfy/server/connection.ts
+++ b/src/lib/comfy/server/connection.ts
@@ -92,7 +92,7 @@ export function connectionFromRequest(request: Request): ComfyConnection {
 
   const mode: ComfyBackendMode =
     rawMode === "local" || rawMode === "remote" || rawMode === "cloud" ? rawMode : "cloud";
-  const timeout = Number(headers.get(COMFY_HEADERS.jobTimeout));
+  const timeout = headers.get(COMFY_HEADERS.jobTimeout);
 
   return {
     mode,

--- a/src/lib/comfy/server/fetch.ts
+++ b/src/lib/comfy/server/fetch.ts
@@ -122,6 +122,23 @@ const CONNECT_FAILURE = /^(ETIMEDOUT|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|EHOSTUNREA
 const DOWNLOAD_TIMEOUT_MS = 300_000;
 const REQUEST_TIMEOUT_MS = 30_000;
 
+/**
+ * What one `/api/object_info` read may cost.
+ *
+ * The catalog is megabytes of JSON, and `getObjectInfo` caches one promise for
+ * every concurrent caller — so its budget has to fit the *tightest* of them,
+ * which is `/api/comfy/status` at 60 s. Five attempts of thirty seconds is
+ * 150 s: the route is killed long before that, and the user gets a platform
+ * timeout in place of "connected, node count unknown".
+ *
+ * Two attempts rather than five for the same reason a stalled read is bounded
+ * at all — a catalog that does not answer in twenty seconds does not answer in
+ * a hundred and fifty either. Comfy Cloud's, measured hanging, went past ninety
+ * on every one of five tries.
+ */
+export const CATALOG_TIMEOUT_MS = 20_000;
+export const CATALOG_RETRIES = 1;
+
 /** Asset routes move the bytes; everything else is small and should fail fast. */
 const isAssetRoute = (url: string): boolean => /\/assets(\/|$|\?)/.test(url);
 
@@ -190,9 +207,14 @@ export function createEngineFetch(options: EngineFetchOptions = {}): typeof fetc
 
     for (let attempt = 0; ; attempt += 1) {
       const caller = init?.signal ?? undefined;
+      // Never longer than the budget that is left. A first attempt gets the
+      // whole timeout; a later one gets whatever the earlier attempts and their
+      // backoff did not spend, so the last request cannot run past the deadline
+      // it was allowed to start before.
+      const attemptMs = Math.max(1, Math.min(timeoutMs, deadline - Date.now()));
       const signal = caller
-        ? AbortSignal.any([caller, AbortSignal.timeout(timeoutMs)])
-        : AbortSignal.timeout(timeoutMs);
+        ? AbortSignal.any([caller, AbortSignal.timeout(attemptMs)])
+        : AbortSignal.timeout(attemptMs);
       try {
         return await fetch(input, { ...init, signal });
       } catch (error) {
@@ -208,7 +230,12 @@ export function createEngineFetch(options: EngineFetchOptions = {}): typeof fetc
         // the deadline above exists to forbid.
         const budgetLeft = Date.now() < deadline && (neverConnected ? attempt < retries : true);
         if (!worthRetrying || !budgetLeft) throw error;
-        await sleep(retryBaseMs * 2 ** Math.min(attempt, 4));
+        // The backoff spends the same budget the requests do. Left uncapped, a
+        // caller-configured `retryBaseMs` could sleep past the deadline and
+        // still start another attempt, because the check above already passed.
+        const backoff = retryBaseMs * 2 ** Math.min(attempt, 4);
+        await sleep(Math.max(0, Math.min(backoff, deadline - Date.now())));
+        if (Date.now() >= deadline) throw error;
       }
     }
   };

--- a/src/lib/comfy/server/fetch.ts
+++ b/src/lib/comfy/server/fetch.ts
@@ -13,7 +13,27 @@
 
 import { engineNeverAnswered, errorCode } from "./engine";
 
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+/**
+ * A backoff the caller can cut short.
+ *
+ * Cancelling during a wait must land as soon as the user asks, not once the
+ * backoff runs out — otherwise Stop appears to do nothing for a second or two,
+ * and the loop then opens another attempt with a signal that is already
+ * aborted. Resolves rather than rejects: the caller checks `aborted` itself and
+ * has a more useful error to throw than this one would be.
+ */
+function sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", done);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    signal?.addEventListener("abort", done, { once: true });
+  });
+}
 
 /** Transient statuses worth retrying (rate limit, gateway, overloaded). */
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
@@ -63,7 +83,7 @@ export async function resilientFetch(
         // until the collector gets to it — several retries of a 429 would
         // otherwise leave one open connection each.
         await res.body?.cancel().catch(() => undefined);
-        await sleep(retryBaseMs * 2 ** attempt);
+        await sleepUnlessAborted(retryBaseMs * 2 ** attempt, signal);
         continue;
       }
       // Consume the body before the finally disarms the timer — the timeout
@@ -85,7 +105,7 @@ export async function resilientFetch(
         ? new Error(`Request to ${String(url)} timed out after ${timeoutMs}ms`)
         : err;
       if (attempt < retries) {
-        await sleep(retryBaseMs * 2 ** attempt);
+        await sleepUnlessAborted(retryBaseMs * 2 ** attempt, signal);
         continue;
       }
       throw lastErr;
@@ -234,8 +254,8 @@ export function createEngineFetch(options: EngineFetchOptions = {}): typeof fetc
         // caller-configured `retryBaseMs` could sleep past the deadline and
         // still start another attempt, because the check above already passed.
         const backoff = retryBaseMs * 2 ** Math.min(attempt, 4);
-        await sleep(Math.max(0, Math.min(backoff, deadline - Date.now())));
-        if (Date.now() >= deadline) throw error;
+        await sleepUnlessAborted(Math.min(backoff, deadline - Date.now()), caller);
+        if (caller?.aborted || Date.now() >= deadline) throw error;
       }
     }
   };

--- a/src/lib/comfy/server/legacyEngine.ts
+++ b/src/lib/comfy/server/legacyEngine.ts
@@ -20,7 +20,7 @@ import {
   type ComfySubmitOptions,
   type ComfyUploadInput,
 } from "./engine";
-import { resilientFetch } from "./fetch";
+import { CATALOG_RETRIES, CATALOG_TIMEOUT_MS, resilientFetch } from "./fetch";
 
 /** A file reference in a `/history` or `/api/jobs` outputs object. */
 interface RawFileRef {
@@ -129,8 +129,8 @@ export class LegacyComfyEngine implements ComfyEngine {
   async objectInfo(signal?: AbortSignal): Promise<ComfyObjectInfo> {
     const res = await resilientFetch(`${this.base}/api/object_info`, {
       headers: this.headers(),
-      timeoutMs: 30_000,
-      retries: 4,
+      timeoutMs: CATALOG_TIMEOUT_MS,
+      retries: CATALOG_RETRIES,
       signal,
     });
     if (res.status === 401 || res.status === 403) {

--- a/src/lib/comfy/server/sdkEngine.ts
+++ b/src/lib/comfy/server/sdkEngine.ts
@@ -36,7 +36,12 @@ import {
   type ComfyUploadInput,
   type ComfyUploadRef,
 } from "./engine";
-import { createEngineFetch, resilientFetch } from "./fetch";
+import {
+  CATALOG_RETRIES,
+  CATALOG_TIMEOUT_MS,
+  createEngineFetch,
+  resilientFetch,
+} from "./fetch";
 
 /**
  * How long one SDK request may take.
@@ -223,8 +228,8 @@ export class SdkComfyEngine implements ComfyEngine {
       : {};
     const res = await resilientFetch(`${this.connection.baseUrl}/api/object_info`, {
       headers,
-      timeoutMs: 30_000,
-      retries: 4,
+      timeoutMs: CATALOG_TIMEOUT_MS,
+      retries: CATALOG_RETRIES,
       signal,
     });
     if (res.status === 401 || res.status === 403) {

--- a/src/lib/comfy/settings.ts
+++ b/src/lib/comfy/settings.ts
@@ -40,6 +40,13 @@ const MAX_JOB_TIMEOUT_MS = 3_600_000;
  * said was still allowed.
  */
 export function clampJobTimeoutMs(value: unknown): number {
+  // `Number(null)` and `Number("")` are both 0, and 0 is finite — so a header
+  // that was never sent used to clamp to the *minimum* rather than fall back to
+  // the default. A request without one then ran with a one-minute job timeout
+  // instead of thirty, and every long render was cancelled mid-flight.
+  if (value === null || value === undefined || value === "") {
+    return COMFY_DEFAULT_JOB_TIMEOUT_MS;
+  }
   const ms = Number(value);
   return Number.isFinite(ms)
     ? Math.min(MAX_JOB_TIMEOUT_MS, Math.max(MIN_JOB_TIMEOUT_MS, ms))

--- a/src/utils/__tests__/comfyOutputStorage.test.ts
+++ b/src/utils/__tests__/comfyOutputStorage.test.ts
@@ -18,7 +18,14 @@ const VIDEO = "data:video/mp4;base64,dmlkZW8=";
 const AUDIO = "data:audio/mpeg;base64,YXVkaW8=";
 
 /** What each store was handed, so the save side can be read back per type. */
-const written = { images: new Map<string, string>(), generations: new Map<string, string>() };
+const written = {
+  images: new Map<string, string>(),
+  // The kind is recorded alongside the bytes, and a load answers under that
+  // field only. A stub that returned the same value as both `video` and `audio`
+  // would pass even if hydration read a video out of the audio field — which is
+  // the mix-up this file is here to catch.
+  generations: new Map<string, { kind: "video" | "audio"; data: string }>(),
+};
 
 const app = {
   id: "app-1",
@@ -80,15 +87,16 @@ beforeEach(() => {
         return new Response(JSON.stringify({ success: true, imageId: body.imageId }));
       }
       if (url === "/api/save-generation") {
-        written.generations.set(body.imageId!, body.video ?? body.audio ?? "");
+        written.generations.set(body.imageId!, {
+          kind: body.video ? "video" : "audio",
+          data: body.video ?? body.audio ?? "",
+        });
         return new Response(JSON.stringify({ success: true, imageId: body.imageId }));
       }
       if (url === "/api/load-generation") {
         const stored = written.generations.get(body.imageId!);
         if (!stored) return new Response(JSON.stringify({ success: false, notFound: true }));
-        return new Response(
-          JSON.stringify({ success: true, video: stored, audio: stored })
-        );
+        return new Response(JSON.stringify({ success: true, [stored.kind]: stored.data }));
       }
       throw new Error(`unexpected fetch: ${url}`);
     })
@@ -113,8 +121,14 @@ describe("a Comfy node's outputs across save and reload", () => {
 
     // …and each one landed in its own store.
     expect(written.images.get(data.outputRefs!["9"]!)).toBe(IMAGE);
-    expect(written.generations.get(data.outputRefs!["10"]!)).toBe(VIDEO);
-    expect(written.generations.get(data.outputRefs!["11"]!)).toBe(AUDIO);
+    expect(written.generations.get(data.outputRefs!["10"]!)).toEqual({
+      kind: "video",
+      data: VIDEO,
+    });
+    expect(written.generations.get(data.outputRefs!["11"]!)).toEqual({
+      kind: "audio",
+      data: AUDIO,
+    });
   });
 
   it("brings all three back, and rebuilds the typed mirrors", async () => {


### PR DESCRIPTION
Follow-up to #141. Two more review rounds — the second covered the whole branch (including the saved-node and preview work the release PR's first review never reached), the third came from the post-merge review on #138.

## The one that matters

`clampJobTimeoutMs` treated a **missing** job-timeout header as zero. `headers.get()` answers `null`, `Number(null)` is `0`, and `0` is finite — so the clamp took it for a supplied value and raised it to the *lower* bound. Any request without `X-Comfy-Job-Timeout` ran on a one-minute job timeout instead of thirty minutes, and a render cancelled part-way costs the GPU time with nothing to show. Reachable through the env-var path a headless deployment uses.

## Budgets that were not enforced

- `/api/object_info` used 30s x 5 on both engines. It is cached and shared, so its budget has to fit the tightest caller — `/api/comfy/status` at 60s. Now 20s x 2, which loses nothing: the Cloud catalog measured hanging went past 90s on all five tries.
- `createEngineFetch` checked its deadline *before* sleeping, so a configured backoff could cross it and still start another full attempt.
- The smoke script's cancel had no timeout, so a stalled poll swallowed the error the run was reporting.

## Things a node read without checking

- The saved-node shape check accepted an `app` with only `outputs` as an array, while the connection menu calls `app.inputs.some(...)` on every entry as it renders.
- The preview route drained the engine as fast as it emitted (`enqueue` never blocks), piling ~100KB frames in server memory for a slow reader; it also closed a controller the platform had already closed on disconnect, and let a non-JSON body become a 500.

## Visual

`border-transparent` and `border-blue-500` were both emitted for a node that is selected *and* running with settings open, and which won came down to Tailwind's emit order — half the time, the doubled outline. Running now wins explicitly. A settings probe still in flight also wrote its result after the config changed, putting a green tick on an endpoint it never tested.

## Not fixed

`appInputHandles` assigns positional handle ids (`text-0`), so reordering same-type inputs can silently rebind an existing edge. Real, but the id is persisted in `edge.targetHandle` in every saved workflow — changing it needs a load-time migration and belongs in its own change. Replied on #141; CodeRabbit agreed and recorded it.

## Verification

2602 tests across 121 files, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview streaming with clearer validation, reliable cancellation, and fallback node identification.
  * Prevented outdated connection checks from overwriting newer settings results.
  * Fixed saved-app validation and handling of missing configuration fields.
  * Improved job timeout defaults and ensured retries respect overall time limits.
  * Refined running-node borders to avoid duplicate outlines.
* **Improvements**
  * Preview requests now stop after a job completes.
  * Saved workflow metadata has improved layout and truncation.
  * Media storage verification now distinguishes audio and video content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->