### PR TITLE
feat: add OrcaRouter as a named LLM and image-generation provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ KIE_API_KEY=your_kie_api_key_here
 # WaveSpeed API Key (Optional - only needed if using WaveSpeed models)
 # Get your API key from: https://wavespeed.ai/
 WAVESPEED_API_KEY=your_wavespeed_api_key_here
+
+# OrcaRouter API Key (Optional - only needed if using OrcaRouter LLM or image generation)
+# Get your API key from: https://www.orcarouter.ai
+ORCAROUTER_API_KEY=your_orcarouter_api_key_here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,9 @@ npm run test:run # Run all tests once (CI mode)
 Create `.env.local` in the root directory:
 ```
 GEMINI_API_KEY=your_gemini_api_key
-OPENAI_API_KEY=your_openai_api_key  # Optional, for OpenAI LLM provider
-KIE_API_KEY=your_kie_api_key        # Optional, for Kie.ai models (Sora, Veo, Kling, etc.)
+OPENAI_API_KEY=your_openai_api_key        # Optional, for OpenAI LLM provider
+KIE_API_KEY=your_kie_api_key              # Optional, for Kie.ai models (Sora, Veo, Kling, etc.)
+ORCAROUTER_API_KEY=your_orcarouter_api_key # Optional, for OrcaRouter LLM/image generation
 ```
 
 ## Architecture Overview
@@ -71,6 +72,8 @@ Image generation models (these exist and are recently released):
 LLM models:
 - Google: `gemini-2.5-flash`, `gemini-3-flash-preview`, `gemini-3-pro-preview`
 - OpenAI: `gpt-4.1-mini`, `gpt-4.1-nano`
+- Anthropic: `claude-sonnet-4.5`, `claude-haiku-4.5`, `claude-opus-4.6`
+- OrcaRouter: `orcarouter/auto` (routes to the best model for the task)
 
 ## Node Types
 
@@ -313,7 +316,7 @@ All routes in `src/app/api/`:
 | Route | Timeout | Purpose |
 |-------|---------|---------|
 | `/api/generate` | 5 min | Image generation via Gemini |
-| `/api/llm` | 1 min | Text generation (Google/OpenAI) |
+| `/api/llm` | 1 min | Text generation (Google/OpenAI/Anthropic/OrcaRouter) |
 | `/api/workflow` | default | Save/load workflow files |
 | `/api/save-generation` | default | Auto-save generated images |
 | `/api/logs` | default | Session logging |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Node Banana is a node-based workflow editor for AI media generation. Drag nodes 
 | **Audio Generation** | Text-to-speech and AI audio generation |
 | **3D Generation** | Generate 3D models or use them as node inputs |
 | **Image Annotation** | Full-screen editor with drawing tools (rectangles, circles, arrows, freehand, text) |
-| **Text Generation** | Generate text using Google Gemini, OpenAI, or Anthropic models |
+| **Text Generation** | Generate text using Google Gemini, OpenAI, Anthropic, or OrcaRouter models |
 | **Workflow Chaining** | Connect multiple nodes to create complex multi-step pipelines |
 | **Group Locking** | Lock node groups to skip them during execution |
 | **Save/Load** | Export and import workflows as JSON files |
@@ -59,6 +59,7 @@ Node Banana is a node-based workflow editor for AI media generation. Drag nodes 
 | [Kie.ai](https://kie.ai/) | Supported |
 | [WaveSpeed](https://wavespeed.ai/) | Supported |
 | [OpenAI](https://openai.com/) | LLM only |
+| [OrcaRouter](https://www.orcarouter.ai) | LLM + image generation |
 
 ## Getting Started
 
@@ -90,6 +91,7 @@ REPLICATE_API_KEY=your_replicate_api_key    # Optional
 FAL_API_KEY=your_fal_api_key                # Optional
 KIE_API_KEY=your_kie_api_key                # Optional
 WAVESPEED_API_KEY=your_wavespeed_api_key    # Optional
+ORCAROUTER_API_KEY=your_orcarouter_api_key  # Optional (sk-orca-...)
 ```
 
 API keys can also be entered in the app (Settings → Providers), which is the
@@ -143,7 +145,7 @@ The `/examples` directory contains example workflow files. To try them:
 | **Generate Video** | AI video generation |
 | **Generate Audio** | Text-to-speech and AI audio generation |
 | **Generate 3D** | AI 3D model generation |
-| **LLM** | AI text generation (Gemini, OpenAI, Anthropic) |
+| **LLM** | AI text generation (Gemini, OpenAI, Anthropic, OrcaRouter) |
 | **Annotation** | Draw on images with full-screen editor |
 | **Split Grid** | Split image into grid cells |
 | **Video Stitch** | Combine video clips into a single output |

--- a/src/app/api/env-status/route.ts
+++ b/src/app/api/env-status/route.ts
@@ -8,6 +8,7 @@ export interface EnvStatusResponse {
   fal: boolean;
   kie: boolean;
   wavespeed: boolean;
+  orcarouter: boolean;
 }
 
 export async function GET() {
@@ -20,6 +21,7 @@ export async function GET() {
     fal: !!process.env.FAL_API_KEY,
     kie: !!process.env.KIE_API_KEY,
     wavespeed: !!process.env.WAVESPEED_API_KEY,
+    orcarouter: !!process.env.ORCAROUTER_API_KEY,
   };
 
   return NextResponse.json(status);

--- a/src/app/api/generate/providers/index.ts
+++ b/src/app/api/generate/providers/index.ts
@@ -7,3 +7,4 @@ export { generateWithReplicate } from "./replicate";
 export { clearFalInputMappingCache, generateWithFalQueue } from "./fal";
 export { generateWithWaveSpeed } from "./wavespeed";
 export { generateWithOpenAI } from "./openai";
+export { generateWithOrcaRouter } from "./orcarouter";

--- a/src/app/api/generate/providers/orcarouter.ts
+++ b/src/app/api/generate/providers/orcarouter.ts
@@ -1,0 +1,171 @@
+/**
+ * OrcaRouter Provider for Generate API Route
+ *
+ * Handles image generation through OrcaRouter's OpenAI-compatible Images API
+ * (gpt-image-1, gpt-image-2 routed upstream). Supports both text-to-image
+ * (/v1/images/generations) and image-to-image (/v1/images/edits).
+ */
+
+import { GenerationInput, GenerationOutput } from "@/lib/providers/types";
+
+/**
+ * Extract base64 data and MIME type from a data URL
+ */
+function extractBase64Data(dataUrl: string): { data: string; mimeType: string } {
+  if (dataUrl.includes("base64,")) {
+    const [header, data] = dataUrl.split("base64,");
+    const mimeMatch = header.match(/data:([^;]+)/);
+    const mimeType = mimeMatch ? mimeMatch[1] : "image/png";
+    return { data, mimeType };
+  }
+  return { data: dataUrl, mimeType: "image/png" };
+}
+
+/**
+ * Generate image using OrcaRouter Images API (OpenAI-compatible)
+ */
+export async function generateWithOrcaRouter(
+  requestId: string,
+  apiKey: string,
+  input: GenerationInput
+): Promise<GenerationOutput> {
+  console.log(`[API:${requestId}] OrcaRouter generation - Model: ${input.model.id}, Images: ${input.images?.length || 0}, Prompt: ${input.prompt.length} chars`);
+
+  const ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1";
+  const modelId = input.model.id;
+
+  const hasImages = input.images && input.images.length > 0;
+  // If images are provided, use the edits endpoint; otherwise use generations
+  const isImageToImage = hasImages;
+
+  // Build parameters from user settings
+  const parameters = input.parameters || {};
+
+  // Determine endpoint
+  const endpoint = isImageToImage
+    ? `${ORCAROUTER_API_BASE}/images/edits`
+    : `${ORCAROUTER_API_BASE}/images/generations`;
+
+  let response: Response;
+
+  if (isImageToImage) {
+    // Multipart form data for image edits
+    const formData = new FormData();
+    formData.append("model", modelId);
+    formData.append("prompt", input.prompt);
+    // gpt-image models return base64 by default; response_format is not a valid parameter
+
+    if (parameters.size) formData.append("size", String(parameters.size));
+    if (parameters.quality) formData.append("quality", String(parameters.quality));
+    if (parameters.n) formData.append("n", String(parameters.n));
+    if (parameters.background) formData.append("background", String(parameters.background));
+
+    // Add first image only (OpenAI edits supports up to 4 images, but single image is the safest default)
+    const image = input.images![0];
+    const { data, mimeType } = extractBase64Data(image);
+    const ext = mimeType === "image/jpeg" ? "jpg" : "png";
+    const blob = new Blob([Buffer.from(data, "base64")], { type: mimeType });
+    formData.append("image", blob, `image.${ext}`);
+
+    console.log(`[API:${requestId}] OrcaRouter edits request: 1 image, model=${modelId}`);
+
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: formData,
+      signal: AbortSignal.timeout(120_000),
+    });
+  } else {
+    // JSON payload for text-to-image generations
+    const body: Record<string, unknown> = {
+      model: modelId,
+      prompt: input.prompt,
+      // gpt-image models return base64 by default; response_format is not a valid parameter
+    };
+
+    if (parameters.size) body.size = parameters.size;
+    if (parameters.quality) body.quality = parameters.quality;
+    if (parameters.n) body.n = parameters.n;
+    if (parameters.background) body.background = parameters.background;
+
+    console.log(`[API:${requestId}] OrcaRouter generations request: model=${modelId}`);
+
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(120_000),
+    });
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    // Default to a concise, status-based message so we never surface a raw HTML
+    // gateway/error page (e.g. a Cloudflare 520) to the user.
+    let errorDetail = `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
+    try {
+      const errorJson = JSON.parse(errorText);
+      errorDetail = errorJson.error?.message || errorJson.error?.type || errorDetail;
+    } catch {
+      // Non-JSON body (HTML error page, etc.) — keep the status-based message.
+    }
+    console.error(`[API:${requestId}] OrcaRouter error ${response.status}: ${errorText.slice(0, 300)}`);
+
+    // Handle rate limits
+    if (response.status === 429) {
+      return {
+        success: false,
+        error: `${input.model.name}: Rate limit exceeded. Try again in a moment.`,
+      };
+    }
+
+    // Upstream/gateway errors (500-599, incl. Cloudflare 520-524) are transient.
+    if (response.status >= 500) {
+      return {
+        success: false,
+        error: `${input.model.name}: OrcaRouter is temporarily unavailable (${errorDetail}). Please try again.`,
+      };
+    }
+
+    return {
+      success: false,
+      error: `${input.model.name}: ${errorDetail}`,
+    };
+  }
+
+  const data = await response.json();
+
+  // Extract base64 image from response
+  const firstImage = data.data?.[0];
+  const b64Json = firstImage?.b64_json;
+
+  if (!b64Json) {
+    console.error(`[API:${requestId}] No b64_json in OrcaRouter response`);
+    return {
+      success: false,
+      error: "No image returned from OrcaRouter",
+    };
+  }
+
+  // OrcaRouter returns PNG by default for b64_json format
+  const mimeType = "image/png";
+  const dataUrl = `data:${mimeType};base64,${b64Json}`;
+  const imageSizeKB = (b64Json.length / 1024).toFixed(1);
+
+  console.log(`[API:${requestId}] SUCCESS - Returning image: ${mimeType}, ${imageSizeKB}KB`);
+
+  return {
+    success: true,
+    outputs: [
+      {
+        type: "image",
+        data: dataUrl,
+      },
+    ],
+  };
+}

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -19,6 +19,7 @@ import { generateWithFalQueue } from "./providers/fal";
 import { submitKieTask } from "./providers/kie";
 import { generateWithWaveSpeed } from "./providers/wavespeed";
 import { generateWithOpenAI } from "./providers/openai";
+import { generateWithOrcaRouter } from "./providers/orcarouter";
 import { buildMediaResponse } from "./shared";
 
 export const maxDuration = 600; // 10 minute timeout for video generation polling
@@ -470,6 +471,85 @@ export async function POST(request: NextRequest) {
       };
 
       const result = await generateWithOpenAI(requestId, openaiApiKey, genInput);
+
+      if (!result.success) {
+        return NextResponse.json<GenerateResponse>(
+          {
+            success: false,
+            error: result.error || "Generation failed",
+          },
+          { status: 500 }
+        );
+      }
+
+      // Return first output
+      const output = result.outputs?.[0];
+      if (!output?.data && !output?.url) {
+        return NextResponse.json<GenerateResponse>(
+          { success: false, error: "No output in generation result" },
+          { status: 500 }
+        );
+      }
+
+      return buildMediaResponse(output);
+    }
+
+    if (provider === "orcarouter") {
+      if (!selectedModel?.modelId || !selectedModel?.displayName) {
+        return NextResponse.json<GenerateResponse>(
+          { success: false, error: "selectedModel with modelId and displayName is required for OrcaRouter" },
+          { status: 400 }
+        );
+      }
+
+      // User-provided key takes precedence over env variable
+      const orcarouterApiKey = request.headers.get("X-OrcaRouter-API-Key") || process.env.ORCAROUTER_API_KEY;
+      if (!orcarouterApiKey) {
+        return NextResponse.json<GenerateResponse>(
+          {
+            success: false,
+            error: "OrcaRouter API key not configured. Add ORCAROUTER_API_KEY to .env.local or configure in Settings.",
+          },
+          { status: 401 }
+        );
+      }
+
+      // Keep Data URIs as-is since localhost URLs won't work
+      const processedImages: string[] = images ? [...images] : [];
+
+      // Process dynamicInputs: filter empty values
+      let processedDynamicInputs: Record<string, string | string[]> | undefined = undefined;
+
+      if (dynamicInputs) {
+        processedDynamicInputs = {};
+        for (const key of Object.keys(dynamicInputs)) {
+          const value = dynamicInputs[key];
+
+          // Skip empty/null/undefined values
+          if (value === null || value === undefined || value === '') {
+            continue;
+          }
+
+          processedDynamicInputs[key] = value;
+        }
+      }
+
+      // Build generation input
+      const genInput: GenerationInput = {
+        model: {
+          id: selectedModel.modelId,
+          name: selectedModel.displayName,
+          provider: "orcarouter",
+          capabilities: capabilitiesForMediaType(mediaType),
+          description: null,
+        },
+        prompt: prompt || "",
+        images: processedImages,
+        parameters,
+        dynamicInputs: processedDynamicInputs,
+      };
+
+      const result = await generateWithOrcaRouter(requestId, orcarouterApiKey, genInput);
 
       if (!result.success) {
         return NextResponse.json<GenerateResponse>(

--- a/src/app/api/llm/__tests__/route.test.ts
+++ b/src/app/api/llm/__tests__/route.test.ts
@@ -869,4 +869,237 @@ describe("/api/llm route", () => {
       );
     });
   });
+
+  describe("OrcaRouter provider", () => {
+    beforeEach(() => {
+      global.fetch = mockFetch;
+    });
+
+    it("should generate text successfully with OrcaRouter", async () => {
+      process.env.ORCAROUTER_API_KEY = "sk-orca-test-key";
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "OrcaRouter response text" } }],
+          }),
+      });
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        provider: "orcarouter",
+        model: "orcarouter/auto",
+        temperature: 0.7,
+        maxTokens: 1024,
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.text).toBe("OrcaRouter response text");
+
+      // Verify fetch was called with correct parameters
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.orcarouter.ai/v1/chat/completions",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer sk-orca-test-key",
+          },
+          body: JSON.stringify({
+            model: "orcarouter/auto",
+            messages: [{ role: "user", content: "Test prompt" }],
+            temperature: 0.7,
+            max_tokens: 1024,
+          }),
+        })
+      );
+    });
+
+    it("should handle vision input (images + prompt)", async () => {
+      process.env.ORCAROUTER_API_KEY = "sk-orca-test-key";
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "Image description from OrcaRouter" } }],
+          }),
+      });
+
+      const request = createMockPostRequest({
+        prompt: "Describe this image",
+        images: ["data:image/png;base64,iVBORw0KGgo="],
+        provider: "orcarouter",
+        model: "orcarouter/auto",
+        temperature: 0.7,
+        maxTokens: 1024,
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.text).toBe("Image description from OrcaRouter");
+
+      // Verify fetch was called with vision content structure
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.orcarouter.ai/v1/chat/completions",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            model: "orcarouter/auto",
+            messages: [
+              {
+                role: "user",
+                content: [
+                  { type: "text", text: "Describe this image" },
+                  { type: "image_url", image_url: { url: "data:image/png;base64,iVBORw0KGgo=" } },
+                ],
+              },
+            ],
+            temperature: 0.7,
+            max_tokens: 1024,
+          }),
+        })
+      );
+    });
+
+    it("should reject missing OrcaRouter API key", async () => {
+      delete process.env.ORCAROUTER_API_KEY;
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        provider: "orcarouter",
+        model: "orcarouter/auto",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("ORCAROUTER_API_KEY not configured");
+    });
+
+    it("should use X-OrcaRouter-API-Key header over env var", async () => {
+      process.env.ORCAROUTER_API_KEY = "env-orca-key";
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "Response with header key" } }],
+          }),
+      });
+
+      const request = createMockPostRequest(
+        {
+          prompt: "Test prompt",
+          provider: "orcarouter",
+          model: "orcarouter/auto",
+        },
+        { "X-OrcaRouter-API-Key": "header-orca-key" }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      // Verify fetch was called with header key (takes precedence)
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.orcarouter.ai/v1/chat/completions",
+        expect.objectContaining({
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer header-orca-key",
+          },
+        })
+      );
+    });
+
+    it("should return 429 on rate limit errors", async () => {
+      process.env.ORCAROUTER_API_KEY = "sk-orca-test-key";
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        json: () =>
+          Promise.resolve({
+            error: { message: "429 Rate limit exceeded" },
+          }),
+      });
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        provider: "orcarouter",
+        model: "orcarouter/auto",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(429);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("Rate limit reached. Please wait and try again.");
+    });
+
+    it("should handle OrcaRouter API error responses", async () => {
+      process.env.ORCAROUTER_API_KEY = "sk-orca-test-key";
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () =>
+          Promise.resolve({
+            error: { message: "Invalid API key" },
+          }),
+      });
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        provider: "orcarouter",
+        model: "orcarouter/auto",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("Invalid API key");
+    });
+
+    it("should handle no text in OrcaRouter response", async () => {
+      process.env.ORCAROUTER_API_KEY = "sk-orca-test-key";
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: null } }],
+          }),
+      });
+
+      const request = createMockPostRequest({
+        prompt: "Test prompt",
+        provider: "orcarouter",
+        model: "orcarouter/auto",
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("No text in OrcaRouter response");
+    });
+  });
 });

--- a/src/app/api/llm/route.ts
+++ b/src/app/api/llm/route.ts
@@ -29,6 +29,10 @@ const ANTHROPIC_MODEL_MAP: Record<string, string> = {
   "claude-opus-4.6": "claude-opus-4-6",
 };
 
+const ORCAROUTER_MODEL_MAP: Record<string, string> = {
+  "orcarouter/auto": "orcarouter/auto",
+};
+
 async function generateWithGoogle(
   prompt: string,
   model: LLMModelType,
@@ -289,6 +293,90 @@ async function generateWithAnthropic(
   return text;
 }
 
+async function generateWithOrcaRouter(
+  prompt: string,
+  model: LLMModelType,
+  temperature: number,
+  maxTokens: number,
+  images?: string[],
+  requestId?: string,
+  userApiKey?: string | null
+): Promise<string> {
+  // User-provided key takes precedence over env variable
+  const apiKey = userApiKey || process.env.ORCAROUTER_API_KEY;
+  if (!apiKey) {
+    logger.error('api.error', 'ORCAROUTER_API_KEY not configured', { requestId });
+    throw new Error("ORCAROUTER_API_KEY not configured. Add it to .env.local or configure in Settings.");
+  }
+
+  const modelId = ORCAROUTER_MODEL_MAP[model] || model;
+
+  logger.info('api.llm', 'Calling OrcaRouter API', {
+    requestId,
+    model: modelId,
+    temperature,
+    maxTokens,
+    imageCount: images?.length || 0,
+    promptLength: prompt.length,
+  });
+
+  // Build content array for vision if images are provided
+  let content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
+  if (images && images.length > 0) {
+    content = [
+      { type: "text", text: prompt },
+      ...images.map((img) => ({
+        type: "image_url" as const,
+        image_url: { url: img },
+      })),
+    ];
+  } else {
+    content = prompt;
+  }
+
+  const startTime = Date.now();
+  const response = await fetch("https://api.orcarouter.ai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: modelId,
+      messages: [{ role: "user", content }],
+      temperature,
+      max_tokens: maxTokens,
+    }),
+  });
+  const duration = Date.now() - startTime;
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    logger.error('api.error', 'OrcaRouter API request failed', {
+      requestId,
+      status: response.status,
+      error: error.error?.message,
+    });
+    throw new Error(error.error?.message || `OrcaRouter API error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const text = data.choices?.[0]?.message?.content;
+
+  if (!text) {
+    logger.error('api.error', 'No text in OrcaRouter response', { requestId });
+    throw new Error("No text in OrcaRouter response");
+  }
+
+  logger.info('api.llm', 'OrcaRouter API response received', {
+    requestId,
+    duration,
+    responseLength: text.length,
+  });
+
+  return text;
+}
+
 export async function POST(request: NextRequest) {
   const requestId = generateRequestId();
 
@@ -297,6 +385,7 @@ export async function POST(request: NextRequest) {
     const geminiApiKey = request.headers.get("X-Gemini-API-Key");
     const openaiApiKey = request.headers.get("X-OpenAI-API-Key");
     const anthropicApiKey = request.headers.get("X-Anthropic-API-Key");
+    const orcarouterApiKey = request.headers.get("X-OrcaRouter-API-Key");
 
     const body: LLMGenerateRequest = await request.json();
     const {
@@ -335,6 +424,8 @@ export async function POST(request: NextRequest) {
       text = await generateWithOpenAI(prompt, model, temperature, maxTokens, images, requestId, openaiApiKey);
     } else if (provider === "anthropic") {
       text = await generateWithAnthropic(prompt, model, temperature, maxTokens, images, requestId, anthropicApiKey);
+    } else if (provider === "orcarouter") {
+      text = await generateWithOrcaRouter(prompt, model, temperature, maxTokens, images, requestId, orcarouterApiKey);
     } else {
       logger.warn('api.llm', 'Unknown provider requested', { requestId, provider });
       return NextResponse.json<LLMGenerateResponse>(

--- a/src/app/api/models/[modelId]/route.ts
+++ b/src/app/api/models/[modelId]/route.ts
@@ -1570,11 +1570,11 @@ export async function GET(
   const decodedModelId = decodeURIComponent(modelId);
   const provider = request.nextUrl.searchParams.get("provider") as ProviderType | null;
 
-  if (!provider || (provider !== "replicate" && provider !== "fal" && provider !== "kie" && provider !== "wavespeed" && provider !== "gemini" && provider !== "openai")) {
+  if (!provider || (provider !== "replicate" && provider !== "fal" && provider !== "kie" && provider !== "wavespeed" && provider !== "gemini" && provider !== "openai" && provider !== "orcarouter")) {
     return NextResponse.json<SchemaErrorResponse>(
       {
         success: false,
-        error: "Invalid or missing provider. Use ?provider=replicate, ?provider=fal, ?provider=kie, ?provider=wavespeed, ?provider=openai, or ?provider=gemini",
+        error: "Invalid or missing provider. Use ?provider=replicate, ?provider=fal, ?provider=kie, ?provider=wavespeed, ?provider=openai, ?provider=orcarouter, or ?provider=gemini",
       },
       { status: 400 }
     );
@@ -1628,6 +1628,9 @@ export async function GET(
       result = await fetchWaveSpeedSchema(decodedModelId, apiKey);
     } else if (provider === "openai") {
       // OpenAI uses hardcoded schemas (no schema discovery API for image models)
+      result = getOpenAiSchema(decodedModelId);
+    } else if (provider === "orcarouter") {
+      // OrcaRouter serves OpenAI-compatible image models with the same schema
       result = getOpenAiSchema(decodedModelId);
     } else {
       // User-provided key takes precedence over env variable

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -607,6 +607,21 @@ const OPENAI_IMAGE_MODELS: ProviderModel[] = [
   },
 ];
 
+// OrcaRouter serves OpenAI-compatible models through a single gateway key; the
+// routed model ids are the upstream providers' own (e.g. gpt-image-2).
+const ORCAROUTER_IMAGE_MODELS: ProviderModel[] = [
+  {
+    id: "gpt-image-2",
+    name: "GPT Image 2 (via OrcaRouter)",
+    description: "OpenAI gpt-image-2 routed through OrcaRouter — best-in-class text rendering, photorealism, and precise editing. Supports text-to-image and image-to-image.",
+    provider: "orcarouter",
+    capabilities: ["text-to-image", "image-to-image"],
+    coverImage: undefined,
+    pricing: { type: "per-run", amount: 0.05, currency: "USD" },
+    pageUrl: "https://www.orcarouter.ai",
+  },
+];
+
 // WaveSpeed models are now fetched dynamically from https://api.wavespeed.ai/api/v3/models
 
 // ============ Replicate Types ============
@@ -1255,6 +1270,7 @@ export async function GET(
   const kieKey = request.headers.get("X-Kie-Key") || process.env.KIE_API_KEY || null;
   const wavespeedKey = request.headers.get("X-WaveSpeed-Key") || process.env.WAVESPEED_API_KEY || null;
   const openaiKey = request.headers.get("X-OpenAI-API-Key") || process.env.OPENAI_API_KEY || null;
+  const orcarouterKey = request.headers.get("X-OrcaRouter-API-Key") || process.env.ORCAROUTER_API_KEY || null;
 
   // Build list of all available providers (have keys from env or client headers)
   const availableProviders: string[] = ["gemini"]; // Gemini always available
@@ -1263,12 +1279,14 @@ export async function GET(
   if (kieKey) availableProviders.push("kie");
   if (wavespeedKey) availableProviders.push("wavespeed");
   if (openaiKey) availableProviders.push("openai");
+  if (orcarouterKey) availableProviders.push("orcarouter");
 
-  // Determine which providers to fetch from (gemini/kie/openai handled separately as hardcoded)
+  // Determine which providers to fetch from (gemini/kie/openai/orcarouter handled separately as hardcoded)
   const providersToFetch: ProviderType[] = [];
   let includeGemini = false;
   let includeKie = false;
   let includeOpenai = false;
+  let includeOrcarouter = false;
 
   if (providerFilter) {
     if (providerFilter === "gemini") {
@@ -1315,6 +1333,19 @@ export async function GET(
           { status: 400 }
         );
       }
+    } else if (providerFilter === "orcarouter") {
+      // Only OrcaRouter requested - no external API calls needed (hardcoded models)
+      if (orcarouterKey) {
+        includeOrcarouter = true;
+      } else {
+        return NextResponse.json<ModelsErrorResponse>(
+          {
+            success: false,
+            error: "OrcaRouter API key required. Add ORCAROUTER_API_KEY to .env.local or configure in Settings.",
+          },
+          { status: 400 }
+        );
+      }
     } else if (providerFilter === "replicate" && replicateKey) {
       providersToFetch.push("replicate");
     } else if (providerFilter === "fal" && falKey) {
@@ -1325,6 +1356,7 @@ export async function GET(
     includeGemini = true; // Gemini always available
     includeKie = kieKey ? true : false; // Kie only if API key is configured
     includeOpenai = openaiKey ? true : false; // OpenAI only if API key is configured
+    includeOrcarouter = orcarouterKey ? true : false; // OrcaRouter only if API key is configured
     if (wavespeedKey) {
       providersToFetch.push("wavespeed"); // WaveSpeed if key is configured
     }
@@ -1336,13 +1368,13 @@ export async function GET(
     }
   }
 
-  // Gemini/Kie/OpenAI are handled as hardcoded, so we don't fail if no external providers
-  if (providersToFetch.length === 0 && !includeGemini && !includeKie && !includeOpenai) {
+  // Gemini/Kie/OpenAI/OrcaRouter are handled as hardcoded, so we don't fail if no external providers
+  if (providersToFetch.length === 0 && !includeGemini && !includeKie && !includeOpenai && !includeOrcarouter) {
     return NextResponse.json<ModelsErrorResponse>(
       {
         success: false,
         error:
-          "No providers available. Add REPLICATE_API_KEY, FAL_API_KEY, KIE_API_KEY, WAVESPEED_API_KEY, or OPENAI_API_KEY to .env.local or configure in Settings.",
+          "No providers available. Add REPLICATE_API_KEY, FAL_API_KEY, KIE_API_KEY, WAVESPEED_API_KEY, OPENAI_API_KEY, or ORCAROUTER_API_KEY to .env.local or configure in Settings.",
       },
       { status: 400 }
     );
@@ -1397,6 +1429,22 @@ export async function GET(
     providerResults["openai"] = {
       success: true,
       count: openaiModels.length,
+      cached: true, // Hardcoded models are effectively "cached"
+    };
+    anyFromCache = true;
+  }
+
+  // Add OrcaRouter models if included (hardcoded, no API call needed)
+  if (includeOrcarouter) {
+    // Filter by search query if provided
+    let orcarouterModels = ORCAROUTER_IMAGE_MODELS;
+    if (searchQuery) {
+      orcarouterModels = filterModelsBySearch(orcarouterModels, searchQuery);
+    }
+    allModels.push(...orcarouterModels);
+    providerResults["orcarouter"] = {
+      success: true,
+      count: orcarouterModels.length,
       cached: true, // Hardcoded models are effectively "cached"
     };
     anyFromCache = true;

--- a/src/components/CostDialog.tsx
+++ b/src/components/CostDialog.tsx
@@ -23,6 +23,7 @@ function ProviderIcon({ provider }: { provider: ProviderType }) {
     anthropic: { bg: "bg-amber-500/20", text: "text-amber-300" },
     kie: { bg: "bg-orange-500/20", text: "text-orange-300" },
     wavespeed: { bg: "bg-purple-500/20", text: "text-purple-300" },
+    orcarouter: { bg: "bg-indigo-500/20", text: "text-indigo-300" },
   };
 
   const labels: Record<ProviderType, string> = {
@@ -33,6 +34,7 @@ function ProviderIcon({ provider }: { provider: ProviderType }) {
     anthropic: "A",
     kie: "K",
     wavespeed: "W",
+    orcarouter: "O",
   };
 
   const color = colors[provider] || colors.gemini;
@@ -56,6 +58,7 @@ function getProviderDisplayName(provider: ProviderType): string {
     anthropic: "Anthropic",
     kie: "Kie.ai",
     wavespeed: "WaveSpeed",
+    orcarouter: "OrcaRouter",
   };
   return names[provider] || provider;
 }

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -18,6 +18,7 @@ const LLM_PROVIDERS: { value: LLMProvider; label: string }[] = [
   { value: "google", label: "Google" },
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
+  { value: "orcarouter", label: "OrcaRouter" },
 ];
 
 const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> = {
@@ -35,6 +36,9 @@ const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> 
     { value: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
     { value: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
     { value: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  ],
+  orcarouter: [
+    { value: "orcarouter/auto", label: "OrcaRouter Auto" },
   ],
 };
 
@@ -168,6 +172,7 @@ export function ProjectSetupModal({
     fal: false,
     kie: false,
     wavespeed: false,
+    orcarouter: false,
   });
   const [overrideActive, setOverrideActive] = useState<Record<ProviderType, boolean>>({
     gemini: false,
@@ -177,6 +182,7 @@ export function ProjectSetupModal({
     fal: false,
     kie: false,
     wavespeed: false,
+    orcarouter: false,
   });
   const [envStatus, setEnvStatus] = useState<EnvStatusResponse | null>(null);
 
@@ -211,7 +217,7 @@ export function ProjectSetupModal({
 
       // Sync local providers state
       setLocalProviders(providerSettings);
-      setShowApiKey({ gemini: false, openai: false, anthropic: false, replicate: false, fal: false, kie: false, wavespeed: false });
+      setShowApiKey({ gemini: false, openai: false, anthropic: false, replicate: false, fal: false, kie: false, wavespeed: false, orcarouter: false });
       // Initialize override as active if user already has a key set
       setOverrideActive({
         gemini: !!providerSettings.providers.gemini?.apiKey,
@@ -221,6 +227,7 @@ export function ProjectSetupModal({
         fal: !!providerSettings.providers.fal?.apiKey,
         kie: !!providerSettings.providers.kie?.apiKey,
         wavespeed: !!providerSettings.providers.wavespeed?.apiKey,
+        orcarouter: !!providerSettings.providers.orcarouter?.apiKey,
       });
       setError(null);
 
@@ -872,6 +879,54 @@ export function ProjectSetupModal({
                         onClick={() => {
                           setOverrideActive((prev) => ({ ...prev, wavespeed: false }));
                           updateLocalProvider("wavespeed", { apiKey: null });
+                        }}
+                        className="text-xs text-neutral-500 hover:text-neutral-300"
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* OrcaRouter Provider */}
+            <div className="p-3 bg-neutral-900 rounded-lg border border-neutral-700">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-neutral-100">OrcaRouter</span>
+                {envStatus?.orcarouter && !overrideActive.orcarouter ? (
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-green-400">Configured via .env</span>
+                    <button
+                      type="button"
+                      onClick={() => setOverrideActive((prev) => ({ ...prev, orcarouter: true }))}
+                      className="px-2 py-1 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
+                    >
+                      Override
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <input
+                      type={showApiKey.orcarouter ? "text" : "password"}
+                      value={localProviders.providers.orcarouter?.apiKey || ""}
+                      onChange={(e) => updateLocalProvider("orcarouter", { apiKey: e.target.value || null })}
+                      placeholder="sk-orca-..."
+                      className="w-48 px-2 py-1 bg-neutral-800 border border-neutral-600 rounded-lg text-neutral-100 text-xs focus:outline-none focus:border-neutral-500"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowApiKey((prev) => ({ ...prev, orcarouter: !prev.orcarouter }))}
+                      className="text-xs text-neutral-400 hover:text-neutral-200"
+                    >
+                      {showApiKey.orcarouter ? "Hide" : "Show"}
+                    </button>
+                    {envStatus?.orcarouter && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setOverrideActive((prev) => ({ ...prev, orcarouter: false }));
+                          updateLocalProvider("orcarouter", { apiKey: null });
                         }}
                         className="text-xs text-neutral-500 hover:text-neutral-300"
                       >

--- a/src/components/__tests__/FloatingActionBar.test.tsx
+++ b/src/components/__tests__/FloatingActionBar.test.tsx
@@ -64,10 +64,12 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: false, apiKey: null },
+    orcarouter: { id: "orcarouter", name: "OrcaRouter", enabled: false, apiKey: null, apiKeyEnvVar: "ORCAROUTER_API_KEY" },
   },
 };
 

--- a/src/components/__tests__/GenerateAudioNode.test.tsx
+++ b/src/components/__tests__/GenerateAudioNode.test.tsx
@@ -90,10 +90,12 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: false, apiKey: null },
+    orcarouter: { id: "orcarouter", name: "OrcaRouter", enabled: false, apiKey: null, apiKeyEnvVar: "ORCAROUTER_API_KEY" },
   },
 };
 

--- a/src/components/__tests__/GenerateImageNode.test.tsx
+++ b/src/components/__tests__/GenerateImageNode.test.tsx
@@ -85,10 +85,12 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: false, apiKey: null },
+    orcarouter: { id: "orcarouter", name: "OrcaRouter", enabled: false, apiKey: null, apiKeyEnvVar: "ORCAROUTER_API_KEY" },
   },
 };
 

--- a/src/components/__tests__/GenerateVideoNode.test.tsx
+++ b/src/components/__tests__/GenerateVideoNode.test.tsx
@@ -84,10 +84,12 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: false, apiKey: null },
+    orcarouter: { id: "orcarouter", name: "OrcaRouter", enabled: false, apiKey: null, apiKeyEnvVar: "ORCAROUTER_API_KEY" },
   },
 };
 

--- a/src/components/__tests__/ModelSearchDialog.test.tsx
+++ b/src/components/__tests__/ModelSearchDialog.test.tsx
@@ -71,10 +71,12 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: true, apiKey: "test-replicate-key" },
     fal: { id: "fal", name: "fal.ai", enabled: true, apiKey: "test-fal-key" },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: false, apiKey: null },
+    orcarouter: { id: "orcarouter", name: "OrcaRouter", enabled: false, apiKey: null, apiKeyEnvVar: "ORCAROUTER_API_KEY" },
   },
 };
 

--- a/src/components/__tests__/ProjectSetupModal.test.tsx
+++ b/src/components/__tests__/ProjectSetupModal.test.tsx
@@ -46,10 +46,12 @@ const defaultProviderSettings: ProviderSettings = {
   providers: {
     gemini: { id: "gemini", name: "Gemini", enabled: true, apiKey: null, apiKeyEnvVar: "GEMINI_API_KEY" },
     openai: { id: "openai", name: "OpenAI", enabled: false, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: false, apiKey: null },
     replicate: { id: "replicate", name: "Replicate", enabled: false, apiKey: null },
     fal: { id: "fal", name: "fal.ai", enabled: false, apiKey: null },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: false, apiKey: null },
+    orcarouter: { id: "orcarouter", name: "OrcaRouter", enabled: false, apiKey: null, apiKeyEnvVar: "ORCAROUTER_API_KEY" },
   },
 };
 

--- a/src/components/modals/ModelSearchDialog.tsx
+++ b/src/components/modals/ModelSearchDialog.tsx
@@ -75,6 +75,7 @@ function getProvidersHash(providers: {
   kie: boolean;
   wavespeed: boolean;
   openai: boolean;
+  orcarouter: boolean;
 }): string {
   // Fixed order keeps the hash deterministic across renders.
   return [
@@ -83,6 +84,7 @@ function getProvidersHash(providers: {
     providers.kie ? "k" : "",
     providers.wavespeed ? "w" : "",
     providers.openai ? "o" : "",
+    providers.orcarouter ? "or" : "",
   ].join("");
 }
 
@@ -186,7 +188,7 @@ export function ModelSearchDialog({
     trackModelUsage,
   } = useWorkflowStore();
   // Use stable selector for API keys to prevent unnecessary re-fetches
-  const { replicateApiKey, falApiKey, kieApiKey, wavespeedApiKey, openaiApiKey } = useProviderApiKeys();
+  const { replicateApiKey, falApiKey, kieApiKey, wavespeedApiKey, openaiApiKey, orcarouterApiKey } = useProviderApiKeys();
   const { screenToFlowPosition } = useReactFlow();
 
   // State
@@ -244,6 +246,7 @@ export function ModelSearchDialog({
       kie: !!kieApiKey,
       wavespeed: !!wavespeedApiKey,
       openai: !!openaiApiKey,
+      orcarouter: !!orcarouterApiKey,
     });
     const cacheKey = `${providersHash}:${providerFilter}:${capabilityFilter}:${debouncedSearch}`;
 
@@ -303,6 +306,9 @@ export function ModelSearchDialog({
       if (openaiApiKey) {
         headers["X-OpenAI-API-Key"] = openaiApiKey;
       }
+      if (orcarouterApiKey) {
+        headers["X-OrcaRouter-API-Key"] = orcarouterApiKey;
+      }
 
       const response = await deduplicatedFetch(`/api/models?${params.toString()}`, {
         headers,
@@ -344,7 +350,7 @@ export function ModelSearchDialog({
         setIsLoading(false);
       }
     }
-  }, [debouncedSearch, providerFilter, capabilityFilter, replicateApiKey, falApiKey, kieApiKey, wavespeedApiKey, openaiApiKey]);
+  }, [debouncedSearch, providerFilter, capabilityFilter, replicateApiKey, falApiKey, kieApiKey, wavespeedApiKey, openaiApiKey, orcarouterApiKey]);
 
   // Fetch models when filters change
   useEffect(() => {
@@ -490,6 +496,8 @@ export function ModelSearchDialog({
         return "WaveSpeed";
       case "openai":
         return "OpenAI";
+      case "orcarouter":
+        return "OrcaRouter";
       default:
         return provider;
     }
@@ -503,12 +511,13 @@ export function ModelSearchDialog({
     if (kieApiKey) providers.add("kie");
     if (wavespeedApiKey) providers.add("wavespeed");
     if (openaiApiKey) providers.add("openai");
+    if (orcarouterApiKey) providers.add("orcarouter");
     // Server-side keys (from env vars, reported by /api/models)
     for (const p of serverAvailableProviders) {
       providers.add(p as ProviderType);
     }
     return providers;
-  }, [replicateApiKey, kieApiKey, wavespeedApiKey, openaiApiKey, serverAvailableProviders]);
+  }, [replicateApiKey, kieApiKey, wavespeedApiKey, openaiApiKey, orcarouterApiKey, serverAvailableProviders]);
 
   // Reset provider filter if current selection becomes unavailable
   useEffect(() => {

--- a/src/components/nodes/ControlPanel.tsx
+++ b/src/components/nodes/ControlPanel.tsx
@@ -49,6 +49,7 @@ const LLM_PROVIDERS: { value: LLMProvider; label: string }[] = [
   { value: "google", label: "Google" },
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
+  { value: "orcarouter", label: "OrcaRouter" },
 ];
 
 const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> = {
@@ -66,6 +67,9 @@ const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> 
     { value: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
     { value: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
     { value: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  ],
+  orcarouter: [
+    { value: "orcarouter/auto", label: "OrcaRouter Auto" },
   ],
 };
 
@@ -191,7 +195,7 @@ function GenerateImageControls({ node }: { node: Node }) {
   const updateNodeData = useWorkflowStore((state) => state.updateNodeData);
   const regenerateNode = useWorkflowStore((state) => state.regenerateNode);
   const isRunning = useWorkflowStore((state) => state.isRunning);
-  const { replicateApiKey, kieApiKey, openaiApiKey, replicateEnabled, kieEnabled, openaiEnabled } = useProviderApiKeys();
+  const { replicateApiKey, kieApiKey, openaiApiKey, orcarouterApiKey, replicateEnabled, kieEnabled, openaiEnabled, orcarouterEnabled } = useProviderApiKeys();
   const [isBrowseDialogOpen, setIsBrowseDialogOpen] = useState(false);
 
   const currentProvider: ProviderType = nodeData.selectedModel?.provider || "gemini";
@@ -210,8 +214,11 @@ function GenerateImageControls({ node }: { node: Node }) {
     if (openaiEnabled && openaiApiKey) {
       providers.push({ id: "openai", name: "OpenAI" });
     }
+    if (orcarouterEnabled && orcarouterApiKey) {
+      providers.push({ id: "orcarouter", name: "OrcaRouter" });
+    }
     return providers;
-  }, [replicateEnabled, replicateApiKey, kieEnabled, kieApiKey, openaiEnabled, openaiApiKey]);
+  }, [replicateEnabled, replicateApiKey, kieEnabled, kieApiKey, openaiEnabled, openaiApiKey, orcarouterEnabled, orcarouterApiKey]);
 
   const handleAspectRatioChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/src/components/nodes/GenerateImageNode.tsx
+++ b/src/components/nodes/GenerateImageNode.tsx
@@ -58,7 +58,7 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
   const adaptiveOutputImage = useAdaptiveImageSrc(data.outputImage, id);
   const updateNodeData = useWorkflowStore((state) => state.updateNodeData);
   // Use stable selector for API keys to prevent unnecessary re-fetches
-  const { replicateApiKey, falApiKey, kieApiKey, openaiApiKey, replicateEnabled, kieEnabled, openaiEnabled } = useProviderApiKeys();
+  const { replicateApiKey, falApiKey, kieApiKey, openaiApiKey, orcarouterApiKey, replicateEnabled, kieEnabled, openaiEnabled, orcarouterEnabled } = useProviderApiKeys();
   const [externalModels, setExternalModels] = useState<ProviderModel[]>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
   const [modelsFetchError, setModelsFetchError] = useState<string | null>(null);
@@ -103,8 +103,12 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
     if (openaiEnabled && openaiApiKey) {
       providers.push({ id: "openai", name: "OpenAI" });
     }
+    // Add OrcaRouter if configured
+    if (orcarouterEnabled && orcarouterApiKey) {
+      providers.push({ id: "orcarouter", name: "OrcaRouter" });
+    }
     return providers;
-  }, [replicateEnabled, replicateApiKey, kieEnabled, kieApiKey, openaiEnabled, openaiApiKey]);
+  }, [replicateEnabled, replicateApiKey, kieEnabled, kieApiKey, openaiEnabled, openaiApiKey, orcarouterEnabled, orcarouterApiKey]);
 
   // Migrate legacy data: derive selectedModel from model field if missing
   useEffect(() => {
@@ -143,6 +147,9 @@ export function GenerateImageNode({ id, data, selected }: NodeProps<NanoBananaNo
       }
       if (openaiApiKey) {
         headers["X-OpenAI-API-Key"] = openaiApiKey;
+      }
+      if (orcarouterApiKey) {
+        headers["X-OrcaRouter-API-Key"] = orcarouterApiKey;
       }
       const response = await deduplicatedFetch(`/api/models?provider=${currentProvider}&capabilities=${capabilities}`, { headers });
       if (response.ok) {

--- a/src/components/nodes/LLMFallbackPopover.tsx
+++ b/src/components/nodes/LLMFallbackPopover.tsx
@@ -24,6 +24,7 @@ const LLM_PROVIDERS: { value: LLMProvider; label: string }[] = [
   { value: "google", label: "Google" },
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
+  { value: "orcarouter", label: "OrcaRouter" },
 ];
 
 const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> = {
@@ -41,6 +42,9 @@ const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> 
     { value: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
     { value: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
     { value: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  ],
+  orcarouter: [
+    { value: "orcarouter/auto", label: "OrcaRouter Auto" },
   ],
 };
 

--- a/src/components/nodes/LLMGenerateNode.tsx
+++ b/src/components/nodes/LLMGenerateNode.tsx
@@ -16,6 +16,7 @@ const LLM_PROVIDERS: { value: LLMProvider; label: string }[] = [
   { value: "google", label: "Google" },
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
+  { value: "orcarouter", label: "OrcaRouter" },
 ];
 
 const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> = {
@@ -33,6 +34,9 @@ const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> 
     { value: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
     { value: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
     { value: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  ],
+  orcarouter: [
+    { value: "orcarouter/auto", label: "OrcaRouter Auto" },
   ],
 };
 

--- a/src/components/nodes/ProviderBadge.tsx
+++ b/src/components/nodes/ProviderBadge.tsx
@@ -3,7 +3,7 @@ import { ProviderType } from "@/types";
 
 /** Provider badge component - shows provider icon for all providers */
 export function ProviderBadge({ provider }: { provider: ProviderType }) {
-  const providerName = provider === "gemini" ? "Gemini" : provider === "replicate" ? "Replicate" : provider === "kie" ? "Kie.ai" : provider === "wavespeed" ? "WaveSpeed" : provider === "openai" ? "OpenAI" : "fal.ai";
+  const providerName = provider === "gemini" ? "Gemini" : provider === "replicate" ? "Replicate" : provider === "kie" ? "Kie.ai" : provider === "wavespeed" ? "WaveSpeed" : provider === "openai" ? "OpenAI" : provider === "orcarouter" ? "OrcaRouter" : "fal.ai";
 
   return (
     <span className="text-neutral-500 shrink-0" title={providerName}>

--- a/src/components/onboarding/FTUXApiKeysStep.tsx
+++ b/src/components/onboarding/FTUXApiKeysStep.tsx
@@ -71,6 +71,7 @@ const providers: ProviderInfo[] = [
   { id: "replicate", name: "Replicate", icon: ReplicateIcon, apiKeyUrl: "https://replicate.com/account/api-tokens" },
   { id: "kie", name: "Kie.ai", icon: KieIcon, apiKeyUrl: "https://kie.ai/api-key" },
   { id: "wavespeed", name: "WaveSpeed", icon: WaveSpeedIcon, apiKeyUrl: "https://wavespeed.ai/accesskey" },
+  { id: "orcarouter", name: "OrcaRouter", icon: OpenAIIcon, apiKeyUrl: "https://www.orcarouter.ai" },
 ];
 
 export function FTUXApiKeysStep({}: FTUXStepProps) {
@@ -85,6 +86,7 @@ export function FTUXApiKeysStep({}: FTUXStepProps) {
     fal: false,
     kie: false,
     wavespeed: false,
+    orcarouter: false,
   });
   const [localKeys, setLocalKeys] = useState<Record<ProviderType, string>>(() => {
     const keys: Record<ProviderType, string> = {
@@ -95,6 +97,7 @@ export function FTUXApiKeysStep({}: FTUXStepProps) {
       fal: "",
       kie: "",
       wavespeed: "",
+      orcarouter: "",
     };
     for (const id of Object.keys(keys) as ProviderType[]) {
       const saved = providerSettings.providers[id]?.apiKey;

--- a/src/components/splitgrid/TemplateNodes.tsx
+++ b/src/components/splitgrid/TemplateNodes.tsx
@@ -102,6 +102,7 @@ const LLM_PROVIDERS: { value: LLMProvider; label: string }[] = [
   { value: "google", label: "Google" },
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
+  { value: "orcarouter", label: "OrcaRouter" },
 ];
 const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> = {
   google: [
@@ -118,6 +119,9 @@ const LLM_MODELS: Record<LLMProvider, { value: LLMModelType; label: string }[]> 
     { value: "claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
     { value: "claude-haiku-4.5", label: "Claude Haiku 4.5" },
     { value: "claude-opus-4.6", label: "Claude Opus 4.6" },
+  ],
+  orcarouter: [
+    { value: "orcarouter/auto", label: "OrcaRouter Auto" },
   ],
 };
 

--- a/src/store/execution/llmGenerateExecutor.ts
+++ b/src/store/execution/llmGenerateExecutor.ts
@@ -30,6 +30,7 @@ function providerTypeToLlmProvider(p: ProviderType): LLMProvider {
   if (p === "gemini") return "google";
   if (p === "openai") return "openai";
   if (p === "anthropic") return "anthropic";
+  if (p === "orcarouter") return "orcarouter";
   // Unsupported provider for LLM — caller will surface an error from /api/llm.
   return p as unknown as LLMProvider;
 }

--- a/src/store/utils/__tests__/buildApiHeaders.test.ts
+++ b/src/store/utils/__tests__/buildApiHeaders.test.ts
@@ -10,6 +10,8 @@ function makeSettings(overrides: Partial<Record<string, { apiKey: string | null 
     kie: { id: "kie", name: "Kie.ai", enabled: true, apiKey: null },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: true, apiKey: null },
     openai: { id: "openai", name: "OpenAI", enabled: true, apiKey: null },
+    anthropic: { id: "anthropic", name: "Anthropic", enabled: true, apiKey: null },
+    orcarouter: { id: "orcarouter", name: "OrcaRouter", enabled: true, apiKey: null },
   };
   for (const [key, val] of Object.entries(overrides)) {
     if (defaults[key]) {
@@ -55,6 +57,12 @@ describe("buildGenerateHeaders", () => {
     expect(headers["X-WaveSpeed-Key"]).toBe("ws-key");
   });
 
+  it("should add OrcaRouter API key header", () => {
+    const settings = makeSettings({ orcarouter: { apiKey: "sk-orca-key" } });
+    const headers = buildGenerateHeaders("orcarouter", settings);
+    expect(headers["X-OrcaRouter-API-Key"]).toBe("sk-orca-key");
+  });
+
   it("should not add header when API key is null", () => {
     const headers = buildGenerateHeaders("gemini", makeSettings());
     expect(headers["X-Gemini-API-Key"]).toBeUndefined();
@@ -82,6 +90,12 @@ describe("buildLlmHeaders", () => {
     const settings = makeSettings({ openai: { apiKey: "oai-key" } });
     const headers = buildLlmHeaders("openai", settings);
     expect(headers["X-OpenAI-API-Key"]).toBe("oai-key");
+  });
+
+  it("should add OrcaRouter API key for orcarouter provider", () => {
+    const settings = makeSettings({ orcarouter: { apiKey: "sk-orca-key" } });
+    const headers = buildLlmHeaders("orcarouter", settings);
+    expect(headers["X-OrcaRouter-API-Key"]).toBe("sk-orca-key");
   });
 
   it("should not add header when API key is null", () => {

--- a/src/store/utils/__tests__/localStorage.test.ts
+++ b/src/store/utils/__tests__/localStorage.test.ts
@@ -252,6 +252,7 @@ describe("localStorage utilities", () => {
       // Should also have the default providers that were missing
       expect(result.providers.replicate).toBeDefined();
       expect(result.providers.fal).toBeDefined();
+      expect(result.providers.orcarouter).toBeDefined();
     });
 
     it("returns default on invalid JSON", () => {

--- a/src/store/utils/buildApiHeaders.ts
+++ b/src/store/utils/buildApiHeaders.ts
@@ -18,6 +18,7 @@ const PROVIDER_HEADER_MAP: Record<ProviderType, string> = {
   wavespeed: "X-WaveSpeed-Key",
   openai: "X-OpenAI-API-Key",
   anthropic: "X-Anthropic-API-Key",
+  orcarouter: "X-OrcaRouter-API-Key",
 };
 
 /**
@@ -70,6 +71,11 @@ export function buildLlmHeaders(
     const anthropicConfig = providerSettings.providers.anthropic;
     if (anthropicConfig?.apiKey) {
       headers["X-Anthropic-API-Key"] = anthropicConfig.apiKey;
+    }
+  } else if (llmProvider === "orcarouter") {
+    const orcarouterConfig = providerSettings.providers.orcarouter;
+    if (orcarouterConfig?.apiKey) {
+      headers["X-OrcaRouter-API-Key"] = orcarouterConfig.apiKey;
     }
   }
 

--- a/src/store/utils/localStorage.ts
+++ b/src/store/utils/localStorage.ts
@@ -54,6 +54,7 @@ export const defaultProviderSettings: ProviderSettings = {
     fal: { id: "fal", name: "fal.ai", enabled: false, apiKey: null, apiKeyEnvVar: "FAL_API_KEY" },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null, apiKeyEnvVar: "KIE_API_KEY" },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: false, apiKey: null, apiKeyEnvVar: "WAVESPEED_API_KEY" },
+    orcarouter: { id: "orcarouter", name: "OrcaRouter", enabled: false, apiKey: null, apiKeyEnvVar: "ORCAROUTER_API_KEY" },
   }
 };
 

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -3292,10 +3292,12 @@ export function useProviderApiKeys() {
       kieApiKey: state.providerSettings.providers.kie?.apiKey ?? null,
       wavespeedApiKey: state.providerSettings.providers.wavespeed?.apiKey ?? null,
       openaiApiKey: state.providerSettings.providers.openai?.apiKey ?? null,
+      orcarouterApiKey: state.providerSettings.providers.orcarouter?.apiKey ?? null,
       // Provider enabled states (for conditional UI)
       replicateEnabled: state.providerSettings.providers.replicate?.enabled ?? false,
       kieEnabled: state.providerSettings.providers.kie?.enabled ?? false,
       openaiEnabled: state.providerSettings.providers.openai?.enabled ?? false,
+      orcarouterEnabled: state.providerSettings.providers.orcarouter?.enabled ?? false,
     }))
   );
 }

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -6,7 +6,7 @@
  */
 
 // Provider Types for multi-provider support (image/video generation)
-export type ProviderType = "gemini" | "openai" | "anthropic" | "replicate" | "fal" | "kie" | "wavespeed";
+export type ProviderType = "gemini" | "openai" | "anthropic" | "replicate" | "fal" | "kie" | "wavespeed" | "orcarouter";
 
 // Model pricing info (stored when model is selected)
 export interface SelectedModelPricing {
@@ -36,7 +36,7 @@ export interface ProviderSettings {
 }
 
 // LLM Provider Options
-export type LLMProvider = "google" | "openai" | "anthropic";
+export type LLMProvider = "google" | "openai" | "anthropic" | "orcarouter";
 
 // LLM Model Options
 export type LLMModelType =
@@ -48,7 +48,8 @@ export type LLMModelType =
   | "gpt-4.1-nano"
   | "claude-opus-4.6"
   | "claude-sonnet-4.5"
-  | "claude-haiku-4.5";
+  | "claude-haiku-4.5"
+  | "orcarouter/auto";
 
 // Recently used models tracking
 export interface RecentModel {

--- a/src/utils/providerUrls.ts
+++ b/src/utils/providerUrls.ts
@@ -23,6 +23,8 @@ export function getModelPageUrl(
       return `https://wavespeed.ai`;
     case "openai":
       return `https://platform.openai.com/docs/guides/images`;
+    case "orcarouter":
+      return `https://www.orcarouter.ai`;
     default:
       return null;
   }
@@ -45,6 +47,8 @@ export function getProviderDisplayName(provider: ProviderType): string {
       return "WaveSpeed";
     case "openai":
       return "OpenAI";
+    case "orcarouter":
+      return "OrcaRouter";
     default:
       return provider;
   }


### PR DESCRIPTION
## What's Changed

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider for both the LLM text-generation node and the image-generation provider registry. With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint. Because the LLM and image-generation providers here are wired as named providers with per-provider endpoints (not free-form base URLs), any Node Banana pipeline that selects OrcaRouter also inherits OrcaRouter's gateway-level, zero-trust security controls for AI agents — with no application code changes. The gateway screens every prompt and response and governs every tool call on a default-deny basis, across four layers:

- **Scoped keys** — bind a key to specific models, IPs, spend caps, and expiry.
- **Guardrails** — screen for PII, secret leakage, prompt injection, and unsafe output.
- **Agent firewall** — tool allow-lists with per-argument validation.
- **Audit trail** — a record of every match, verdict, and approval decision.

## Implementation

- New `orcarouter` entry in `ProviderType` / `LLMProvider`, mirroring the existing `openai` provider wiring (hardcoded `https://api.orcarouter.ai/v1` endpoint).
- LLM node (`src/app/api/llm/route.ts`): `generateWithOrcaRouter` calls `POST /v1/chat/completions` with model `orcarouter/auto`.
- Image generation (`src/app/api/generate/providers/orcarouter.ts`): `images/generations` + `images/edits`; `gpt-image-2` registered in the model catalog.
- API key via `X-OrcaRouter-API-Key` request header or `ORCAROUTER_API_KEY` env var.
- Settings UI (Project Setup + FTUX onboarding), provider badges, cost dialog, env status, model search, and model catalog all updated.
- Tests added/updated for the LLM route, header builder, localStorage defaults, and provider fixtures.

## Verification

- `npm run build` passes (TypeScript + all pages).
- Targeted vitest suites pass (all touched test files green).
- `orcarouter/auto` chat-completions live-tested against `https://api.orcarouter.ai/v1` → HTTP 200 (`PONG`).
- Image-generation probe reached the gateway (upstream image provider returned 503 at test time — transient upstream availability).

I'm an engineer on the OrcaRouter team.
