### PR TITLE
feat(providers): add Atlas Cloud as an image + video provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ KIE_API_KEY=your_kie_api_key_here
 # WaveSpeed API Key (Optional - only needed if using WaveSpeed models)
 # Get your API key from: https://wavespeed.ai/
 WAVESPEED_API_KEY=your_wavespeed_api_key_here
+
+# Atlas Cloud API Key (Optional - image + video generation)
+# Get your API key from: https://www.atlascloud.ai/console
+ATLASCLOUD_API_KEY=your_atlascloud_api_key_here

--- a/src/app/api/env-status/route.ts
+++ b/src/app/api/env-status/route.ts
@@ -8,6 +8,7 @@ export interface EnvStatusResponse {
   fal: boolean;
   kie: boolean;
   wavespeed: boolean;
+  atlas: boolean;
 }
 
 export async function GET() {
@@ -20,6 +21,7 @@ export async function GET() {
     fal: !!process.env.FAL_API_KEY,
     kie: !!process.env.KIE_API_KEY,
     wavespeed: !!process.env.WAVESPEED_API_KEY,
+    atlas: !!process.env.ATLASCLOUD_API_KEY,
   };
 
   return NextResponse.json(status);

--- a/src/app/api/generate/providers/__tests__/atlas-payload.test.ts
+++ b/src/app/api/generate/providers/__tests__/atlas-payload.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { generateWithAtlas } from "../atlas";
+import type { GenerationInput } from "@/lib/providers/types";
+
+/**
+ * Tests for the Atlas provider payload contract.
+ *
+ * Atlas differs from the other async providers in three ways that are easy to
+ * get wrong, so each one is pinned here:
+ *   - the model id goes in the request BODY (WaveSpeed puts it in the path)
+ *   - input images travel in ONE newline-separated `images` string
+ *   - video requests need an explicit shot_type, and Seedance generates audio
+ *     by default (a blocked score fails the whole task), so both get defaults
+ */
+
+let capturedSubmitBody: Record<string, unknown> | null = null;
+let capturedSubmitUrl = "";
+let capturedHeaders: Record<string, string> = {};
+
+function makeInput(overrides: Partial<GenerationInput> = {}): GenerationInput {
+  return {
+    model: {
+      id: "bytedance/seedream-v4",
+      name: "Seedream v4",
+      description: null,
+      provider: "atlas",
+      capabilities: ["text-to-image"],
+    },
+    prompt: "a photo of a cat",
+    images: [],
+    parameters: {},
+    ...overrides,
+  };
+}
+
+function createMockFetch(outputContentType = "image/png") {
+  return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+
+    if (urlStr.includes("/generateImage") || urlStr.includes("/generateVideo")) {
+      capturedSubmitUrl = urlStr;
+      capturedSubmitBody = JSON.parse(String(init?.body));
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 200, data: { id: "pred-1", status: "processing" } }),
+      } as Response;
+    }
+
+    if (urlStr.includes("/prediction/")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          code: 200,
+          data: { id: "pred-1", status: "completed", outputs: ["https://cdn.example/out.bin"] },
+        }),
+      } as Response;
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": outputContentType, "content-length": "8" }),
+      arrayBuffer: async () => new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer,
+    } as unknown as Response;
+  });
+}
+
+describe("generateWithAtlas", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    capturedSubmitBody = null;
+    capturedSubmitUrl = "";
+    capturedHeaders = {};
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("sends the model id in the body and hits the image endpoint", async () => {
+    global.fetch = createMockFetch() as unknown as typeof fetch;
+
+    const result = await generateWithAtlas("req-1", "test-key", makeInput());
+
+    expect(result.success).toBe(true);
+    expect(capturedSubmitUrl).toContain("/generateImage");
+    expect(capturedSubmitBody?.model).toBe("bytedance/seedream-v4");
+    expect(capturedSubmitBody?.prompt).toBe("a photo of a cat");
+    // api.atlascloud.ai rejects a default User-Agent with 403 (error code 1010)
+    expect(capturedHeaders["User-Agent"]).toBeTruthy();
+  });
+
+  it("keeps the prompt when dynamicInputs are present and joins images with newlines", async () => {
+    global.fetch = createMockFetch() as unknown as typeof fetch;
+
+    const result = await generateWithAtlas(
+      "req-2",
+      "test-key",
+      makeInput({
+        model: {
+          id: "bytedance/seedream-v4/edit",
+          name: "Seedream v4 Edit",
+          description: null,
+          provider: "atlas",
+          capabilities: ["image-to-image"],
+        },
+        dynamicInputs: { images: ["data:image/png;base64,AAA", "data:image/png;base64,BBB"] },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(capturedSubmitBody?.prompt).toBe("a photo of a cat");
+    expect(capturedSubmitBody?.images).toBe("data:image/png;base64,AAA\ndata:image/png;base64,BBB");
+  });
+
+  it("defaults shot_type and generate_audio for video models", async () => {
+    global.fetch = createMockFetch("video/mp4") as unknown as typeof fetch;
+
+    const result = await generateWithAtlas(
+      "req-3",
+      "test-key",
+      makeInput({
+        model: {
+          id: "bytedance/seedance-2.0/text-to-video",
+          name: "Seedance 2.0",
+          description: null,
+          provider: "atlas",
+          capabilities: ["text-to-video"],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(capturedSubmitUrl).toContain("/generateVideo");
+    // An empty shot_type is rejected by the API
+    expect(capturedSubmitBody?.shot_type).toBe("single");
+    // Seedance 2.0 generates synced audio by default and a blocked score fails
+    // the whole task, so this stays off unless asked for
+    expect(capturedSubmitBody?.generate_audio).toBe(false);
+    expect(result.outputs?.[0].type).toBe("video");
+  });
+
+  it("normalises size to the asterisk form and drops it for nano-banana", async () => {
+    global.fetch = createMockFetch() as unknown as typeof fetch;
+
+    await generateWithAtlas(
+      "req-4",
+      "test-key",
+      makeInput({ parameters: { size: "1280x720" } })
+    );
+    expect(capturedSubmitBody?.size).toBe("1280*720");
+
+    await generateWithAtlas(
+      "req-5",
+      "test-key",
+      makeInput({
+        model: {
+          id: "google/nano-banana-pro/text-to-image",
+          name: "Nano Banana Pro",
+          description: null,
+          provider: "atlas",
+          capabilities: ["text-to-image"],
+        },
+        parameters: { size: "1280x720", aspect_ratio: "16:9" },
+      })
+    );
+    // Measured: this family ignores size and honours aspect_ratio
+    expect(capturedSubmitBody?.size).toBeUndefined();
+    expect(capturedSubmitBody?.aspect_ratio).toBe("16:9");
+    // Two sequential generations, each waiting one poll interval
+  }, 20000);
+
+  it("surfaces a failed prediction", async () => {
+    global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes("/generateImage")) {
+        return { ok: true, status: 200, json: async () => ({ data: { id: "pred-9" } }) } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { status: "failed", error: "content policy" } }),
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    const result = await generateWithAtlas("req-6", "test-key", makeInput());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("content policy");
+  });
+});

--- a/src/app/api/generate/providers/atlas.ts
+++ b/src/app/api/generate/providers/atlas.ts
@@ -1,0 +1,351 @@
+/**
+ * Atlas Cloud Provider for Generate API Route
+ *
+ * Handles image/video generation using Atlas Cloud's media API.
+ * Uses async task submission + polling, the same shape as the WaveSpeed
+ * provider, with three Atlas-specific differences:
+ *   - the model id travels in the request body, not the URL path
+ *   - input images travel in one newline-separated `images` field
+ *   - the endpoint is chosen from the model's capabilities
+ *     (/generateImage vs /generateVideo)
+ */
+
+import { GenerationInput, GenerationOutput } from "@/lib/providers/types";
+import { validateMediaUrl } from "@/utils/urlValidation";
+
+type AtlasStatus = "processing" | "queued" | "pending" | "starting" | "completed" | "failed";
+
+/** Atlas submit response: { code, message, data: { id, status, urls: { get } } } */
+interface AtlasSubmitResponse {
+  code?: number;
+  message?: string;
+  msg?: string;
+  data?: {
+    id?: string;
+    status?: AtlasStatus;
+    urls?: { get?: string };
+  };
+}
+
+/** Atlas prediction response: { code, message, data: { id, status, outputs, error } } */
+interface AtlasPredictionResponse {
+  code?: number;
+  message?: string;
+  msg?: string;
+  data?: {
+    id?: string;
+    status?: AtlasStatus;
+    outputs?: string[] | null;
+    error?: string;
+  };
+}
+
+const ATLAS_API_BASE = "https://api.atlascloud.ai/api/v1/model";
+// api.atlascloud.ai answers a missing/default User-Agent with 403 (error code
+// 1010), so every request to the API host sends an explicit one. The result CDN
+// does not need it.
+const ATLAS_USER_AGENT = "node-banana/1";
+const ATLAS_MAX_MEDIA_SIZE = 500 * 1024 * 1024; // 500MB, matching the other providers
+
+/**
+ * Generate image/video using Atlas Cloud
+ * Uses async task submission + polling
+ */
+export async function generateWithAtlas(
+  requestId: string,
+  apiKey: string,
+  input: GenerationInput
+): Promise<GenerationOutput> {
+  console.log(`[API:${requestId}] Atlas generation - Model: ${input.model.id}, Images: ${input.images?.length || 0}, Prompt: ${input.prompt.length} chars`);
+
+  const modelId = input.model.id;
+
+  // Validate modelId — it goes in the request body, but keep the same guard the
+  // other providers apply so a malformed id fails before the network call.
+  if (/[^a-zA-Z0-9\-_/.]/.test(modelId) || modelId.includes("..")) {
+    return { success: false, error: `Invalid model ID: ${modelId}` };
+  }
+
+  const isVideoModel =
+    input.model.capabilities.includes("text-to-video") ||
+    input.model.capabilities.includes("image-to-video") ||
+    input.model.capabilities.includes("audio-to-video");
+
+  const hasDynamicInputs = input.dynamicInputs && Object.keys(input.dynamicInputs).length > 0;
+  console.log(`[API:${requestId}] Dynamic inputs: ${hasDynamicInputs ? Object.keys(input.dynamicInputs!).join(", ") : "none"}`);
+
+  // Build the payload — spread parameters first so the explicit prompt wins
+  const payload: Record<string, unknown> = {
+    ...input.parameters,
+    model: modelId,
+    prompt: input.prompt,
+  };
+
+  // Atlas takes every input image in ONE newline-separated field, so collect
+  // images from dynamic inputs and the images array into a single list.
+  const collectedImages: string[] = [];
+  if (hasDynamicInputs) {
+    for (const [key, value] of Object.entries(input.dynamicInputs!)) {
+      if (value === null || value === undefined || value === "") continue;
+      const values = Array.isArray(value) ? value : [value];
+      if (key === "images" || key === "image" || key.endsWith("image_url")) {
+        collectedImages.push(...values.filter((v): v is string => typeof v === "string" && v !== ""));
+      } else {
+        payload[key] = Array.isArray(value) ? value[0] : value;
+      }
+    }
+  }
+  if (collectedImages.length === 0 && input.images && input.images.length > 0) {
+    collectedImages.push(...input.images);
+  }
+  if (collectedImages.length > 0) {
+    payload.images = collectedImages.join("\n");
+  }
+
+  // Video models reject an empty shot_type, and Seedance 2.0 generates synced
+  // audio by default — a generated score that trips the provider's copyright
+  // check fails the whole task — so both get an explicit default here.
+  if (isVideoModel) {
+    if (payload.shot_type === undefined || payload.shot_type === "") {
+      payload.shot_type = "single";
+    }
+    if (payload.generate_audio === undefined) {
+      payload.generate_audio = false;
+    }
+  }
+
+  // Size controls differ per model family: nano-banana models ignore `size` and
+  // honour `aspect_ratio`; seedream models honour `size` in `width*height` form.
+  if (typeof payload.size === "string" && payload.size.includes("x")) {
+    payload.size = (payload.size as string).replace("x", "*");
+  }
+  if (modelId.includes("nano-banana") && payload.size) {
+    console.log(`[API:${requestId}] ${modelId} ignores size; dropping it in favour of aspect_ratio`);
+    delete payload.size;
+  }
+
+  const endpoint = isVideoModel ? "generateVideo" : "generateImage";
+  const submitUrl = `${ATLAS_API_BASE}/${endpoint}`;
+  console.log(`[API:${requestId}] Atlas submit URL: ${submitUrl} with inputs: ${Object.keys(payload).join(", ")}`);
+
+  const submitResponse = await fetch(submitUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "User-Agent": ATLAS_USER_AGENT,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!submitResponse.ok) {
+    const errorText = await submitResponse.text();
+    let errorDetail = errorText || `HTTP ${submitResponse.status}`;
+    try {
+      const errorJson = JSON.parse(errorText);
+      errorDetail = errorJson.error || errorJson.message || errorJson.msg || errorText || `HTTP ${submitResponse.status}`;
+    } catch {
+      // Keep original text
+    }
+
+    console.error(`[API:${requestId}] Atlas submit failed: ${submitResponse.status} - ${errorDetail}`);
+
+    if (submitResponse.status === 429) {
+      return {
+        success: false,
+        error: `${input.model.name || "Atlas"}: Rate limit exceeded. Try again in a moment.`,
+      };
+    }
+
+    return {
+      success: false,
+      error: `${input.model.name || "Atlas"}: ${errorDetail}`,
+    };
+  }
+
+  const submitResult: AtlasSubmitResponse = await submitResponse.json();
+  console.log(`[API:${requestId}] Atlas submit response:`, JSON.stringify(submitResult).substring(0, 500));
+
+  const taskId = submitResult.data?.id;
+  if (!taskId) {
+    console.error(`[API:${requestId}] No prediction ID in Atlas submit response`);
+    return {
+      success: false,
+      error: "Atlas: No prediction ID returned from API",
+    };
+  }
+
+  // Prefer the polling URL the API hands back, with the same SSRF guard the
+  // WaveSpeed provider applies to its own host.
+  let providedPollUrl: string | undefined = submitResult.data?.urls?.get;
+  if (providedPollUrl) {
+    const pollUrlCheck = validateMediaUrl(providedPollUrl);
+    if (!pollUrlCheck.valid || !providedPollUrl.startsWith("https://api.atlascloud.ai")) {
+      console.warn(`[API:${requestId}] Atlas provided invalid poll URL: ${providedPollUrl} — falling back to constructed URL`);
+      providedPollUrl = undefined;
+    }
+  }
+
+  console.log(`[API:${requestId}] Atlas prediction submitted: ${taskId}`);
+
+  // Poll for completion. Status flow: processing → completed/failed.
+  // Video generation routinely takes minutes, so the ceiling matches the
+  // slowest provider here rather than the image-only case.
+  const maxWaitTime = 10 * 60 * 1000; // 10 minutes
+  const pollInterval = 3000; // 3 seconds — the API is not a per-second endpoint
+  const startTime = Date.now();
+  let lastStatus = "";
+  let resultData: AtlasPredictionResponse | null = null;
+
+  while (true) {
+    if (Date.now() - startTime > maxWaitTime) {
+      console.error(`[API:${requestId}] Atlas prediction timed out after 10 minutes`);
+      return {
+        success: false,
+        error: `${input.model.name}: Generation timed out after 10 minutes`,
+      };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+
+    try {
+      const pollUrl = providedPollUrl || `${ATLAS_API_BASE}/prediction/${encodeURIComponent(taskId)}`;
+      const pollResponse = await fetch(pollUrl, {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "User-Agent": ATLAS_USER_AGENT,
+        },
+      });
+
+      const elapsedSec = Math.round((Date.now() - startTime) / 1000);
+      console.log(`[API:${requestId}] Atlas poll (${elapsedSec}s): ${pollResponse.status}`);
+
+      if (pollResponse.status === 404) {
+        lastStatus = "pending";
+        continue;
+      }
+
+      if (!pollResponse.ok) {
+        const errorText = await pollResponse.text();
+        let errorDetail = errorText || `HTTP ${pollResponse.status}`;
+        try {
+          const errorJson = JSON.parse(errorText);
+          errorDetail = errorJson.error || errorJson.message || errorJson.msg || errorDetail;
+        } catch {
+          // Keep original text
+        }
+        console.error(`[API:${requestId}] Atlas poll failed: ${pollResponse.status} - ${errorDetail}`);
+        return {
+          success: false,
+          error: `${input.model.name}: ${errorDetail}`,
+        };
+      }
+
+      const pollData: AtlasPredictionResponse = await pollResponse.json();
+      const currentStatus = pollData.data?.status;
+      const currentError = pollData.data?.error;
+
+      if (currentStatus !== lastStatus) {
+        console.log(`[API:${requestId}] Atlas status changed: ${lastStatus} → ${currentStatus}`);
+        lastStatus = currentStatus || "";
+      }
+
+      if (currentStatus === "completed") {
+        console.log(`[API:${requestId}] Atlas prediction completed`);
+        resultData = pollData;
+        break;
+      }
+
+      if (currentStatus === "failed") {
+        const failureReason = currentError || pollData.message || pollData.msg || "Generation failed";
+        console.error(`[API:${requestId}] Atlas prediction failed: ${failureReason}`);
+        return {
+          success: false,
+          error: `${input.model.name}: ${failureReason}`,
+        };
+      }
+
+      // Continue polling for processing/queued/pending/starting
+    } catch (pollError) {
+      const message = pollError instanceof Error ? pollError.message : String(pollError);
+      console.error(`[API:${requestId}] Atlas poll error: ${message}`);
+      return {
+        success: false,
+        error: `${input.model.name}: ${message}`,
+      };
+    }
+  }
+
+  const outputUrls = resultData?.data?.outputs ?? [];
+  if (!Array.isArray(outputUrls) || outputUrls.length === 0) {
+    console.error(`[API:${requestId}] No outputs in Atlas result. Response:`, JSON.stringify(resultData).substring(0, 500));
+    return {
+      success: false,
+      error: `${input.model.name}: No outputs in generation result`,
+    };
+  }
+
+  const outputUrl = outputUrls[0];
+  const outputUrlCheck = validateMediaUrl(outputUrl);
+  if (!outputUrlCheck.valid) {
+    return { success: false, error: `Invalid output URL: ${outputUrlCheck.error}` };
+  }
+
+  console.log(`[API:${requestId}] Fetching Atlas output from: ${outputUrl.substring(0, 80)}...`);
+
+  const outputResponse = await fetch(outputUrl);
+  if (!outputResponse.ok) {
+    return {
+      success: false,
+      error: `Failed to fetch output: ${outputResponse.status}`,
+    };
+  }
+
+  const declaredLength = parseInt(outputResponse.headers.get("content-length") || "0", 10);
+  if (!isNaN(declaredLength) && declaredLength > ATLAS_MAX_MEDIA_SIZE) {
+    return { success: false, error: `Media too large: ${(declaredLength / (1024 * 1024)).toFixed(0)}MB > 500MB limit` };
+  }
+
+  const outputArrayBuffer = await outputResponse.arrayBuffer();
+  if (outputArrayBuffer.byteLength > ATLAS_MAX_MEDIA_SIZE) {
+    return { success: false, error: `Media too large: ${(outputArrayBuffer.byteLength / (1024 * 1024)).toFixed(0)}MB > 500MB limit` };
+  }
+  const outputSizeMB = outputArrayBuffer.byteLength / (1024 * 1024);
+
+  // The container is not fixed per model — the same Atlas model returned PNG on
+  // one call and JPEG on the next — so trust the response header, then the
+  // model's modality, rather than assuming from the model id.
+  const rawContentType = outputResponse.headers.get("content-type");
+  const contentType =
+    rawContentType && (rawContentType.startsWith("video/") || rawContentType.startsWith("image/") || rawContentType.startsWith("audio/"))
+      ? rawContentType
+      : isVideoModel
+        ? "video/mp4"
+        : "image/png";
+
+  console.log(`[API:${requestId}] Output: ${contentType}, ${outputSizeMB.toFixed(2)}MB`);
+
+  // Match the other providers: very large videos come back as a URL only.
+  if (isVideoModel && outputSizeMB > 20) {
+    console.log(`[API:${requestId}] SUCCESS - Returning URL for large video`);
+    return {
+      success: true,
+      outputs: [{ type: "video", data: "", url: outputUrl }],
+    };
+  }
+
+  const outputBase64 = Buffer.from(outputArrayBuffer).toString("base64");
+
+  console.log(`[API:${requestId}] SUCCESS - Returning ${isVideoModel ? "video" : "image"}`);
+
+  return {
+    success: true,
+    outputs: [
+      {
+        type: isVideoModel ? "video" : "image",
+        data: `data:${contentType};base64,${outputBase64}`,
+        url: outputUrl,
+      },
+    ],
+  };
+}

--- a/src/app/api/generate/providers/index.ts
+++ b/src/app/api/generate/providers/index.ts
@@ -7,3 +7,4 @@ export { generateWithReplicate } from "./replicate";
 export { clearFalInputMappingCache, generateWithFalQueue } from "./fal";
 export { generateWithWaveSpeed } from "./wavespeed";
 export { generateWithOpenAI } from "./openai";
+export { generateWithAtlas } from "./atlas";

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -18,6 +18,7 @@ import { generateWithReplicate } from "./providers/replicate";
 import { generateWithFalQueue } from "./providers/fal";
 import { submitKieTask } from "./providers/kie";
 import { generateWithWaveSpeed } from "./providers/wavespeed";
+import { generateWithAtlas } from "./providers/atlas";
 import { generateWithOpenAI } from "./providers/openai";
 import { buildMediaResponse } from "./shared";
 
@@ -412,6 +413,80 @@ export async function POST(request: NextRequest) {
       }
 
       return buildMediaResponse(output);
+    }
+
+    if (provider === "atlas") {
+      if (!selectedModel?.modelId || !selectedModel?.displayName) {
+        return NextResponse.json<GenerateResponse>(
+          { success: false, error: "selectedModel with modelId and displayName is required for Atlas" },
+          { status: 400 }
+        );
+      }
+
+      // User-provided key takes precedence over env variable
+      const atlasApiKey = request.headers.get("X-Atlas-Key") || process.env.ATLASCLOUD_API_KEY;
+      if (!atlasApiKey) {
+        return NextResponse.json<GenerateResponse>(
+          {
+            success: false,
+            error: "Atlas Cloud API key not configured. Add ATLASCLOUD_API_KEY to .env.local or configure in Settings.",
+          },
+          { status: 401 }
+        );
+      }
+
+      // Atlas accepts Data URIs directly, so keep them as-is like WaveSpeed
+      const processedImages: string[] = images ? [...images] : [];
+
+      // Process dynamicInputs: filter empty values
+      let processedDynamicInputs: Record<string, string | string[]> | undefined = undefined;
+
+      if (dynamicInputs) {
+        processedDynamicInputs = {};
+        for (const key of Object.keys(dynamicInputs)) {
+          const value = dynamicInputs[key];
+          if (value === null || value === undefined || value === '') {
+            continue;
+          }
+          processedDynamicInputs[key] = value;
+        }
+      }
+
+      const genInput: GenerationInput = {
+        model: {
+          id: selectedModel.modelId,
+          name: selectedModel.displayName,
+          provider: "atlas",
+          capabilities: capabilitiesForMediaType(mediaType),
+          description: null,
+        },
+        prompt: prompt || "",
+        images: processedImages,
+        parameters,
+        dynamicInputs: processedDynamicInputs,
+      };
+
+      const result = await generateWithAtlas(requestId, atlasApiKey, genInput);
+
+      if (!result.success) {
+        return NextResponse.json<GenerateResponse>(
+          {
+            success: false,
+            error: result.error || "Generation failed",
+          },
+          { status: 500 }
+        );
+      }
+
+      const atlasOutput = result.outputs?.[0];
+      if (!atlasOutput?.data && !atlasOutput?.url) {
+        return NextResponse.json<GenerateResponse>(
+          { success: false, error: "No output in generation result" },
+          { status: 500 }
+        );
+      }
+
+      return buildMediaResponse(atlasOutput);
     }
 
     if (provider === "openai") {

--- a/src/components/CostDialog.tsx
+++ b/src/components/CostDialog.tsx
@@ -23,6 +23,7 @@ function ProviderIcon({ provider }: { provider: ProviderType }) {
     anthropic: { bg: "bg-amber-500/20", text: "text-amber-300" },
     kie: { bg: "bg-orange-500/20", text: "text-orange-300" },
     wavespeed: { bg: "bg-purple-500/20", text: "text-purple-300" },
+    atlas: { bg: "bg-sky-500/20", text: "text-sky-300" },
   };
 
   const labels: Record<ProviderType, string> = {
@@ -33,6 +34,7 @@ function ProviderIcon({ provider }: { provider: ProviderType }) {
     anthropic: "A",
     kie: "K",
     wavespeed: "W",
+    atlas: "A",
   };
 
   const color = colors[provider] || colors.gemini;
@@ -56,6 +58,7 @@ function getProviderDisplayName(provider: ProviderType): string {
     anthropic: "Anthropic",
     kie: "Kie.ai",
     wavespeed: "WaveSpeed",
+    atlas: "Atlas Cloud",
   };
   return names[provider] || provider;
 }

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -168,6 +168,7 @@ export function ProjectSetupModal({
     fal: false,
     kie: false,
     wavespeed: false,
+    atlas: false,
   });
   const [overrideActive, setOverrideActive] = useState<Record<ProviderType, boolean>>({
     gemini: false,
@@ -177,6 +178,7 @@ export function ProjectSetupModal({
     fal: false,
     kie: false,
     wavespeed: false,
+    atlas: false,
   });
   const [envStatus, setEnvStatus] = useState<EnvStatusResponse | null>(null);
 
@@ -211,7 +213,7 @@ export function ProjectSetupModal({
 
       // Sync local providers state
       setLocalProviders(providerSettings);
-      setShowApiKey({ gemini: false, openai: false, anthropic: false, replicate: false, fal: false, kie: false, wavespeed: false });
+      setShowApiKey({ gemini: false, openai: false, anthropic: false, replicate: false, fal: false, kie: false, wavespeed: false, atlas: false });
       // Initialize override as active if user already has a key set
       setOverrideActive({
         gemini: !!providerSettings.providers.gemini?.apiKey,
@@ -221,6 +223,7 @@ export function ProjectSetupModal({
         fal: !!providerSettings.providers.fal?.apiKey,
         kie: !!providerSettings.providers.kie?.apiKey,
         wavespeed: !!providerSettings.providers.wavespeed?.apiKey,
+        atlas: !!providerSettings.providers.atlas?.apiKey,
       });
       setError(null);
 

--- a/src/components/onboarding/FTUXApiKeysStep.tsx
+++ b/src/components/onboarding/FTUXApiKeysStep.tsx
@@ -85,6 +85,7 @@ export function FTUXApiKeysStep({}: FTUXStepProps) {
     fal: false,
     kie: false,
     wavespeed: false,
+    atlas: false,
   });
   const [localKeys, setLocalKeys] = useState<Record<ProviderType, string>>(() => {
     const keys: Record<ProviderType, string> = {
@@ -95,6 +96,7 @@ export function FTUXApiKeysStep({}: FTUXStepProps) {
       fal: "",
       kie: "",
       wavespeed: "",
+      atlas: "",
     };
     for (const id of Object.keys(keys) as ProviderType[]) {
       const saved = providerSettings.providers[id]?.apiKey;

--- a/src/store/utils/buildApiHeaders.ts
+++ b/src/store/utils/buildApiHeaders.ts
@@ -18,6 +18,7 @@ const PROVIDER_HEADER_MAP: Record<ProviderType, string> = {
   wavespeed: "X-WaveSpeed-Key",
   openai: "X-OpenAI-API-Key",
   anthropic: "X-Anthropic-API-Key",
+  atlas: "X-Atlas-Key",
 };
 
 /**

--- a/src/store/utils/localStorage.ts
+++ b/src/store/utils/localStorage.ts
@@ -54,6 +54,7 @@ export const defaultProviderSettings: ProviderSettings = {
     fal: { id: "fal", name: "fal.ai", enabled: false, apiKey: null, apiKeyEnvVar: "FAL_API_KEY" },
     kie: { id: "kie", name: "Kie.ai", enabled: false, apiKey: null, apiKeyEnvVar: "KIE_API_KEY" },
     wavespeed: { id: "wavespeed", name: "WaveSpeed", enabled: false, apiKey: null, apiKeyEnvVar: "WAVESPEED_API_KEY" },
+    atlas: { id: "atlas", name: "Atlas Cloud", enabled: false, apiKey: null, apiKeyEnvVar: "ATLASCLOUD_API_KEY" },
   }
 };
 

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -6,7 +6,7 @@
  */
 
 // Provider Types for multi-provider support (image/video generation)
-export type ProviderType = "gemini" | "openai" | "anthropic" | "replicate" | "fal" | "kie" | "wavespeed";
+export type ProviderType = "gemini" | "openai" | "anthropic" | "replicate" | "fal" | "kie" | "wavespeed" | "atlas";
 
 // Model pricing info (stored when model is selected)
 export interface SelectedModelPricing {

--- a/src/utils/providerUrls.ts
+++ b/src/utils/providerUrls.ts
@@ -23,6 +23,8 @@ export function getModelPageUrl(
       return `https://wavespeed.ai`;
     case "openai":
       return `https://platform.openai.com/docs/guides/images`;
+    case "atlas":
+      return `https://www.atlascloud.ai/models`;
     default:
       return null;
   }
@@ -45,6 +47,8 @@ export function getProviderDisplayName(provider: ProviderType): string {
       return "WaveSpeed";
     case "openai":
       return "OpenAI";
+    case "atlas":
+      return "Atlas Cloud";
     default:
       return provider;
   }


### PR DESCRIPTION
## Summary

The generate route already fans out to gemini / openai / replicate / fal / kie / wavespeed. This adds
**`atlas`**, covering **image and video** through one submit-then-poll API.

Atlas's response shape is close to WaveSpeed's (`{ code, message, data: { id, status, urls: { get },
outputs } }`), so `providers/atlas.ts` deliberately follows that file's structure — same SSRF check on
the provider-supplied poll URL, same 500 MB media guard, same URL-only path for videos over 20 MB.

## Three Atlas-specific differences (each pinned by a test)

- **The model id travels in the request body**, not the URL path.
- **Input images travel in ONE newline-separated `images` string**, so images arriving via
  `dynamicInputs` and via the `images` array are collected into a single field.
- **The endpoint comes from the model's capabilities** — `/generateImage` vs `/generateVideo`.

## Defaults that exist because the API rejects the alternative

- `shot_type: "single"` for video — an empty value is refused.
- `generate_audio: false` — Seedance 2.0 generates synced audio by default, and a generated score
  that trips the provider's copyright check **fails the whole task**. Callers can turn it on.

## Size handling is per model family (measured, not assumed)

| Family | Behaviour |
|---|---|
| `seedream` | honours `size` in `width*height` form → a `1280x720` parameter is normalised to `1280*720` |
| `nano-banana` | **ignores `size`**, honours `aspect_ratio` → `size` is dropped with a log line |

The output container is not fixed either — the *same* model returned PNG on one call and JPEG on the
next — so the mime type comes from the response header, with the model's modality as fallback.

One edge detail: `api.atlascloud.ai` answers a default `User-Agent` with `403 error code 1010`, so
every request to the API host sends an explicit one. The result CDN does not need it.

## Wiring

Adding `"atlas"` to `ProviderType` made the compiler surface every exhaustive
`Record<ProviderType, …>` map, which is a good thing: the provider is registered **everywhere**
rather than half-way — generate-route branch (`X-Atlas-Key` header or `ATLASCLOUD_API_KEY`),
`env-status`, provider display name and model-page URL, `buildApiHeaders`, default provider settings,
the settings modal and the FTUX key step.

## Verification

- `vitest run src/app/api/generate/providers/__tests__ src/store/utils/__tests__` → **242 passed
  (13 files)**, including 5 new cases (body-carried model id, prompt survival alongside
  `dynamicInputs` plus newline-joined images, video defaults, size normalisation/drop per family,
  failed prediction).
- `tsc --noEmit` → back to the **baseline 430** pre-existing errors, **none added**. (I checked by
  stashing the branch and re-running: adding the union member first produced 16 new errors, which is
  how I found the maps above.)
- **Live call** through `generateWithAtlas` returned a real `data:image/jpeg;base64,…` payload plus
  its CDN URL.

`.env.example` documents the new key. No credentials in the diff — the test uses `"test-key"`.

<!-- atlas-partnership-start -->
---

### 🤝 Partnership & contact

This PR comes from the **Atlas Cloud** team. Beyond the integration above, we'd love to explore a closer collaboration with **node-banana** — for example **co-marketing** or a featured integration.

If that sounds interesting, reach out anytime:
- 📧 **marketing@atlascloud.ai**
- 🌐 https://www.atlascloud.ai
- 📚 Docs: https://www.atlascloud.ai/docs

And of course, happy to revise this PR to match your project's conventions — just leave a comment. 🙌
<!-- atlas-partnership-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Atlas Cloud as a supported provider for image and video generation.
  - Added Atlas Cloud API key configuration during onboarding and project setup.
  - Added Atlas Cloud provider status visibility and automatic API-key header handling.
  - Added Atlas Cloud labels, icons, and model links throughout the interface.
  - Supports video options, image inputs, model-specific sizing, and clear generation errors.

- **Tests**
  - Added coverage for Atlas Cloud request formatting, polling, error handling, and output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->