### PR TITLE
feat(chrome): icon-only action bar and navigator card for the bottom chrome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Returns `{ images: string[], text: string | null }`.
 5. Create the component in `src/components/nodes/`
 6. Export from `src/components/nodes/index.ts`
 7. Register in `nodeTypes` in `WorkflowCanvas.tsx`
-8. Add minimap color in `WorkflowCanvas.tsx`
+8. Add minimap color to `getMiniMapNodeColor()` in `src/components/CanvasMinimap.tsx`
 9. Update `getConnectedInputs()` if the node produces consumable output
 10. Add execution logic in `executeWorkflow()` if the node requires processing
 11. Update `ConnectionDropMenu.tsx` to include the node in source/target lists

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -275,40 +275,6 @@ body {
   cursor: nesw-resize !important;
 }
 
-/* React Flow Controls dark theme */
-.react-flow__controls {
-  background: #262626 !important;
-  border: 1px solid #404040 !important;
-  border-radius: 8px !important;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3) !important;
-}
-
-.react-flow__controls-button {
-  background: #262626 !important;
-  border-bottom: 1px solid #404040 !important;
-}
-
-.react-flow__controls-button svg {
-  fill: #d4d4d4 !important;
-}
-
-.react-flow__controls-button svg path {
-  fill: #d4d4d4 !important;
-}
-
-.react-flow__controls-button:hover {
-  background: #404040 !important;
-}
-
-.react-flow__controls-button:hover svg,
-.react-flow__controls-button:hover svg path {
-  fill: #fafafa !important;
-}
-
-.react-flow__controls-button:last-child {
-  border-bottom: none !important;
-}
-
 /* Scrollbars.
  *
  * A thumb and nothing else. The groove is chrome nobody asked for, and it drew

--- a/src/components/CanvasMinimap.tsx
+++ b/src/components/CanvasMinimap.tsx
@@ -13,21 +13,18 @@ import {
 import { ChromeIconButton } from "./ChromeIconButton";
 import { CHROME_DIVIDER, CHROME_SURFACE } from "./chromeStyles";
 
-/**
- * The navigator: minimap on top, one row of canvas controls beneath. Hiding
- * the minimap leaves the row on its own, so zoom, fit and lock never move.
- */
 /** Card width, with its 1px border: wide enough for the control row. Neighbours to the left offset from this. */
 export const NAVIGATOR_WIDTH = 280;
+/** Inset between the card edge and the minimap. */
+const MINIMAP_PADDING = 6;
 
 export const MINIMAP_GEOMETRY = {
   /** Fills the card between the insets. */
-  width: NAVIGATOR_WIDTH - 6 * 2 - 2,
+  width: NAVIGATOR_WIDTH - MINIMAP_PADDING * 2 - 2,
   height: 150,
   /** Distance from the canvas edges. */
   margin: 16,
-  /** Inset between the card edge and the minimap. */
-  padding: 6,
+  padding: MINIMAP_PADDING,
 } as const;
 
 export function getMiniMapNodeColor(node: Node): string {
@@ -101,6 +98,10 @@ interface CanvasMinimapProps {
   disabled?: boolean;
 }
 
+/**
+ * The navigator: minimap on top, one row of canvas controls beneath. Hiding
+ * the minimap leaves the row on its own, so zoom, fit and lock never move.
+ */
 export function CanvasMinimap({ disabled = false }: CanvasMinimapProps) {
   const [isMinimapVisible, setIsMinimapVisible] = useState(true);
   const { zoomIn, zoomOut, fitView } = useReactFlow();

--- a/src/components/CanvasMinimap.tsx
+++ b/src/components/CanvasMinimap.tsx
@@ -145,17 +145,17 @@ export function CanvasMinimap({ disabled = false }: CanvasMinimapProps) {
           />
         </div>
       )}
-      <div className="flex h-[34px] items-center gap-0.5 px-1">
+      <div className="flex h-[38px] items-center gap-0.5 px-1">
         <ControlButton label="Zoom out" disabled={disabled} onClick={() => zoomOut()}>
-          <svg className="h-4 w-4" {...iconProps}><path d="M5 12h14" /></svg>
+          <svg className="h-[18px] w-[18px]" {...iconProps}><path d="M5 12h14" /></svg>
         </ControlButton>
         <ZoomReadout />
         <ControlButton label="Zoom in" disabled={disabled} onClick={() => zoomIn()}>
-          <svg className="h-4 w-4" {...iconProps}><path d="M12 5v14M5 12h14" /></svg>
+          <svg className="h-[18px] w-[18px]" {...iconProps}><path d="M12 5v14M5 12h14" /></svg>
         </ControlButton>
         <div className={CHROME_DIVIDER} />
         <ControlButton label="Fit view" disabled={disabled} onClick={() => fitView()}>
-          <svg className="h-4 w-4" {...iconProps}>
+          <svg className="h-[18px] w-[18px]" {...iconProps}>
             <path d="M4 9V5a1 1 0 011-1h4M20 9V5a1 1 0 00-1-1h-4M4 15v4a1 1 0 001 1h4M20 15v4a1 1 0 01-1 1h-4" />
           </svg>
         </ControlButton>
@@ -166,7 +166,7 @@ export function CanvasMinimap({ disabled = false }: CanvasMinimapProps) {
           disabled={disabled}
           onClick={toggleInteractive}
         >
-          <svg className="h-4 w-4" {...iconProps}>
+          <svg className="h-[18px] w-[18px]" {...iconProps}>
             <rect x="5" y="11" width="14" height="10" rx="2" />
             <path d={isInteractive ? "M8 11V7a4 4 0 018 0" : "M8 11V7a4 4 0 018 0v4"} />
           </svg>
@@ -179,7 +179,7 @@ export function CanvasMinimap({ disabled = false }: CanvasMinimapProps) {
           disabled={disabled}
           onClick={() => setIsMinimapVisible((v) => !v)}
         >
-          <svg className="h-4 w-4" {...iconProps} strokeWidth={1.5}>
+          <svg className="h-[18px] w-[18px]" {...iconProps} strokeWidth={1.5}>
             <rect x="3" y="4" width="18" height="16" rx="2" />
             <path d="M7 8h3v3H7zM12 8h3v3h-3zM7 13h8v3H7z" fill="currentColor" stroke="none" />
           </svg>

--- a/src/components/CanvasMinimap.tsx
+++ b/src/components/CanvasMinimap.tsx
@@ -88,7 +88,7 @@ function ZoomReadout() {
   const { zoom } = useViewport();
   return (
     <span
-      className="min-w-9 text-center text-[10px] font-medium tabular-nums text-neutral-400"
+      className="min-w-9 text-center text-[10px] font-medium tabular-nums text-neutral-300"
       aria-label="Zoom level"
     >
       {Math.round(zoom * 100)}%

--- a/src/components/CanvasMinimap.tsx
+++ b/src/components/CanvasMinimap.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import {
+  MiniMap,
+  Panel,
+  useReactFlow,
+  useStore,
+  useStoreApi,
+  useViewport,
+  type Node,
+} from "@xyflow/react";
+import { CHROME_DIVIDER, CHROME_ICON_BUTTON, CHROME_ICON_BUTTON_OPEN, CHROME_SURFACE } from "./chromeStyles";
+
+/**
+ * The navigator: minimap on top, one row of canvas controls beneath. Hiding
+ * the minimap leaves the row on its own, so zoom, fit and lock never move.
+ */
+export const MINIMAP_GEOMETRY = {
+  width: 200,
+  height: 120,
+  /** Distance from the canvas edges. */
+  margin: 16,
+  /** Inset between the card edge and the minimap. */
+  padding: 6,
+} as const;
+
+/** Card width, with its 1px border. Neighbours to the left offset from this. */
+export const NAVIGATOR_WIDTH = MINIMAP_GEOMETRY.width + MINIMAP_GEOMETRY.padding * 2 + 2;
+
+export function getMiniMapNodeColor(node: Node): string {
+  switch (node.type) {
+    case "imageInput": return "#3b82f6";
+    case "audioInput": return "#a78bfa";
+    case "videoInput": return "#c084fc";
+    case "annotation": return "#8b5cf6";
+    case "prompt": return "#f97316";
+    case "array": return "#a3e635";
+    case "promptConstructor": return "#f472b6";
+    case "nanoBanana": return "#22c55e";
+    case "generateVideo": return "#9333ea";
+    case "generate3d": return "#fb923c";
+    case "generateAudio": return "#d946ef";
+    case "llmGenerate": return "#06b6d4";
+    case "splitGrid": return "#f59e0b";
+    case "output": return "#ef4444";
+    case "outputGallery": return "#ec4899";
+    case "imageCompare": return "#14b8a6";
+    case "videoStitch": return "#f97316";
+    case "easeCurve": return "#bef264";
+    case "videoTrim": return "#60a5fa";
+    case "videoFrameGrab": return "#38bdf8";
+    case "removeBackground": return "#2dd4bf";
+    case "imageResize": return "#0d9488";
+    case "gifEncoder": return "#f472b6";
+    case "router": return "#6b7280";
+    case "switch": return "#8b5cf6";
+    case "conditionalSwitch": return "#06b6d4";
+    case "glbViewer": return "#0ea5e9";
+    case "comfyApp": return "#7dd3fc";
+    default: return "#94a3b8";
+  }
+}
+
+const iconProps = { fill: "none", stroke: "currentColor", strokeWidth: 1.75, strokeLinecap: "round", strokeLinejoin: "round", viewBox: "0 0 24 24", "aria-hidden": true } as const;
+
+interface ControlButtonProps {
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+  on?: boolean;
+  pressed?: boolean;
+  children: ReactNode;
+}
+
+function ControlButton({ label, disabled, onClick, on = false, pressed, children }: ControlButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      aria-pressed={pressed}
+      disabled={disabled}
+      onClick={onClick}
+      className={`${CHROME_ICON_BUTTON} ${on ? CHROME_ICON_BUTTON_OPEN : ""}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Subscribes to the viewport on its own so panning re-renders only this label. */
+function ZoomReadout() {
+  const { zoom } = useViewport();
+  return (
+    <span
+      className="min-w-9 text-center text-[10px] font-medium tabular-nums text-neutral-400"
+      aria-label="Zoom level"
+    >
+      {Math.round(zoom * 100)}%
+    </span>
+  );
+}
+
+interface CanvasMinimapProps {
+  /** Tutorial lock: greyed out and inert. */
+  disabled?: boolean;
+}
+
+export function CanvasMinimap({ disabled = false }: CanvasMinimapProps) {
+  const [isMinimapVisible, setIsMinimapVisible] = useState(true);
+  const { zoomIn, zoomOut, fitView } = useReactFlow();
+  const store = useStoreApi();
+  const isInteractive = useStore(
+    (s) => Boolean(s.nodesDraggable || s.nodesConnectable || s.elementsSelectable),
+  );
+
+  const toggleInteractive = () => {
+    store.setState({
+      nodesDraggable: !isInteractive,
+      nodesConnectable: !isInteractive,
+      elementsSelectable: !isInteractive,
+    });
+  };
+
+  return (
+    <Panel
+      position="bottom-right"
+      data-testid="canvas-navigator"
+      style={{ margin: MINIMAP_GEOMETRY.margin }}
+      className={`${CHROME_SURFACE} nodrag nopan nowheel flex flex-col overflow-hidden rounded-xl ${
+        disabled ? "opacity-30 pointer-events-none" : ""
+      }`}
+    >
+      {isMinimapVisible && (
+        <div style={{ padding: `${MINIMAP_GEOMETRY.padding}px ${MINIMAP_GEOMETRY.padding}px 0` }}>
+          <MiniMap
+            className="rounded-[7px] squircle bg-well shadow-well"
+            style={{
+              position: "static",
+              margin: 0,
+              width: MINIMAP_GEOMETRY.width,
+              height: MINIMAP_GEOMETRY.height,
+            }}
+            bgColor="#1a1a1a"
+            maskColor="rgba(0, 0, 0, 0.6)"
+            maskStrokeColor="rgba(255, 255, 255, 0.35)"
+            maskStrokeWidth={1}
+            pannable
+            zoomable
+            nodeColor={getMiniMapNodeColor}
+          />
+        </div>
+      )}
+      <div className="flex h-[34px] items-center gap-0.5 px-1">
+        <ControlButton label="Zoom out" disabled={disabled} onClick={() => zoomOut()}>
+          <svg className="h-4 w-4" {...iconProps}><path d="M5 12h14" /></svg>
+        </ControlButton>
+        <ZoomReadout />
+        <ControlButton label="Zoom in" disabled={disabled} onClick={() => zoomIn()}>
+          <svg className="h-4 w-4" {...iconProps}><path d="M12 5v14M5 12h14" /></svg>
+        </ControlButton>
+        <div className={CHROME_DIVIDER} />
+        <ControlButton label="Fit view" disabled={disabled} onClick={() => fitView()}>
+          <svg className="h-4 w-4" {...iconProps}>
+            <path d="M4 9V5a1 1 0 011-1h4M20 9V5a1 1 0 00-1-1h-4M4 15v4a1 1 0 001 1h4M20 15v4a1 1 0 01-1 1h-4" />
+          </svg>
+        </ControlButton>
+        <ControlButton
+          label={isInteractive ? "Lock canvas" : "Unlock canvas"}
+          pressed={!isInteractive}
+          on={!isInteractive}
+          disabled={disabled}
+          onClick={toggleInteractive}
+        >
+          <svg className="h-4 w-4" {...iconProps}>
+            <rect x="5" y="11" width="14" height="10" rx="2" />
+            <path d={isInteractive ? "M8 11V7a4 4 0 018 0" : "M8 11V7a4 4 0 018 0v4"} />
+          </svg>
+        </ControlButton>
+        <div className={CHROME_DIVIDER} />
+        <ControlButton
+          label={isMinimapVisible ? "Hide minimap" : "Show minimap"}
+          pressed={isMinimapVisible}
+          on={isMinimapVisible}
+          disabled={disabled}
+          onClick={() => setIsMinimapVisible((v) => !v)}
+        >
+          <svg className="h-4 w-4" {...iconProps} strokeWidth={1.5}>
+            <rect x="3" y="4" width="18" height="16" rx="2" />
+            <path d="M7 8h3v3H7zM12 8h3v3h-3zM7 13h8v3H7z" fill="currentColor" stroke="none" />
+          </svg>
+        </ControlButton>
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/CanvasMinimap.tsx
+++ b/src/components/CanvasMinimap.tsx
@@ -17,17 +17,18 @@ import { CHROME_DIVIDER, CHROME_SURFACE } from "./chromeStyles";
  * The navigator: minimap on top, one row of canvas controls beneath. Hiding
  * the minimap leaves the row on its own, so zoom, fit and lock never move.
  */
+/** Card width, with its 1px border: wide enough for the control row. Neighbours to the left offset from this. */
+export const NAVIGATOR_WIDTH = 280;
+
 export const MINIMAP_GEOMETRY = {
-  width: 200,
-  height: 120,
+  /** Fills the card between the insets. */
+  width: NAVIGATOR_WIDTH - 6 * 2 - 2,
+  height: 150,
   /** Distance from the canvas edges. */
   margin: 16,
   /** Inset between the card edge and the minimap. */
   padding: 6,
 } as const;
-
-/** Card width, with its 1px border. Neighbours to the left offset from this. */
-export const NAVIGATOR_WIDTH = MINIMAP_GEOMETRY.width + MINIMAP_GEOMETRY.padding * 2 + 2;
 
 export function getMiniMapNodeColor(node: Node): string {
   switch (node.type) {
@@ -120,7 +121,7 @@ export function CanvasMinimap({ disabled = false }: CanvasMinimapProps) {
     <Panel
       position="bottom-right"
       data-testid="canvas-navigator"
-      style={{ margin: MINIMAP_GEOMETRY.margin }}
+      style={{ margin: MINIMAP_GEOMETRY.margin, width: NAVIGATOR_WIDTH }}
       className={`${CHROME_SURFACE} nodrag nopan nowheel flex flex-col overflow-hidden rounded-xl ${
         disabled ? "opacity-30 pointer-events-none" : ""
       }`}
@@ -128,7 +129,8 @@ export function CanvasMinimap({ disabled = false }: CanvasMinimapProps) {
       {isMinimapVisible && (
         <div style={{ padding: `${MINIMAP_GEOMETRY.padding}px ${MINIMAP_GEOMETRY.padding}px 0` }}>
           <MiniMap
-            className="rounded-[7px] squircle bg-well shadow-well"
+            // 6px radius = the card's 12px minus the 6px inset, so the corners run concentric.
+            className="overflow-hidden rounded-md squircle bg-well shadow-well"
             style={{
               position: "static",
               margin: 0,
@@ -145,7 +147,7 @@ export function CanvasMinimap({ disabled = false }: CanvasMinimapProps) {
           />
         </div>
       )}
-      <div className="flex h-[38px] items-center gap-0.5 px-1">
+      <div className="flex h-[38px] items-center justify-center gap-0.5 px-1">
         <ControlButton label="Zoom out" disabled={disabled} onClick={() => zoomOut()}>
           <svg className="h-[18px] w-[18px]" {...iconProps}><path d="M5 12h14" /></svg>
         </ControlButton>

--- a/src/components/CanvasMinimap.tsx
+++ b/src/components/CanvasMinimap.tsx
@@ -10,7 +10,8 @@ import {
   useViewport,
   type Node,
 } from "@xyflow/react";
-import { CHROME_DIVIDER, CHROME_ICON_BUTTON, CHROME_ICON_BUTTON_OPEN, CHROME_SURFACE } from "./chromeStyles";
+import { ChromeIconButton } from "./ChromeIconButton";
+import { CHROME_DIVIDER, CHROME_SURFACE } from "./chromeStyles";
 
 /**
  * The navigator: minimap on top, one row of canvas controls beneath. Hiding
@@ -75,17 +76,9 @@ interface ControlButtonProps {
 
 function ControlButton({ label, disabled, onClick, on = false, pressed, children }: ControlButtonProps) {
   return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      aria-pressed={pressed}
-      disabled={disabled}
-      onClick={onClick}
-      className={`${CHROME_ICON_BUTTON} ${on ? CHROME_ICON_BUTTON_OPEN : ""}`}
-    >
+    <ChromeIconButton label={label} aria-pressed={pressed} open={on} disabled={disabled} onClick={onClick}>
       {children}
-    </button>
+    </ChromeIconButton>
   );
 }
 

--- a/src/components/ChromeIconButton.tsx
+++ b/src/components/ChromeIconButton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { CHROME_ICON_BUTTON, CHROME_ICON_BUTTON_OPEN } from "./chromeStyles";
+
+/**
+ * Hover label for an icon-only button. CSS-driven (300ms delay, fades in on
+ * hover and on keyboard focus), so it never fights the popover state.
+ */
+function Tooltip({ label, shortcut }: { label: string; shortcut?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2.5 flex -translate-x-1/2 items-center gap-1.5 whitespace-nowrap rounded-md squircle border border-white/10 bg-neutral-950 py-1 pl-2 pr-1.5 text-[10px] font-medium leading-3 text-neutral-200 opacity-0 shadow-[0_4px_12px_rgba(0,0,0,0.5)] transition-opacity delay-300 duration-[120ms] group-hover:opacity-100 group-has-focus-visible:opacity-100"
+    >
+      {label}
+      {shortcut && (
+        <kbd className="rounded-[3px] border border-white/6 bg-white/6 px-1 font-sans text-[9px] text-neutral-500">
+          {shortcut}
+        </kbd>
+      )}
+    </span>
+  );
+}
+
+export interface ChromeIconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Accessible name; also the hover label. */
+  label: string;
+  shortcut?: string;
+  /** Popover up, or a stateful toggle that is on. */
+  open?: boolean;
+  /** Suppress the hover label (while this button's own popover is up). */
+  silent?: boolean;
+  badge?: ReactNode;
+  children: ReactNode;
+}
+
+/** 28px icon-only button on the chrome surface, with its hover label. */
+export function ChromeIconButton({ label, shortcut, open = false, silent = false, badge, className = "", children, ...rest }: ChromeIconButtonProps) {
+  return (
+    <div className="group relative flex">
+      <button
+        type="button"
+        aria-label={label}
+        className={`${CHROME_ICON_BUTTON} ${open ? CHROME_ICON_BUTTON_OPEN : ""} ${className}`}
+        {...rest}
+      >
+        {children}
+      </button>
+      {badge}
+      {!silent && <Tooltip label={label} shortcut={shortcut} />}
+    </div>
+  );
+}

--- a/src/components/ChromeIconButton.tsx
+++ b/src/components/ChromeIconButton.tsx
@@ -35,7 +35,7 @@ export interface ChromeIconButtonProps extends React.ButtonHTMLAttributes<HTMLBu
   children: ReactNode;
 }
 
-/** 28px icon-only button on the chrome surface, with its hover label. */
+/** 32px icon-only button on the chrome surface, with its hover label. */
 export function ChromeIconButton({ label, shortcut, open = false, silent = false, badge, className = "", children, ...rest }: ChromeIconButtonProps) {
   return (
     <div className="group relative flex">

--- a/src/components/ChromeIconButton.tsx
+++ b/src/components/ChromeIconButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { CHROME_ICON_BUTTON, CHROME_ICON_BUTTON_OPEN } from "./chromeStyles";
+import { CHROME_ICON_BUTTON, CHROME_ICON_BUTTON_OPEN, CHROME_ICON_BUTTON_SIZE } from "./chromeStyles";
 
 /**
  * Hover label for an icon-only button. CSS-driven (300ms delay, fades in on
@@ -32,17 +32,18 @@ export interface ChromeIconButtonProps extends React.ButtonHTMLAttributes<HTMLBu
   /** Suppress the hover label (while this button's own popover is up). */
   silent?: boolean;
   badge?: ReactNode;
+  size?: keyof typeof CHROME_ICON_BUTTON_SIZE;
   children: ReactNode;
 }
 
-/** 32px icon-only button on the chrome surface, with its hover label. */
-export function ChromeIconButton({ label, shortcut, open = false, silent = false, badge, className = "", children, ...rest }: ChromeIconButtonProps) {
+/** Icon-only button on the chrome surface, with its hover label. */
+export function ChromeIconButton({ label, shortcut, open = false, silent = false, badge, size = "md", className = "", children, ...rest }: ChromeIconButtonProps) {
   return (
     <div className="group relative flex">
       <button
         type="button"
         aria-label={label}
-        className={`${CHROME_ICON_BUTTON} ${open ? CHROME_ICON_BUTTON_OPEN : ""} ${className}`}
+        className={`${CHROME_ICON_BUTTON} ${CHROME_ICON_BUTTON_SIZE[size]} ${open ? CHROME_ICON_BUTTON_OPEN : ""} ${className}`}
         {...rest}
       >
         {children}

--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -151,12 +151,12 @@ const CaretUpIcon = ({ open = false }: { open?: boolean }) => (
   </svg>
 );
 const PlayIcon = () => (
-  <svg className="h-3 w-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M8 5v14l11-7z" />
   </svg>
 );
 const SpinnerIcon = () => (
-  <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
     <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="3" opacity="0.25" />
     <path d="M12 3a9 9 0 019 9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
   </svg>
@@ -595,7 +595,7 @@ export function FloatingActionBar() {
               disabled={!valid && !isRunning}
               title={runTitle}
               data-tutorial="floating-run-button"
-              className="flex items-center gap-1.5 whitespace-nowrap pl-3.5 pr-3 text-[11px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
+              className="flex items-center gap-2 whitespace-nowrap pl-4 pr-3.5 text-[13px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
             >
               {isRunning ? (
                 <>
@@ -622,7 +622,7 @@ export function FloatingActionBar() {
                 title="Run options"
                 className={`flex w-7 items-center justify-center border-l border-black/10 transition-colors duration-[120ms] focus-visible:outline-none ${runMenuOpen ? "bg-neutral-200" : ""}`}
               >
-                <svg className={`h-2.5 w-2.5 transition-transform duration-[120ms] ${runMenuOpen ? "rotate-180" : ""}`} {...iconProps} strokeWidth={2.5}>
+                <svg className={`h-3 w-3 transition-transform duration-[120ms] ${runMenuOpen ? "rotate-180" : ""}`} {...iconProps} strokeWidth={2.5}>
                   <path d="M19 9l-7 7-7-7" />
                 </svg>
               </button>

--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -95,7 +95,7 @@ function getPaneCenter() {
 
 // ---- Icons: 16px, 1.5 stroke, one style throughout ------------------------------
 
-const ICON = "h-4 w-4";
+const ICON = "h-[18px] w-[18px]";
 const iconProps = { fill: "none", stroke: "currentColor", strokeWidth: 1.5, strokeLinecap: "round", strokeLinejoin: "round", viewBox: "0 0 24 24", "aria-hidden": true } as const;
 
 const ImageIcon = () => (
@@ -146,17 +146,17 @@ const LlmIcon = () => (
   </svg>
 );
 const CaretUpIcon = ({ open = false }: { open?: boolean }) => (
-  <svg className={`h-2.5 w-2.5 transition-transform duration-[120ms] ${open ? "rotate-180" : ""}`} {...iconProps} strokeWidth={2.25}>
+  <svg className={`h-3 w-3 transition-transform duration-[120ms] ${open ? "rotate-180" : ""}`} {...iconProps} strokeWidth={2.25}>
     <path d="M5 15l7-7 7 7" />
   </svg>
 );
 const PlayIcon = () => (
-  <svg className="h-[11px] w-[11px]" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <svg className="h-3 w-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M8 5v14l11-7z" />
   </svg>
 );
 const SpinnerIcon = () => (
-  <svg className="h-[11px] w-[11px] animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
     <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="3" opacity="0.25" />
     <path d="M12 3a9 9 0 019 9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
   </svg>
@@ -232,8 +232,8 @@ const GENERATORS: { type: NodeType; label: string; shortcut?: string; icon: Reac
   { type: "llmGenerate", label: "Text (LLM)", shortcut: "⇧L", icon: <LlmIcon /> },
 ];
 
-/** Split control: the sparkle adds an image generator, the caret lists the others. */
-function GenerateSplitButton() {
+/** One trigger; the menu lists the generators. Clicking the trigger never adds a node. */
+function GenerateMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const { add, dragStart } = useAddNode(true);
@@ -246,25 +246,16 @@ function GenerateSplitButton() {
   };
 
   return (
-    <div className="relative flex items-center" ref={menuRef}>
+    <div className="relative flex" ref={menuRef}>
       <IconButton
-        label="Generate image"
-        shortcut="⇧G"
-        onClick={() => handleAddNode("nanoBanana")}
-        draggable
-        onDragStart={(e) => dragStart(e, "nanoBanana")}
-        className="cursor-grab rounded-r-none active:cursor-grabbing"
-      >
-        <SparkleIcon />
-      </IconButton>
-      <IconButton
-        label="More generators"
+        label="Generate"
         open={isOpen}
         silent={isOpen}
         aria-expanded={isOpen}
         onClick={() => setIsOpen(!isOpen)}
-        className={`w-3.5 rounded-l-none ${isOpen ? "" : "text-neutral-500"}`}
+        className="w-auto gap-0.5 pl-1.5 pr-1"
       >
+        <SparkleIcon />
         <CaretUpIcon open={isOpen} />
       </IconButton>
 
@@ -550,11 +541,11 @@ export function FloatingActionBar() {
   return (
     <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
       {/* w-max: a fixed element anchored at left-1/2 otherwise shrinks to half the viewport and wraps. */}
-      <div className={`${CHROME_SURFACE} flex h-10 w-max items-center gap-0.5 rounded-xl px-1.5`}>
+      <div className={`${CHROME_SURFACE} flex h-11 w-max items-center gap-0.5 rounded-xl px-1.5`}>
         <NodeButton type="imageInput" label="Image" shortcut="⇧I" dataTutorial="image-button"><ImageIcon /></NodeButton>
         <NodeButton type="videoInput" label="Video" shortcut="⇧Y"><VideoIcon /></NodeButton>
         <NodeButton type="prompt" label="Prompt" shortcut="⇧P" dataTutorial="prompt-button"><PromptIcon /></NodeButton>
-        <GenerateSplitButton />
+        <GenerateMenu />
         <NodeButton type="output" label="Output" dataTutorial="output-button"><OutputIcon /></NodeButton>
 
         <Divider />
@@ -587,7 +578,7 @@ export function FloatingActionBar() {
 
         <div className="relative ml-0.5 flex items-center" ref={runMenuRef}>
           <div
-            className={`flex h-7 items-stretch overflow-hidden rounded-[7px] squircle transition-[background-color,box-shadow,transform] duration-[120ms] ease-out ${
+            className={`flex h-8 items-stretch overflow-hidden rounded-lg squircle transition-[background-color,box-shadow,transform] duration-[120ms] ease-out ${
               !valid && !isRunning
                 ? "bg-white/8 text-neutral-500"
                 : "bg-neutral-50 text-neutral-900 hover:bg-white hover:shadow-[0_0_0_1px_rgba(255,255,255,0.35),0_1px_2px_rgba(0,0,0,0.3)] active:scale-[0.97] active:bg-neutral-200"
@@ -599,7 +590,7 @@ export function FloatingActionBar() {
               disabled={!valid && !isRunning}
               title={runTitle}
               data-tutorial="floating-run-button"
-              className="flex items-center gap-1.5 whitespace-nowrap pl-[11px] pr-2.5 text-[11px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
+              className="flex items-center gap-1.5 whitespace-nowrap pl-3 pr-2.5 text-[11px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
             >
               {isRunning ? (
                 <>
@@ -624,7 +615,7 @@ export function FloatingActionBar() {
                 data-tutorial="floating-run-dropdown"
                 aria-expanded={runMenuOpen}
                 title="Run options"
-                className={`flex w-5 items-center justify-center border-l border-black/10 transition-colors duration-[120ms] focus-visible:outline-none ${runMenuOpen ? "bg-neutral-200" : ""}`}
+                className={`flex w-6 items-center justify-center border-l border-black/10 transition-colors duration-[120ms] focus-visible:outline-none ${runMenuOpen ? "bg-neutral-200" : ""}`}
               >
                 <svg className={`h-2.5 w-2.5 transition-transform duration-[120ms] ${runMenuOpen ? "rotate-180" : ""}`} {...iconProps} strokeWidth={2.5}>
                   <path d="M19 9l-7 7-7-7" />

--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect, useMemo, useCallback, type ReactNode } from "react";
-import { ChromeIconButton as IconButton } from "./ChromeIconButton";
+import { ChromeIconButton, type ChromeIconButtonProps } from "./ChromeIconButton";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { useShallow } from "zustand/shallow";
 import { NodeType } from "@/types";
@@ -95,7 +95,7 @@ function getPaneCenter() {
 
 // ---- Icons: 16px, 1.5 stroke, one style throughout ------------------------------
 
-const ICON = "h-[18px] w-[18px]";
+const ICON = "h-5 w-5";
 const iconProps = { fill: "none", stroke: "currentColor", strokeWidth: 1.5, strokeLinecap: "round", strokeLinejoin: "round", viewBox: "0 0 24 24", "aria-hidden": true } as const;
 
 const ImageIcon = () => (
@@ -163,6 +163,11 @@ const SpinnerIcon = () => (
 );
 
 // ---- Primitives -------------------------------------------------------------------
+
+/** The bar runs one size up from the navigator. */
+function IconButton(props: ChromeIconButtonProps) {
+  return <ChromeIconButton size="lg" {...props} />;
+}
 
 function Divider() {
   return <div className={CHROME_DIVIDER} />;
@@ -541,7 +546,7 @@ export function FloatingActionBar() {
   return (
     <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
       {/* w-max: a fixed element anchored at left-1/2 otherwise shrinks to half the viewport and wraps. */}
-      <div className={`${CHROME_SURFACE} flex h-11 w-max items-center gap-0.5 rounded-xl px-1.5`}>
+      <div className={`${CHROME_SURFACE} flex h-12 w-max items-center gap-0.5 rounded-xl px-1.5`}>
         <NodeButton type="imageInput" label="Image" shortcut="⇧I" dataTutorial="image-button"><ImageIcon /></NodeButton>
         <NodeButton type="videoInput" label="Video" shortcut="⇧Y"><VideoIcon /></NodeButton>
         <NodeButton type="prompt" label="Prompt" shortcut="⇧P" dataTutorial="prompt-button"><PromptIcon /></NodeButton>
@@ -578,7 +583,7 @@ export function FloatingActionBar() {
 
         <div className="relative ml-0.5 flex items-center" ref={runMenuRef}>
           <div
-            className={`flex h-8 items-stretch overflow-hidden rounded-lg squircle transition-[background-color,box-shadow,transform] duration-[120ms] ease-out ${
+            className={`flex h-9 items-stretch overflow-hidden rounded-lg squircle transition-[background-color,box-shadow,transform] duration-[120ms] ease-out ${
               !valid && !isRunning
                 ? "bg-white/8 text-neutral-500"
                 : "bg-neutral-50 text-neutral-900 hover:bg-white hover:shadow-[0_0_0_1px_rgba(255,255,255,0.35),0_1px_2px_rgba(0,0,0,0.3)] active:scale-[0.97] active:bg-neutral-200"
@@ -590,7 +595,7 @@ export function FloatingActionBar() {
               disabled={!valid && !isRunning}
               title={runTitle}
               data-tutorial="floating-run-button"
-              className="flex items-center gap-1.5 whitespace-nowrap pl-3 pr-2.5 text-[11px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
+              className="flex items-center gap-1.5 whitespace-nowrap pl-3.5 pr-3 text-[11px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
             >
               {isRunning ? (
                 <>
@@ -615,7 +620,7 @@ export function FloatingActionBar() {
                 data-tutorial="floating-run-dropdown"
                 aria-expanded={runMenuOpen}
                 title="Run options"
-                className={`flex w-6 items-center justify-center border-l border-black/10 transition-colors duration-[120ms] focus-visible:outline-none ${runMenuOpen ? "bg-neutral-200" : ""}`}
+                className={`flex w-7 items-center justify-center border-l border-black/10 transition-colors duration-[120ms] focus-visible:outline-none ${runMenuOpen ? "bg-neutral-200" : ""}`}
               >
                 <svg className={`h-2.5 w-2.5 transition-transform duration-[120ms] ${runMenuOpen ? "rotate-180" : ""}`} {...iconProps} strokeWidth={2.5}>
                   <path d="M19 9l-7 7-7-7" />

--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect, useMemo, useCallback, type ReactNode } from "react";
+import { ChromeIconButton as IconButton } from "./ChromeIconButton";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { useShallow } from "zustand/shallow";
 import { NodeType } from "@/types";
@@ -10,8 +11,6 @@ import { useFTUXStore, TutorialStep } from "@/store/ftuxStore";
 import type { EdgeStyle } from "@/types";
 import {
   CHROME_DIVIDER,
-  CHROME_ICON_BUTTON,
-  CHROME_ICON_BUTTON_OPEN,
   CHROME_MENU,
   CHROME_MENU_HEADING,
   CHROME_MENU_HINT,
@@ -164,53 +163,6 @@ const SpinnerIcon = () => (
 );
 
 // ---- Primitives -------------------------------------------------------------------
-
-/**
- * Hover label for an icon-only button. CSS-driven (300ms delay, fades in on
- * hover and on keyboard focus), so it never fights the popover state.
- */
-function Tooltip({ label, shortcut }: { label: string; shortcut?: string }) {
-  return (
-    <span
-      aria-hidden="true"
-      className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2.5 flex -translate-x-1/2 items-center gap-1.5 whitespace-nowrap rounded-md squircle border border-white/10 bg-neutral-950 py-1 pl-2 pr-1.5 text-[10px] font-medium leading-3 text-neutral-200 opacity-0 shadow-[0_4px_12px_rgba(0,0,0,0.5)] transition-opacity delay-300 duration-[120ms] group-hover:opacity-100 group-focus-within:opacity-100"
-    >
-      {label}
-      {shortcut && (
-        <kbd className="rounded-[3px] border border-white/6 bg-white/6 px-1 font-sans text-[9px] text-neutral-500">
-          {shortcut}
-        </kbd>
-      )}
-    </span>
-  );
-}
-
-interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  label: string;
-  shortcut?: string;
-  open?: boolean;
-  /** Suppress the tooltip (while this button's own popover is up). */
-  silent?: boolean;
-  badge?: ReactNode;
-  children: ReactNode;
-}
-
-function IconButton({ label, shortcut, open = false, silent = false, badge, className = "", children, ...rest }: IconButtonProps) {
-  return (
-    <div className="group relative flex">
-      <button
-        type="button"
-        aria-label={label}
-        className={`${CHROME_ICON_BUTTON} ${open ? CHROME_ICON_BUTTON_OPEN : ""} ${className}`}
-        {...rest}
-      >
-        {children}
-      </button>
-      {badge}
-      {!silent && <Tooltip label={label} shortcut={shortcut} />}
-    </div>
-  );
-}
 
 function Divider() {
   return <div className={CHROME_DIVIDER} />;
@@ -608,18 +560,17 @@ export function FloatingActionBar() {
         <Divider />
 
         <AllNodesMenu />
-        <IconButton label="All models" title="Browse models" onClick={() => setModelSearchOpen(true)}>
+        <IconButton label="All models" onClick={() => setModelSearchOpen(true)}>
           <CubeIcon />
         </IconButton>
 
         <Divider />
 
-        <IconButton label={edgeStyleLabel} title={edgeStyleLabel} onClick={toggleEdgeStyle}>
+        <IconButton label={edgeStyleLabel} onClick={toggleEdgeStyle}>
           <EdgeStyleIcon style={edgeStyle} />
         </IconButton>
         <IconButton
           label={hiddenEdgesLabel}
-          title={hiddenEdgesLabel}
           open={hiddenEdgeCount > 0}
           disabled={totalEdgeCount === 0}
           onClick={toggleHiddenEdges}

--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -151,12 +151,12 @@ const CaretUpIcon = ({ open = false }: { open?: boolean }) => (
   </svg>
 );
 const PlayIcon = () => (
-  <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <svg className="h-[18px] w-[18px]" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M8 5v14l11-7z" />
   </svg>
 );
 const SpinnerIcon = () => (
-  <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
     <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="3" opacity="0.25" />
     <path d="M12 3a9 9 0 019 9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
   </svg>
@@ -595,7 +595,7 @@ export function FloatingActionBar() {
               disabled={!valid && !isRunning}
               title={runTitle}
               data-tutorial="floating-run-button"
-              className="flex items-center gap-2 whitespace-nowrap pl-4 pr-3.5 text-[13px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
+              className="flex items-center gap-1.5 whitespace-nowrap pl-3 pr-3.5 text-[13px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
             >
               {isRunning ? (
                 <>

--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -276,7 +276,7 @@ function GenerateMenu() {
               onDragStart={(e) => { dragStart(e, g.type); setIsOpen(false); }}
               className={`${CHROME_MENU_ITEM} cursor-grab active:cursor-grabbing`}
             >
-              <span className="text-neutral-400">{g.icon}</span>
+              <span className="text-neutral-300">{g.icon}</span>
               {g.label}
               {g.shortcut && <span className={CHROME_MENU_HINT}>{g.shortcut}</span>}
             </button>

--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useEffect, useMemo, useCallback } from "react";
+import { useRef, useState, useEffect, useMemo, useCallback, type ReactNode } from "react";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { useShallow } from "zustand/shallow";
 import { NodeType } from "@/types";
@@ -8,6 +8,16 @@ import { useReactFlow } from "@xyflow/react";
 import { ModelSearchDialog } from "./modals/ModelSearchDialog";
 import { useFTUXStore, TutorialStep } from "@/store/ftuxStore";
 import type { EdgeStyle } from "@/types";
+import {
+  CHROME_DIVIDER,
+  CHROME_ICON_BUTTON,
+  CHROME_ICON_BUTTON_OPEN,
+  CHROME_MENU,
+  CHROME_MENU_HEADING,
+  CHROME_MENU_HINT,
+  CHROME_MENU_ITEM,
+  CHROME_SURFACE,
+} from "./chromeStyles";
 
 /** The action-bar button cycles curved → angular → straight → curved. */
 const NEXT_EDGE_STYLE: Record<EdgeStyle, EdgeStyle> = { curved: "angular", angular: "straight", straight: "curved" };
@@ -84,226 +94,289 @@ function getPaneCenter() {
   return { x: window.innerWidth / 2, y: window.innerHeight / 2 };
 }
 
-interface NodeButtonProps {
-  type: NodeType;
-  label: string;
-  dataTutorial?: string;
-}
+// ---- Icons: 16px, 1.5 stroke, one style throughout ------------------------------
 
-function NodeButton({ type, label, dataTutorial }: NodeButtonProps) {
-  const addNode = useWorkflowStore((state) => state.addNode);
-  const { screenToFlowPosition } = useReactFlow();
+const ICON = "h-4 w-4";
+const iconProps = { fill: "none", stroke: "currentColor", strokeWidth: 1.5, strokeLinecap: "round", strokeLinejoin: "round", viewBox: "0 0 24 24", "aria-hidden": true } as const;
 
-  const handleClick = () => {
-    const center = getPaneCenter();
-    const position = screenToFlowPosition({
-      x: center.x,
-      y: center.y,
-    });
+const ImageIcon = () => (
+  <svg className={ICON} {...iconProps}>
+    <rect x="3" y="5" width="18" height="14" rx="2.5" />
+    <path d="M3 16l5-5 4 4 3-3 6 6" />
+    <circle cx="16" cy="9" r="1.25" fill="currentColor" stroke="none" />
+  </svg>
+);
+const VideoIcon = () => (
+  <svg className={ICON} {...iconProps}>
+    <rect x="3" y="7" width="13" height="10" rx="2.5" />
+    <path d="M16 11l5-3v8l-5-3" />
+  </svg>
+);
+const PromptIcon = () => (
+  <svg className={ICON} {...iconProps}>
+    <path d="M4 6h16M4 12h10M4 18h7" />
+  </svg>
+);
+const SparkleIcon = () => (
+  <svg className={ICON} {...iconProps}>
+    <path d="M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8z" />
+    <path d="M19 16l.8 2.2L22 19l-2.2.8L19 22l-.8-2.2L16 19l2.2-.8z" />
+  </svg>
+);
+const OutputIcon = () => (
+  <svg className={ICON} {...iconProps}>
+    <path d="M14 4h6v6M20 4l-8 8M11 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-5" />
+  </svg>
+);
+const GridIcon = () => (
+  <svg className={ICON} {...iconProps}>
+    <rect x="4" y="4" width="6" height="6" rx="1.5" />
+    <rect x="14" y="4" width="6" height="6" rx="1.5" />
+    <rect x="4" y="14" width="6" height="6" rx="1.5" />
+    <rect x="14" y="14" width="6" height="6" rx="1.5" />
+  </svg>
+);
+const CubeIcon = () => (
+  <svg className={ICON} {...iconProps}>
+    <path d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
+  </svg>
+);
+const LlmIcon = () => (
+  <svg className={ICON} {...iconProps}>
+    <path d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
+  </svg>
+);
+const CaretUpIcon = ({ open = false }: { open?: boolean }) => (
+  <svg className={`h-2.5 w-2.5 transition-transform duration-[120ms] ${open ? "rotate-180" : ""}`} {...iconProps} strokeWidth={2.25}>
+    <path d="M5 15l7-7 7 7" />
+  </svg>
+);
+const PlayIcon = () => (
+  <svg className="h-[11px] w-[11px]" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M8 5v14l11-7z" />
+  </svg>
+);
+const SpinnerIcon = () => (
+  <svg className="h-[11px] w-[11px] animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="3" opacity="0.25" />
+    <path d="M12 3a9 9 0 019 9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+  </svg>
+);
 
-    // Nodes are created empty - tutorial will populate after connection
-    addNode(type, position);
-  };
+// ---- Primitives -------------------------------------------------------------------
 
-  const handleDragStart = (event: React.DragEvent) => {
-    event.dataTransfer.setData("application/node-type", type);
-    event.dataTransfer.effectAllowed = "copy";
-  };
-
+/**
+ * Hover label for an icon-only button. CSS-driven (300ms delay, fades in on
+ * hover and on keyboard focus), so it never fights the popover state.
+ */
+function Tooltip({ label, shortcut }: { label: string; shortcut?: string }) {
   return (
-    <button
-      onClick={handleClick}
-      draggable
-      onDragStart={handleDragStart}
-      data-tutorial={dataTutorial}
-      className="px-2.5 py-1.5 text-[11px] font-medium text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700 rounded transition-colors cursor-grab active:cursor-grabbing"
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2.5 flex -translate-x-1/2 items-center gap-1.5 whitespace-nowrap rounded-md squircle border border-white/10 bg-neutral-950 py-1 pl-2 pr-1.5 text-[10px] font-medium leading-3 text-neutral-200 opacity-0 shadow-[0_4px_12px_rgba(0,0,0,0.5)] transition-opacity delay-300 duration-[120ms] group-hover:opacity-100 group-focus-within:opacity-100"
     >
       {label}
-    </button>
+      {shortcut && (
+        <kbd className="rounded-[3px] border border-white/6 bg-white/6 px-1 font-sans text-[9px] text-neutral-500">
+          {shortcut}
+        </kbd>
+      )}
+    </span>
   );
 }
 
-function GenerateComboButton() {
-  const [isOpen, setIsOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  shortcut?: string;
+  open?: boolean;
+  /** Suppress the tooltip (while this button's own popover is up). */
+  silent?: boolean;
+  badge?: ReactNode;
+  children: ReactNode;
+}
+
+function IconButton({ label, shortcut, open = false, silent = false, badge, className = "", children, ...rest }: IconButtonProps) {
+  return (
+    <div className="group relative flex">
+      <button
+        type="button"
+        aria-label={label}
+        className={`${CHROME_ICON_BUTTON} ${open ? CHROME_ICON_BUTTON_OPEN : ""} ${className}`}
+        {...rest}
+      >
+        {children}
+      </button>
+      {badge}
+      {!silent && <Tooltip label={label} shortcut={shortcut} />}
+    </div>
+  );
+}
+
+function Divider() {
+  return <div className={CHROME_DIVIDER} />;
+}
+
+/** Closes a popover on outside mousedown while it is open. */
+function useClickOutside(ref: React.RefObject<HTMLElement | null>, isOpen: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) onClose();
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [ref, isOpen, onClose]);
+}
+
+/** Adds a node at the pane centre (jittered when `scatter`), or via drag onto the canvas. */
+function useAddNode(scatter = false) {
   const addNode = useWorkflowStore((state) => state.addNode);
   const { screenToFlowPosition } = useReactFlow();
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isOpen]);
-
-  const handleAddNode = (type: NodeType) => {
+  const add = useCallback((type: NodeType) => {
     const center = getPaneCenter();
-    const position = screenToFlowPosition({
-      x: center.x + Math.random() * 100 - 50,
-      y: center.y + Math.random() * 100 - 50,
-    });
+    const jitter = () => (scatter ? Math.random() * 100 - 50 : 0);
+    // Nodes are created empty - tutorial will populate after connection
+    addNode(type, screenToFlowPosition({ x: center.x + jitter(), y: center.y + jitter() }));
+  }, [addNode, screenToFlowPosition, scatter]);
 
-    addNode(type, position);
-    setIsOpen(false);
-  };
-
-  const handleDragStart = (event: React.DragEvent, type: NodeType) => {
+  const dragStart = useCallback((event: React.DragEvent, type: NodeType) => {
     event.dataTransfer.setData("application/node-type", type);
     event.dataTransfer.effectAllowed = "copy";
+  }, []);
+
+  return { add, dragStart };
+}
+
+interface NodeButtonProps {
+  type: NodeType;
+  label: string;
+  shortcut?: string;
+  dataTutorial?: string;
+  children: ReactNode;
+}
+
+function NodeButton({ type, label, shortcut, dataTutorial, children }: NodeButtonProps) {
+  const { add, dragStart } = useAddNode();
+  return (
+    <IconButton
+      label={label}
+      shortcut={shortcut}
+      onClick={() => add(type)}
+      draggable
+      onDragStart={(e) => dragStart(e, type)}
+      data-tutorial={dataTutorial}
+      className="cursor-grab active:cursor-grabbing"
+    >
+      {children}
+    </IconButton>
+  );
+}
+
+const GENERATORS: { type: NodeType; label: string; shortcut?: string; icon: ReactNode }[] = [
+  { type: "nanoBanana", label: "Image", shortcut: "⇧G", icon: <ImageIcon /> },
+  { type: "generateVideo", label: "Video", shortcut: "⇧V", icon: <VideoIcon /> },
+  { type: "generate3d", label: "3D", icon: <CubeIcon /> },
+  { type: "llmGenerate", label: "Text (LLM)", shortcut: "⇧L", icon: <LlmIcon /> },
+];
+
+/** Split control: the sparkle adds an image generator, the caret lists the others. */
+function GenerateSplitButton() {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const { add, dragStart } = useAddNode(true);
+  const close = useCallback(() => setIsOpen(false), []);
+  useClickOutside(menuRef, isOpen, close);
+
+  const handleAddNode = (type: NodeType) => {
+    add(type);
     setIsOpen(false);
   };
 
   return (
-    <div className="relative" ref={menuRef}>
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="px-2.5 py-1.5 text-[11px] font-medium text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700 rounded transition-colors flex items-center gap-1"
+    <div className="relative flex items-center" ref={menuRef}>
+      <IconButton
+        label="Generate image"
+        shortcut="⇧G"
+        onClick={() => handleAddNode("nanoBanana")}
+        draggable
+        onDragStart={(e) => dragStart(e, "nanoBanana")}
+        className="cursor-grab rounded-r-none active:cursor-grabbing"
       >
-        Generate
-        <svg
-          className={`w-3 h-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
-        </svg>
-      </button>
+        <SparkleIcon />
+      </IconButton>
+      <IconButton
+        label="More generators"
+        open={isOpen}
+        silent={isOpen}
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen(!isOpen)}
+        className={`w-3.5 rounded-l-none ${isOpen ? "" : "text-neutral-500"}`}
+      >
+        <CaretUpIcon open={isOpen} />
+      </IconButton>
 
       {isOpen && (
-        <div className="absolute bottom-full left-0 mb-2 bg-neutral-800 border border-neutral-700 rounded-lg shadow-xl overflow-hidden min-w-[140px]">
-          <button
-            onClick={() => handleAddNode("nanoBanana")}
-            draggable
-            onDragStart={(e) => handleDragStart(e, "nanoBanana")}
-            className="w-full px-3 py-2 text-left text-[11px] font-medium text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors flex items-center gap-2 cursor-grab active:cursor-grabbing"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
-            </svg>
-            Image
-          </button>
-          <button
-            onClick={() => handleAddNode("generateVideo")}
-            draggable
-            onDragStart={(e) => handleDragStart(e, "generateVideo")}
-            className="w-full px-3 py-2 text-left text-[11px] font-medium text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors flex items-center gap-2 cursor-grab active:cursor-grabbing"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z" />
-            </svg>
-            Video
-          </button>
-          <button
-            onClick={() => handleAddNode("generate3d")}
-            draggable
-            onDragStart={(e) => handleDragStart(e, "generate3d")}
-            className="w-full px-3 py-2 text-left text-[11px] font-medium text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors flex items-center gap-2 cursor-grab active:cursor-grabbing"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
-            </svg>
-            3D
-          </button>
-          <button
-            onClick={() => handleAddNode("llmGenerate")}
-            draggable
-            onDragStart={(e) => handleDragStart(e, "llmGenerate")}
-            className="w-full px-3 py-2 text-left text-[11px] font-medium text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors flex items-center gap-2 cursor-grab active:cursor-grabbing"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
-            </svg>
-            Text (LLM)
-          </button>
+        <div className={`${CHROME_MENU} left-0 min-w-[168px]`} role="menu">
+          {GENERATORS.map((g) => (
+            <button
+              key={g.type}
+              type="button"
+              role="menuitem"
+              onClick={() => handleAddNode(g.type)}
+              draggable
+              onDragStart={(e) => { dragStart(e, g.type); setIsOpen(false); }}
+              className={`${CHROME_MENU_ITEM} cursor-grab active:cursor-grabbing`}
+            >
+              <span className="text-neutral-400">{g.icon}</span>
+              {g.label}
+              {g.shortcut && <span className={CHROME_MENU_HINT}>{g.shortcut}</span>}
+            </button>
+          ))}
         </div>
       )}
     </div>
   );
 }
 
-
 function AllNodesMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-  const addNode = useWorkflowStore((state) => state.addNode);
-  const { screenToFlowPosition } = useReactFlow();
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isOpen]);
+  const { add, dragStart } = useAddNode(true);
+  const close = useCallback(() => setIsOpen(false), []);
+  useClickOutside(menuRef, isOpen, close);
 
   const handleAddNode = useCallback((type: NodeType) => {
-    const center = getPaneCenter();
-    const position = screenToFlowPosition({
-      x: center.x + Math.random() * 100 - 50,
-      y: center.y + Math.random() * 100 - 50,
-    });
-
-    addNode(type, position);
+    add(type);
     setIsOpen(false);
-  }, [addNode, screenToFlowPosition]);
-
-  const handleDragStart = useCallback((event: React.DragEvent, type: NodeType) => {
-    event.dataTransfer.setData("application/node-type", type);
-    event.dataTransfer.effectAllowed = "copy";
-    setIsOpen(false);
-  }, []);
+  }, [add]);
 
   return (
-    <div className="relative" ref={menuRef}>
-      <button
+    <div className="relative flex" ref={menuRef}>
+      <IconButton
+        label="All nodes"
+        open={isOpen}
+        silent={isOpen}
+        aria-expanded={isOpen}
         onClick={() => setIsOpen(!isOpen)}
-        className="px-2.5 py-1.5 text-[11px] font-medium text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700 rounded transition-colors flex items-center gap-1"
       >
-        All nodes
-        <svg
-          className={`w-3 h-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
-        </svg>
-      </button>
+        <GridIcon />
+      </IconButton>
 
       {isOpen && (
-        <div className="absolute bottom-full left-0 mb-2 bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl overflow-hidden min-w-[180px] max-h-[400px] overflow-y-auto">
-          {ALL_NODES_CATEGORIES.map((category, catIndex) => (
+        <div className={`${CHROME_MENU} left-0 max-h-[400px] min-w-[188px] overflow-y-auto`} role="menu">
+          {ALL_NODES_CATEGORIES.map((category) => (
             <div key={category.label}>
-              <div className={`px-3 py-1 text-[10px] text-neutral-500 uppercase tracking-wide${catIndex > 0 ? " border-t border-neutral-700" : ""}`}>
-                {category.label}
-              </div>
+              <div className={CHROME_MENU_HEADING}>{category.label}</div>
               {category.nodes.map((node) => (
                 <button
                   key={node.type}
+                  type="button"
+                  role="menuitem"
                   onClick={() => handleAddNode(node.type)}
                   draggable
-                  onDragStart={(e) => handleDragStart(e, node.type)}
-                  className="w-full px-3 py-2 text-left text-[11px] font-medium text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors flex items-center gap-2 cursor-grab active:cursor-grabbing"
+                  onDragStart={(e) => { dragStart(e, node.type); setIsOpen(false); }}
+                  className={`${CHROME_MENU_ITEM} cursor-grab active:cursor-grabbing`}
                 >
                   {node.label}
                 </button>
@@ -315,6 +388,40 @@ function AllNodesMenu() {
     </div>
   );
 }
+
+function EdgeStyleIcon({ style }: { style: EdgeStyle }) {
+  if (style === "angular") {
+    return (
+      <svg className={ICON} {...iconProps} strokeWidth={1.75}>
+        <path d="M4 12h4l4-8 4 8h4" />
+      </svg>
+    );
+  }
+  if (style === "straight") {
+    return (
+      <svg className={ICON} {...iconProps} strokeWidth={1.75}>
+        <path d="M4 16L20 8" />
+      </svg>
+    );
+  }
+  return (
+    <svg className={ICON} {...iconProps} strokeWidth={1.75}>
+      <path d="M4 17c0 0 4-10 8-10s8 10 8 10" />
+    </svg>
+  );
+}
+
+const EyeIcon = ({ off = false }: { off?: boolean }) =>
+  off ? (
+    <svg className={ICON} {...iconProps} strokeWidth={1.75}>
+      <path d="M3 3l18 18M10.6 10.6a2 2 0 002.8 2.8M9.9 5.1A9.8 9.8 0 0112 5c4.5 0 8.3 2.9 9.6 7a10 10 0 01-2.2 3.6M6.6 6.6A10 10 0 002.4 12c1.3 4.1 5.1 7 9.6 7 1.4 0 2.8-.3 4-.8" />
+    </svg>
+  ) : (
+    <svg className={ICON} {...iconProps} strokeWidth={1.75}>
+      <path d="M2.4 12C3.7 7.9 7.5 5 12 5s8.3 2.9 9.6 7c-1.3 4.1-5.1 7-9.6 7s-8.3-2.9-9.6-7z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
 
 export function FloatingActionBar() {
   const {
@@ -353,15 +460,15 @@ export function FloatingActionBar() {
 
   // FTUX tutorial state (client-side only to avoid SSR hydration issues)
   const [tutorialActive, setTutorialActive] = useState(false);
-  const [lockedFeatures, setLockedFeatures] = useState(false);
   const [currentTutorialStep, setCurrentTutorialStep] = useState(0);
   const [tutorialSteps, setTutorialSteps] = useState<TutorialStep[]>([]);
+  // Run shortcut hint; resolved after mount so the server and client markup agree.
+  const [modKey, setModKey] = useState("Ctrl");
 
   useEffect(() => {
     // Subscribe to FTUX store on client-side only
     const unsubscribe = useFTUXStore.subscribe((state) => {
       setTutorialActive(state.tutorialActive);
-      setLockedFeatures(state.lockedFeatures);
       setCurrentTutorialStep(state.currentTutorialStep);
       setTutorialSteps(state.tutorialSteps);
     });
@@ -369,9 +476,10 @@ export function FloatingActionBar() {
     // Initialize with current state
     const currentState = useFTUXStore.getState();
     setTutorialActive(currentState.tutorialActive);
-    setLockedFeatures(currentState.lockedFeatures);
     setCurrentTutorialStep(currentState.currentTutorialStep);
     setTutorialSteps(currentState.tutorialSteps);
+
+    if (/Mac|iPod|iPhone|iPad/.test(navigator.userAgent)) setModKey("⌘");
 
     return unsubscribe;
   }, []);
@@ -409,24 +517,10 @@ export function FloatingActionBar() {
   }, [tutorialActive, currentTutorialStep, tutorialSteps]);
 
   // Close run menu when clicking outside (but not during tutorial step)
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (runMenuRef.current && !runMenuRef.current.contains(event.target as Node)) {
-        // Don't close menu during the run options tutorial step
-        if (!isRunOptionsTutorialStep) {
-          setRunMenuOpen(false);
-        }
-      }
-    };
-
-    if (runMenuOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [runMenuOpen, isRunOptionsTutorialStep]);
+  const closeRunMenu = useCallback(() => {
+    if (!isRunOptionsTutorialStep) setRunMenuOpen(false);
+  }, [isRunOptionsTutorialStep]);
+  useClickOutside(runMenuRef, runMenuOpen, closeRunMenu);
 
   // Open run menu when tutorial step is "explain-run-options"
   useEffect(() => {
@@ -495,207 +589,152 @@ export function FloatingActionBar() {
     }
   };
 
+  const hiddenEdgesLabel = hiddenEdgeCount > 0
+    ? `Show ${hiddenEdgeCount} hidden connection${hiddenEdgeCount === 1 ? "" : "s"}`
+    : "Hide all connections";
+  const edgeStyleLabel = `Switch to ${NEXT_EDGE_STYLE[edgeStyle]} connectors`;
+  const runTitle = !valid ? errors.join("\n") : isRunning ? getRunningLabel() : "Run";
+
   return (
-    <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50">
-      <div className="flex items-center gap-0.5 bg-neutral-800/95 rounded-lg shadow-lg border border-neutral-700/80 px-1.5 py-1">
-        <NodeButton type="imageInput" label="Image" dataTutorial="image-button" />
-        <NodeButton type="videoInput" label="Video" />
-        <NodeButton type="prompt" label="Prompt" dataTutorial="prompt-button" />
-        <GenerateComboButton />
-        <NodeButton type="output" label="Output" dataTutorial="output-button" />
+    <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
+      {/* w-max: a fixed element anchored at left-1/2 otherwise shrinks to half the viewport and wraps. */}
+      <div className={`${CHROME_SURFACE} flex h-10 w-max items-center gap-0.5 rounded-xl px-1.5`}>
+        <NodeButton type="imageInput" label="Image" shortcut="⇧I" dataTutorial="image-button"><ImageIcon /></NodeButton>
+        <NodeButton type="videoInput" label="Video" shortcut="⇧Y"><VideoIcon /></NodeButton>
+        <NodeButton type="prompt" label="Prompt" shortcut="⇧P" dataTutorial="prompt-button"><PromptIcon /></NodeButton>
+        <GenerateSplitButton />
+        <NodeButton type="output" label="Output" dataTutorial="output-button"><OutputIcon /></NodeButton>
+
+        <Divider />
+
         <AllNodesMenu />
+        <IconButton label="All models" title="Browse models" onClick={() => setModelSearchOpen(true)}>
+          <CubeIcon />
+        </IconButton>
 
-        {/* All models button */}
-        <div className="w-px h-5 bg-neutral-600 mx-1.5" />
-        <button
-          onClick={() => setModelSearchOpen(true)}
-          title="Browse models"
-          className="px-2.5 py-1.5 text-[11px] font-medium text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700 rounded transition-colors"
-        >
-          All models
-        </button>
+        <Divider />
 
-        <div className="w-px h-5 bg-neutral-600 mx-1.5" />
-
-        <button
-          onClick={toggleEdgeStyle}
-          title={`Switch to ${NEXT_EDGE_STYLE[edgeStyle]} connectors`}
-          className="p-1.5 text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700 rounded transition-colors"
-        >
-          {edgeStyle === "angular" ? (
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 12h4l4-8 4 8h4" />
-            </svg>
-          ) : edgeStyle === "straight" ? (
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 16L20 8" />
-            </svg>
-          ) : (
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 12c0 0 4-8 8-8s8 8 8 8" />
-            </svg>
-          )}
-        </button>
-
-        <button
-          onClick={toggleHiddenEdges}
+        <IconButton label={edgeStyleLabel} title={edgeStyleLabel} onClick={toggleEdgeStyle}>
+          <EdgeStyleIcon style={edgeStyle} />
+        </IconButton>
+        <IconButton
+          label={hiddenEdgesLabel}
+          title={hiddenEdgesLabel}
+          open={hiddenEdgeCount > 0}
           disabled={totalEdgeCount === 0}
-          title={hiddenEdgeCount > 0 ? `Show ${hiddenEdgeCount} hidden connection${hiddenEdgeCount === 1 ? "" : "s"}` : "Hide all connections"}
-          className="relative p-1.5 text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-        >
-          {hiddenEdgeCount > 0 ? (
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M3 3l18 18M10.6 10.6a2 2 0 002.8 2.8M9.9 5.1A9.8 9.8 0 0112 5c4.5 0 8.3 2.9 9.6 7a10 10 0 01-2.2 3.6M6.6 6.6A10 10 0 002.4 12c1.3 4.1 5.1 7 9.6 7 1.4 0 2.8-.3 4-.8" />
-            </svg>
-          ) : (
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M2.4 12C3.7 7.9 7.5 5 12 5s8.3 2.9 9.6 7c-1.3 4.1-5.1 7-9.6 7s-8.3-2.9-9.6-7z" />
-              <circle cx="12" cy="12" r="3" />
-            </svg>
-          )}
-          {hiddenEdgeCount > 0 && (
-            <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-3.5 px-1 rounded-full bg-neutral-600 text-[9px] leading-[14px] font-semibold text-neutral-100 text-center">
+          onClick={toggleHiddenEdges}
+          badge={hiddenEdgeCount > 0 && (
+            <span className="pointer-events-none absolute -right-0.5 -top-0.5 min-w-[14px] rounded-full bg-neutral-200 px-1 text-center text-[9px] font-semibold leading-[14px] text-neutral-900 ring-2 ring-neutral-800">
               {hiddenEdgeCount}
             </span>
           )}
-        </button>
+        >
+          <EyeIcon off={hiddenEdgeCount > 0} />
+        </IconButton>
 
-        <div className="w-px h-5 bg-neutral-600 mx-1.5" />
+        <Divider />
 
-        <div className="relative flex items-center" ref={runMenuRef}>
-          <button
-            onClick={handleRunClick}
-            disabled={!valid && !isRunning}
-            title={!valid ? errors.join("\n") : isRunning ? "Stop" : "Run"}
-            data-tutorial="floating-run-button"
-            className={`flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-medium transition-colors ${
-              isRunning
-                ? "bg-white text-neutral-900 hover:bg-neutral-200 rounded"
-                : valid
-                ? "bg-white text-neutral-900 hover:bg-neutral-200 rounded-l"
-                : "bg-neutral-700 text-neutral-500 cursor-not-allowed rounded"
+        <div className="relative ml-0.5 flex items-center" ref={runMenuRef}>
+          <div
+            className={`flex h-7 items-stretch overflow-hidden rounded-[7px] squircle transition-[background-color,box-shadow,transform] duration-[120ms] ease-out ${
+              !valid && !isRunning
+                ? "bg-white/8 text-neutral-500"
+                : "bg-neutral-50 text-neutral-900 hover:bg-white hover:shadow-[0_0_0_1px_rgba(255,255,255,0.35),0_1px_2px_rgba(0,0,0,0.3)] active:scale-[0.97] active:bg-neutral-200"
             }`}
           >
-            {isRunning ? (
-              <>
-                <svg
-                  className="w-3 h-3 animate-spin"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="3"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  />
-                </svg>
-                <span className="max-w-[150px] truncate" title={getRunningLabel()}>
-                  {runningNodeCount > 1 ? `${runningNodeCount} nodes` : "Stop"}
-                </span>
-              </>
-            ) : (
-              <>
-                <svg
-                  className="w-3 h-3"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M8 5v14l11-7z" />
-                </svg>
-                <span>Run</span>
-              </>
-            )}
-          </button>
-
-          {/* Dropdown chevron button */}
-          {!isRunning && valid && (
             <button
-              onClick={() => setRunMenuOpen(!runMenuOpen)}
-              data-tutorial="floating-run-dropdown"
-              className="flex items-center self-stretch px-1.5 rounded-r bg-white text-neutral-900 hover:bg-neutral-200 border-l border-neutral-200 transition-colors"
-              title="Run options"
+              type="button"
+              onClick={handleRunClick}
+              disabled={!valid && !isRunning}
+              title={runTitle}
+              data-tutorial="floating-run-button"
+              className="flex items-center gap-1.5 whitespace-nowrap pl-[11px] pr-2.5 text-[11px] font-semibold focus-visible:outline-none disabled:cursor-not-allowed"
             >
-              <svg
-                className={`w-2.5 h-2.5 transition-transform ${runMenuOpen ? "rotate-180" : ""}`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2.5}
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-              </svg>
+              {isRunning ? (
+                <>
+                  <SpinnerIcon />
+                  <span className="max-w-[150px] truncate">
+                    {runningNodeCount > 1 ? `${runningNodeCount} nodes` : "Stop"}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <PlayIcon />
+                  <span>Run</span>
+                </>
+              )}
             </button>
-          )}
+
+            {/* Dropdown chevron button */}
+            {!isRunning && valid && (
+              <button
+                type="button"
+                onClick={() => setRunMenuOpen(!runMenuOpen)}
+                data-tutorial="floating-run-dropdown"
+                aria-expanded={runMenuOpen}
+                title="Run options"
+                className={`flex w-5 items-center justify-center border-l border-black/10 transition-colors duration-[120ms] focus-visible:outline-none ${runMenuOpen ? "bg-neutral-200" : ""}`}
+              >
+                <svg className={`h-2.5 w-2.5 transition-transform duration-[120ms] ${runMenuOpen ? "rotate-180" : ""}`} {...iconProps} strokeWidth={2.5}>
+                  <path d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+            )}
+          </div>
 
           {/* Dropdown menu */}
           {runMenuOpen && !isRunning && (
-            <div
-              data-tutorial="floating-run-menu"
-              className="absolute bottom-full right-0 mb-2 bg-neutral-800 border border-neutral-700 rounded-lg shadow-xl overflow-hidden min-w-[180px]"
-            >
+            <div data-tutorial="floating-run-menu" className={`${CHROME_MENU} right-0 min-w-[196px]`} role="menu">
               <button
+                type="button"
+                role="menuitem"
                 onClick={() => {
                   executeWorkflow();
                   setRunMenuOpen(false);
                 }}
-                className="w-full px-3 py-2 text-left text-[11px] font-medium text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors flex items-center gap-2"
+                className={CHROME_MENU_ITEM}
               >
-                <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M8 5v14l11-7z" />
-                </svg>
+                <PlayIcon />
                 Run entire workflow
+                <span className={CHROME_MENU_HINT}>{modKey}↵</span>
               </button>
               <button
+                type="button"
+                role="menuitem"
                 onClick={handleRunFromSelected}
                 disabled={!selectedNode}
-                className={`w-full px-3 py-2 text-left text-[11px] font-medium transition-colors flex items-center gap-2 ${
-                  selectedNode
-                    ? "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100"
-                    : "text-neutral-500 cursor-not-allowed"
-                }`}
+                className={CHROME_MENU_ITEM}
                 title={!selectedNode ? "Select a single node first" : undefined}
               >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+                <svg className="h-3.5 w-3.5" {...iconProps} strokeWidth={2}>
+                  <path d="M13 5l7 7-7 7M5 5l7 7-7 7" />
                 </svg>
                 Run from selected node
               </button>
               <button
+                type="button"
+                role="menuitem"
                 onClick={handleRunSelectedOnly}
                 disabled={!selectedNode}
-                className={`w-full px-3 py-2 text-left text-[11px] font-medium transition-colors flex items-center gap-2 ${
-                  selectedNode
-                    ? "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100"
-                    : "text-neutral-500 cursor-not-allowed"
-                }`}
+                className={CHROME_MENU_ITEM}
                 title={!selectedNode ? "Select a single node first" : undefined}
               >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+                <svg className="h-3.5 w-3.5" {...iconProps} strokeWidth={2}>
+                  <path d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
                 </svg>
                 Run selected node only
               </button>
               <button
+                type="button"
+                role="menuitem"
                 onClick={handleRunSelectedNodes}
                 disabled={selectedNodes.length === 0}
-                className={`w-full px-3 py-2 text-left text-[11px] font-medium transition-colors flex items-center gap-2 ${
-                  selectedNodes.length > 0
-                    ? "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100"
-                    : "text-neutral-500 cursor-not-allowed"
-                }`}
+                className={CHROME_MENU_ITEM}
                 title={selectedNodes.length === 0 ? "Select one or more nodes first" : `Run ${selectedNodes.length} selected node${selectedNodes.length > 1 ? 's' : ''}`}
               >
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 9.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V9.653z" />
+                <svg className="h-3.5 w-3.5" {...iconProps} strokeWidth={2}>
+                  <path d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
+                  <path d="M9.75 9.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V9.653z" />
                 </svg>
                 {selectedNodes.length > 0
                   ? `Run ${selectedNodes.length} selected node${selectedNodes.length !== 1 ? 's' : ''}`

--- a/src/components/GlobalImageHistory.tsx
+++ b/src/components/GlobalImageHistory.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { ImageHistoryItem } from "@/types";
+import { MINIMAP_GEOMETRY, NAVIGATOR_WIDTH } from "./CanvasMinimap";
 
 // Helper function for relative time display
 /**
@@ -304,7 +305,11 @@ export function GlobalImageHistory() {
   if (history.length === 0) return null;
 
   return (
-    <div ref={drawerRef} className="absolute bottom-4 right-64 z-10">
+    <div
+      ref={drawerRef}
+      className="absolute z-10"
+      style={{ right: MINIMAP_GEOMETRY.margin + NAVIGATOR_WIDTH + 8, bottom: MINIMAP_GEOMETRY.margin }}
+    >
       {/* Trigger Button */}
       <button
         ref={triggerRef}

--- a/src/components/WorkflowCanvas.tsx
+++ b/src/components/WorkflowCanvas.tsx
@@ -4,8 +4,6 @@ import { useCallback, useRef, useState, useEffect, DragEvent, useMemo, type Comp
 import {
   ReactFlow,
   Background,
-  Controls,
-  MiniMap,
   NodeTypes,
   EdgeTypes,
   Connection,
@@ -62,6 +60,7 @@ import { HandleMenu, type HandleMenuTarget } from "./HandleMenu";
 import { NodeSearchMenu } from "./NodeSearchMenu";
 import { MultiSelectToolbar } from "./MultiSelectToolbar";
 import { GlobalImageHistory } from "./GlobalImageHistory";
+import { CanvasMinimap } from "./CanvasMinimap";
 import { GroupBackgroundsPortal, GroupControlsOverlay } from "./GroupsOverlay";
 import { NodeType, NanoBananaNodeData, HandleType, PromptNodeData, LLMGenerateNodeData, PromptConstructorNodeData, AvailableVariable, WorkflowNodeData } from "@/types";
 import { isComfyWorkflow, isNodeBananaWorkflow } from "@/lib/comfy/detect";
@@ -160,23 +159,6 @@ const edgeTypes: EdgeTypes = {
 const OVERVIEW_EDGES: Edge[] = [];
 /** Pointer travel (px) under which a handle press counts as a click, not a drag. */
 const HANDLE_CLICK_SLOP = 4;
-const MINIMAP_GEOMETRY = {
-  width: 200,
-  height: 150,
-  margin: 15,
-  controlInset: 8,
-  controlSize: 28,
-} as const;
-
-const MINIMAP_CLOSE_POSITION = {
-  right: MINIMAP_GEOMETRY.margin + MINIMAP_GEOMETRY.controlInset,
-  bottom:
-    MINIMAP_GEOMETRY.margin +
-    MINIMAP_GEOMETRY.height -
-    MINIMAP_GEOMETRY.controlInset -
-    MINIMAP_GEOMETRY.controlSize,
-} as const;
-
 /** Height is content-derived; a stored one must not reach React Flow's wrapper. */
 function stripNodeHeight<T extends Node>(node: T): T {
   const styleHeight = node.style && "height" in node.style;
@@ -186,40 +168,6 @@ function stripNodeHeight<T extends Node>(node: T): T {
   const { height: _styleHeight, ...style } = (node.style ?? {}) as Record<string, unknown>;
   void _styleHeight;
   return { ...rest, style } as unknown as T;
-}
-
-function getMiniMapNodeColor(node: Node): string {
-  switch (node.type) {
-    case "imageInput": return "#3b82f6";
-    case "audioInput": return "#a78bfa";
-    case "videoInput": return "#c084fc";
-    case "annotation": return "#8b5cf6";
-    case "prompt": return "#f97316";
-    case "array": return "#a3e635";
-    case "promptConstructor": return "#f472b6";
-    case "nanoBanana": return "#22c55e";
-    case "generateVideo": return "#9333ea";
-    case "generate3d": return "#fb923c";
-    case "generateAudio": return "#d946ef";
-    case "llmGenerate": return "#06b6d4";
-    case "splitGrid": return "#f59e0b";
-    case "output": return "#ef4444";
-    case "outputGallery": return "#ec4899";
-    case "imageCompare": return "#14b8a6";
-    case "videoStitch": return "#f97316";
-    case "easeCurve": return "#bef264";
-    case "videoTrim": return "#60a5fa";
-    case "videoFrameGrab": return "#38bdf8";
-    case "removeBackground": return "#2dd4bf";
-    case "imageResize": return "#0d9488";
-    case "gifEncoder": return "#f472b6";
-    case "router": return "#6b7280";
-    case "switch": return "#8b5cf6";
-    case "conditionalSwitch": return "#06b6d4";
-    case "glbViewer": return "#0ea5e9";
-    case "comfyApp": return "#7dd3fc";
-    default: return "#94a3b8";
-  }
 }
 
 // Connection validation rules
@@ -410,7 +358,6 @@ export function WorkflowCanvas() {
   >(null);
   const [isSplitting, setIsSplitting] = useState(false);
   const [isChatOpen, setIsChatOpen] = useState(false);
-  const [isMinimapVisible, setIsMinimapVisible] = useState(true);
   const [isBuildingWorkflow, setIsBuildingWorkflow] = useState(false);
   const [showNewProjectSetup, setShowNewProjectSetup] = useState(false);
   const [expandingNode, setExpandingNode] = useState<{ id: string; type: string } | null>(null);
@@ -2489,51 +2436,7 @@ export function WorkflowCanvas() {
           size={1}
           className={tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}
         />
-        <Controls className={`bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg [&>button]:bg-neutral-800 [&>button]:border-neutral-700 [&>button]:fill-neutral-300 [&>button:hover]:bg-neutral-700 [&>button:hover]:fill-neutral-100 ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`} />
-        {isMinimapVisible ? (
-          <>
-            <MiniMap
-              className={`bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
-              style={{
-                width: MINIMAP_GEOMETRY.width,
-                height: MINIMAP_GEOMETRY.height,
-                margin: MINIMAP_GEOMETRY.margin,
-              }}
-              maskColor="rgba(0, 0, 0, 0.6)"
-              pannable
-              zoomable
-              nodeColor={getMiniMapNodeColor}
-            />
-            <button
-              type="button"
-              aria-label="Hide minimap"
-              title="Hide minimap"
-              disabled={tutorialActive && lockedFeatures}
-              onClick={() => setIsMinimapVisible(false)}
-              style={MINIMAP_CLOSE_POSITION}
-              className="nodrag nopan nowheel absolute z-[6] flex h-7 w-7 items-center justify-center rounded-md border border-neutral-600/80 bg-neutral-950/85 text-neutral-400 shadow-sm backdrop-blur-sm transition-colors hover:border-neutral-500 hover:bg-neutral-800 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed"
-            >
-              <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4" fill="none">
-                <path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
-              </svg>
-            </button>
-          </>
-        ) : (
-          <button
-            type="button"
-            aria-label="Show minimap"
-            title="Show minimap"
-            disabled={tutorialActive && lockedFeatures}
-            onClick={() => setIsMinimapVisible(true)}
-            style={{ right: MINIMAP_GEOMETRY.margin, bottom: MINIMAP_GEOMETRY.margin }}
-            className={`nodrag nopan nowheel absolute z-[5] flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-700 bg-neutral-800 text-neutral-400 shadow-lg transition-colors hover:border-neutral-600 hover:bg-neutral-700 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed ${tutorialActive && lockedFeatures ? "opacity-30 pointer-events-none" : ""}`}
-          >
-            <svg aria-hidden="true" viewBox="0 0 20 20" className="h-[18px] w-[18px]" fill="none">
-              <rect x="2.5" y="3.5" width="15" height="13" rx="2" stroke="currentColor" strokeWidth="1.5" />
-              <path d="M5.5 7h2v2h-2zM9 7h2v2H9zM12.5 7h2v2h-2zM5.5 10.5h2v2h-2zM9 10.5h5.5v2H9z" fill="currentColor" />
-            </svg>
-          </button>
-        )}
+        <CanvasMinimap disabled={tutorialActive && lockedFeatures} />
         <ViewportPortal>
           {allNodes.map((node) => {
             // Groups don't get floating headers

--- a/src/components/__tests__/CanvasMinimap.test.tsx
+++ b/src/components/__tests__/CanvasMinimap.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ReactFlow, ReactFlowProvider, type Node } from "@xyflow/react";
+import {
+  CanvasMinimap,
+  MINIMAP_GEOMETRY,
+  NAVIGATOR_WIDTH,
+  getMiniMapNodeColor,
+} from "@/components/CanvasMinimap";
+
+const mockZoomIn = vi.fn();
+const mockZoomOut = vi.fn();
+const mockFitView = vi.fn();
+
+vi.mock("@xyflow/react", async () => {
+  const actual = await vi.importActual<typeof import("@xyflow/react")>("@xyflow/react");
+  return {
+    ...actual,
+    useReactFlow: () => ({ zoomIn: mockZoomIn, zoomOut: mockZoomOut, fitView: mockFitView }),
+  };
+});
+
+function renderNavigator(props: { disabled?: boolean } = {}) {
+  return render(
+    <ReactFlowProvider>
+      <ReactFlow nodes={[]} edges={[]}>
+        <CanvasMinimap {...props} />
+      </ReactFlow>
+    </ReactFlowProvider>
+  );
+}
+
+describe("CanvasMinimap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the minimap inside the navigator card with the controls row beneath", () => {
+    renderNavigator();
+
+    const minimap = document.querySelector(".react-flow__minimap");
+    expect(minimap).toBeInTheDocument();
+    expect(minimap).toHaveStyle({
+      width: `${MINIMAP_GEOMETRY.width}px`,
+      height: `${MINIMAP_GEOMETRY.height}px`,
+      position: "static",
+    });
+
+    const card = screen.getByTestId("canvas-navigator");
+    expect(card).toHaveStyle({ margin: `${MINIMAP_GEOMETRY.margin}px` });
+    for (const name of ["Zoom out", "Zoom in", "Fit view", "Lock canvas", "Hide minimap"]) {
+      expect(card).toContainElement(screen.getByRole("button", { name }));
+    }
+  });
+
+  it("hides and restores the minimap while the controls row stays put", () => {
+    renderNavigator();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide minimap" }));
+    expect(document.querySelector(".react-flow__minimap")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show minimap" }));
+    expect(document.querySelector(".react-flow__minimap")).toBeInTheDocument();
+  });
+
+  it("drives zoom and fit through React Flow", () => {
+    renderNavigator();
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fit view" }));
+
+    expect(mockZoomIn).toHaveBeenCalledTimes(1);
+    expect(mockZoomOut).toHaveBeenCalledTimes(1);
+    expect(mockFitView).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the zoom level as a whole percentage", () => {
+    renderNavigator();
+    expect(screen.getByLabelText("Zoom level")).toHaveTextContent("100%");
+  });
+
+  it("locks and unlocks canvas interaction", () => {
+    renderNavigator();
+
+    fireEvent.click(screen.getByRole("button", { name: "Lock canvas" }));
+    const unlock = screen.getByRole("button", { name: "Unlock canvas" });
+    expect(unlock).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(unlock);
+    expect(screen.getByRole("button", { name: "Lock canvas" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("is inert while the tutorial locks features", () => {
+    renderNavigator({ disabled: true });
+
+    const card = screen.getByTestId("canvas-navigator");
+    expect(card).toHaveClass("pointer-events-none");
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Hide minimap" })).toBeDisabled();
+  });
+
+  it("exposes the card width neighbours offset from", () => {
+    expect(NAVIGATOR_WIDTH).toBe(MINIMAP_GEOMETRY.width + MINIMAP_GEOMETRY.padding * 2 + 2);
+  });
+
+  it("keeps the per-node-type minimap colours", () => {
+    const colour = (type: string) => getMiniMapNodeColor({ id: "n", type, position: { x: 0, y: 0 }, data: {} } as Node);
+    expect(colour("imageInput")).toBe("#3b82f6");
+    expect(colour("prompt")).toBe("#f97316");
+    expect(colour("nanoBanana")).toBe("#22c55e");
+    expect(colour("output")).toBe("#ef4444");
+    expect(colour("comfyApp")).toBe("#7dd3fc");
+    expect(colour("unknown")).toBe("#94a3b8");
+  });
+});

--- a/src/components/__tests__/FloatingActionBar.test.tsx
+++ b/src/components/__tests__/FloatingActionBar.test.tsx
@@ -128,7 +128,7 @@ describe("FloatingActionBar", () => {
       });
     });
 
-    it("should render the Generate split control", async () => {
+    it("should render the Generate menu button", async () => {
       render(
         <TestWrapper>
           <FloatingActionBar />
@@ -136,8 +136,7 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "Generate image" })).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
       });
     });
 
@@ -292,10 +291,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
       });
 
-      const generateButton = screen.getByRole("button", { name: "More generators" });
+      const generateButton = screen.getByRole("button", { name: "Generate" });
       fireEvent.click(generateButton);
 
       // Dropdown menu items should appear
@@ -304,17 +303,17 @@ describe("FloatingActionBar", () => {
       expect(screen.getByRole("menuitem", { name: /Text \(LLM\)/ })).toBeInTheDocument();
     });
 
-    it("adds an image generator straight from the sparkle", async () => {
+    it("opens the menu without adding a node", async () => {
       render(
         <TestWrapper>
           <FloatingActionBar />
         </TestWrapper>
       );
 
-      fireEvent.click(await screen.findByRole("button", { name: "Generate image" }));
+      fireEvent.click(await screen.findByRole("button", { name: "Generate" }));
 
-      expect(mockAddNode).toHaveBeenCalledWith("nanoBanana", expect.any(Object));
-      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+      expect(mockAddNode).not.toHaveBeenCalled();
     });
 
     it("should add nanoBanana node when Image option is clicked", async () => {
@@ -325,11 +324,11 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
       });
 
       // Open dropdown
-      fireEvent.click(screen.getByRole("button", { name: "More generators" }));
+      fireEvent.click(screen.getByRole("button", { name: "Generate" }));
 
       // Click Image option in dropdown
       const imageOption = screen.getByRole("menuitem", { name: /^Image/ });
@@ -346,10 +345,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "More generators" }));
+      fireEvent.click(screen.getByRole("button", { name: "Generate" }));
       fireEvent.click(screen.getByRole("menuitem", { name: /^Video/ }));
 
       expect(mockAddNode).toHaveBeenCalledWith("generateVideo", expect.any(Object));
@@ -363,10 +362,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "More generators" }));
+      fireEvent.click(screen.getByRole("button", { name: "Generate" }));
       fireEvent.click(screen.getByRole("menuitem", { name: /Text \(LLM\)/ }));
 
       expect(mockAddNode).toHaveBeenCalledWith("llmGenerate", expect.any(Object));
@@ -380,10 +379,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole("button", { name: "More generators" }));
+      fireEvent.click(screen.getByRole("button", { name: "Generate" }));
 
       // Verify dropdown is open
       expect(screen.getByRole("menuitem", { name: /^Video/ })).toBeInTheDocument();

--- a/src/components/__tests__/FloatingActionBar.test.tsx
+++ b/src/components/__tests__/FloatingActionBar.test.tsx
@@ -121,14 +121,14 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Image")).toBeInTheDocument();
-        expect(screen.getByText("Prompt")).toBeInTheDocument();
-        expect(screen.getByText("Output")).toBeInTheDocument();
-        expect(screen.getByText("All nodes")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Image" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Prompt" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Output" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "All nodes" })).toBeInTheDocument();
       });
     });
 
-    it("should render Generate combo button", async () => {
+    it("should render the Generate split control", async () => {
       render(
         <TestWrapper>
           <FloatingActionBar />
@@ -136,8 +136,20 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Generate")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Generate image" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
       });
+    });
+
+    it("shows the keyboard shortcut in the hover label", async () => {
+      render(
+        <TestWrapper>
+          <FloatingActionBar />
+        </TestWrapper>
+      );
+
+      const imageButton = await screen.findByRole("button", { name: "Image" });
+      expect(imageButton.parentElement).toHaveTextContent("⇧I");
     });
 
     it("should render Run button", async () => {
@@ -174,10 +186,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Image")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Image" })).toBeInTheDocument();
       });
 
-      const imageButton = screen.getByText("Image");
+      const imageButton = screen.getByRole("button", { name: "Image" });
       fireEvent.click(imageButton);
 
       expect(mockAddNode).toHaveBeenCalledWith("imageInput", expect.any(Object));
@@ -191,10 +203,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Prompt")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Prompt" })).toBeInTheDocument();
       });
 
-      const promptButton = screen.getByText("Prompt");
+      const promptButton = screen.getByRole("button", { name: "Prompt" });
       fireEvent.click(promptButton);
 
       expect(mockAddNode).toHaveBeenCalledWith("prompt", expect.any(Object));
@@ -208,10 +220,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Output")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Output" })).toBeInTheDocument();
       });
 
-      const outputButton = screen.getByText("Output");
+      const outputButton = screen.getByRole("button", { name: "Output" });
       fireEvent.click(outputButton);
 
       expect(mockAddNode).toHaveBeenCalledWith("output", expect.any(Object));
@@ -227,10 +239,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Image")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Image" })).toBeInTheDocument();
       });
 
-      const imageButton = screen.getByText("Image");
+      const imageButton = screen.getByRole("button", { name: "Image" });
 
       const mockDataTransfer = {
         setData: vi.fn(),
@@ -253,10 +265,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Prompt")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Prompt" })).toBeInTheDocument();
       });
 
-      const promptButton = screen.getByText("Prompt");
+      const promptButton = screen.getByRole("button", { name: "Prompt" });
 
       const mockDataTransfer = {
         setData: vi.fn(),
@@ -280,16 +292,29 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Generate")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
       });
 
-      const generateButton = screen.getByText("Generate");
+      const generateButton = screen.getByRole("button", { name: "More generators" });
       fireEvent.click(generateButton);
 
       // Dropdown menu items should appear
-      expect(screen.getByText("Image", { selector: "button.w-full" })).toBeInTheDocument();
-      expect(screen.getByText("Video", { selector: "button.w-full" })).toBeInTheDocument();
-      expect(screen.getByText("Text (LLM)")).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /^Image/ })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /^Video/ })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /Text \(LLM\)/ })).toBeInTheDocument();
+    });
+
+    it("adds an image generator straight from the sparkle", async () => {
+      render(
+        <TestWrapper>
+          <FloatingActionBar />
+        </TestWrapper>
+      );
+
+      fireEvent.click(await screen.findByRole("button", { name: "Generate image" }));
+
+      expect(mockAddNode).toHaveBeenCalledWith("nanoBanana", expect.any(Object));
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
 
     it("should add nanoBanana node when Image option is clicked", async () => {
@@ -300,14 +325,14 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Generate")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
       });
 
       // Open dropdown
-      fireEvent.click(screen.getByText("Generate"));
+      fireEvent.click(screen.getByRole("button", { name: "More generators" }));
 
       // Click Image option in dropdown
-      const imageOption = screen.getByText("Image", { selector: "button.w-full" });
+      const imageOption = screen.getByRole("menuitem", { name: /^Image/ });
       fireEvent.click(imageOption);
 
       expect(mockAddNode).toHaveBeenCalledWith("nanoBanana", expect.any(Object));
@@ -321,11 +346,11 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Generate")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByText("Generate"));
-      fireEvent.click(screen.getByText("Video", { selector: "button.w-full" }));
+      fireEvent.click(screen.getByRole("button", { name: "More generators" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: /^Video/ }));
 
       expect(mockAddNode).toHaveBeenCalledWith("generateVideo", expect.any(Object));
     });
@@ -338,11 +363,11 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Generate")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByText("Generate"));
-      fireEvent.click(screen.getByText("Text (LLM)"));
+      fireEvent.click(screen.getByRole("button", { name: "More generators" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: /Text \(LLM\)/ }));
 
       expect(mockAddNode).toHaveBeenCalledWith("llmGenerate", expect.any(Object));
     });
@@ -355,19 +380,19 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Generate")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "More generators" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByText("Generate"));
+      fireEvent.click(screen.getByRole("button", { name: "More generators" }));
 
       // Verify dropdown is open
-      expect(screen.getByText("Video", { selector: "button.w-full" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /^Video/ })).toBeInTheDocument();
 
       // Click an option
-      fireEvent.click(screen.getByText("Video", { selector: "button.w-full" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: /^Video/ }));
 
       // Dropdown should close
-      expect(screen.queryByText("Video", { selector: "button.w-full" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("menuitem", { name: /^Video/ })).not.toBeInTheDocument();
     });
   });
 
@@ -381,7 +406,7 @@ describe("FloatingActionBar", () => {
 
       await waitFor(() => {
         expect(screen.getByTitle("Browse models")).toBeInTheDocument();
-        expect(screen.getByText("All models")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "All models" })).toBeInTheDocument();
       });
     });
 
@@ -393,10 +418,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("All models")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "All models" })).toBeInTheDocument();
       });
 
-      const browseButton = screen.getByText("All models");
+      const browseButton = screen.getByRole("button", { name: "All models" });
       fireEvent.click(browseButton);
 
       expect(mockSetModelSearchOpen).toHaveBeenCalledWith(true);
@@ -412,7 +437,7 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("All nodes")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "All nodes" })).toBeInTheDocument();
       });
     });
 
@@ -424,17 +449,17 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("All nodes")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "All nodes" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByText("All nodes"));
+      fireEvent.click(screen.getByRole("button", { name: "All nodes" }));
 
       // Check representative items from different categories
-      expect(screen.getByText("Image Input")).toBeInTheDocument();
-      expect(screen.getByText("Generate Image")).toBeInTheDocument();
-      expect(screen.getByText("Router")).toBeInTheDocument();
-      expect(screen.getByText("Output Gallery")).toBeInTheDocument();
-      expect(screen.getByText("Annotate")).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Image Input" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Generate Image" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Router" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Output Gallery" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Annotate" })).toBeInTheDocument();
     });
 
     it("should call addNode when a node is selected from All nodes menu", async () => {
@@ -445,11 +470,11 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("All nodes")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "All nodes" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByText("All nodes"));
-      fireEvent.click(screen.getByText("Annotate"));
+      fireEvent.click(screen.getByRole("button", { name: "All nodes" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Annotate" }));
 
       expect(mockAddNode).toHaveBeenCalledWith("annotation", expect.any(Object));
     });
@@ -462,19 +487,19 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("All nodes")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "All nodes" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByText("All nodes"));
+      fireEvent.click(screen.getByRole("button", { name: "All nodes" }));
 
       // Verify dropdown is open
-      expect(screen.getByText("Image Input")).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Image Input" })).toBeInTheDocument();
 
       // Click an item
-      fireEvent.click(screen.getByText("Image Input"));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Image Input" }));
 
       // Dropdown should close - "Image Input" should no longer be visible
-      expect(screen.queryByText("Image Input")).not.toBeInTheDocument();
+      expect(screen.queryByRole("menuitem", { name: "Image Input" })).not.toBeInTheDocument();
     });
   });
 
@@ -728,7 +753,7 @@ describe("FloatingActionBar", () => {
       fireEvent.click(screen.getByTitle("Run options"));
 
       const runFromSelectedButton = screen.getByText("Run from selected node").closest("button");
-      expect(runFromSelectedButton).toHaveClass("cursor-not-allowed");
+      expect(runFromSelectedButton).toBeDisabled();
     });
 
     it("should enable 'Run from selected node' when a single node is selected", async () => {
@@ -842,7 +867,8 @@ describe("Hidden connections toggle", () => {
       </TestWrapper>
     );
     const button = await screen.findByTitle("Show 2 hidden connections");
-    expect(button).toHaveTextContent("2");
+    // The count badge sits beside the button, inside the same group.
+    expect(button.parentElement).toHaveTextContent("2");
     fireEvent.click(button);
     expect(mockSetAllEdgesHidden).toHaveBeenCalledWith(false);
   });

--- a/src/components/__tests__/FloatingActionBar.test.tsx
+++ b/src/components/__tests__/FloatingActionBar.test.tsx
@@ -172,7 +172,7 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTitle("Switch to straight connectors")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Switch to straight connectors" })).toBeInTheDocument();
       });
     });
   });
@@ -397,7 +397,7 @@ describe("FloatingActionBar", () => {
   });
 
   describe("Browse Models Button", () => {
-    it("should render All models button with Browse models title", async () => {
+    it("should render All models button", async () => {
       render(
         <TestWrapper>
           <FloatingActionBar />
@@ -405,7 +405,6 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTitle("Browse models")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "All models" })).toBeInTheDocument();
       });
     });
@@ -512,10 +511,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTitle("Switch to straight connectors")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Switch to straight connectors" })).toBeInTheDocument();
       });
 
-      const toggleButton = screen.getByTitle("Switch to straight connectors");
+      const toggleButton = screen.getByRole("button", { name: "Switch to straight connectors" });
       fireEvent.click(toggleButton);
 
       expect(mockSetEdgeStyle).toHaveBeenCalledWith("straight");
@@ -535,10 +534,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTitle("Switch to curved connectors")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Switch to curved connectors" })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByTitle("Switch to curved connectors"));
+      fireEvent.click(screen.getByRole("button", { name: "Switch to curved connectors" }));
 
       expect(mockSetEdgeStyle).toHaveBeenCalledWith("curved");
     });
@@ -557,10 +556,10 @@ describe("FloatingActionBar", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTitle("Switch to angular connectors")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Switch to angular connectors" })).toBeInTheDocument();
       });
 
-      const toggleButton = screen.getByTitle("Switch to angular connectors");
+      const toggleButton = screen.getByRole("button", { name: "Switch to angular connectors" });
       fireEvent.click(toggleButton);
 
       expect(mockSetEdgeStyle).toHaveBeenCalledWith("angular");
@@ -840,7 +839,7 @@ describe("Hidden connections toggle", () => {
         <FloatingActionBar />
       </TestWrapper>
     );
-    await waitFor(() => expect(screen.getByTitle("Hide all connections")).toBeDisabled());
+    await waitFor(() => expect(screen.getByRole("button", { name: "Hide all connections" })).toBeDisabled());
   });
 
   it("hides every connection when none are hidden", async () => {
@@ -852,8 +851,8 @@ describe("Hidden connections toggle", () => {
         <FloatingActionBar />
       </TestWrapper>
     );
-    await waitFor(() => expect(screen.getByTitle("Hide all connections")).toBeEnabled());
-    fireEvent.click(screen.getByTitle("Hide all connections"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Hide all connections" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Hide all connections" }));
     expect(mockSetAllEdgesHidden).toHaveBeenCalledWith(true);
   });
 
@@ -866,7 +865,7 @@ describe("Hidden connections toggle", () => {
         <FloatingActionBar />
       </TestWrapper>
     );
-    const button = await screen.findByTitle("Show 2 hidden connections");
+    const button = await screen.findByRole("button", { name: "Show 2 hidden connections" });
     // The count badge sits beside the button, inside the same group.
     expect(button.parentElement).toHaveTextContent("2");
     fireEvent.click(button);

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -319,7 +319,7 @@ describe("WorkflowCanvas", () => {
       const navigator = screen.getByTestId("canvas-navigator");
 
       // Static, so it flows inside the card instead of pinning itself to the pane corner.
-      expect(minimap).toHaveStyle({ width: "200px", height: "120px", margin: "0px", position: "static" });
+      expect(minimap).toHaveStyle({ width: "266px", height: "150px", margin: "0px", position: "static" });
       expect(navigator).toHaveStyle({ margin: "16px" });
       expect(navigator).toContainElement(screen.getByRole("button", { name: "Hide minimap" }));
     });

--- a/src/components/__tests__/WorkflowCanvas.test.tsx
+++ b/src/components/__tests__/WorkflowCanvas.test.tsx
@@ -268,15 +268,17 @@ describe("WorkflowCanvas", () => {
       expect(document.querySelector(".react-flow__background")).toBeInTheDocument();
     });
 
-    it("should render Controls component", () => {
+    it("mounts the navigator with its canvas controls", () => {
       render(
         <TestWrapper>
           <WorkflowCanvas />
         </TestWrapper>
       );
 
-      // Controls panel should be rendered
-      expect(document.querySelector(".react-flow__controls")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Fit view" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /lock canvas/i })).toBeInTheDocument();
     });
 
     it("should render MiniMap component", () => {
@@ -306,7 +308,7 @@ describe("WorkflowCanvas", () => {
       expect(document.querySelector(".react-flow__minimap")).toBeInTheDocument();
     });
 
-    it("uses shared explicit geometry for the minimap and close toggle", () => {
+    it("keeps the minimap inside the navigator card at its explicit size", () => {
       render(
         <TestWrapper>
           <WorkflowCanvas />
@@ -314,11 +316,12 @@ describe("WorkflowCanvas", () => {
       );
 
       const minimap = document.querySelector(".react-flow__minimap");
-      const closeButton = screen.getByRole("button", { name: "Hide minimap" });
+      const navigator = screen.getByTestId("canvas-navigator");
 
-      expect(minimap).toHaveStyle({ width: "200px", height: "150px", margin: "15px" });
-      expect(minimap?.parentElement).toHaveClass("react-flow");
-      expect(closeButton).toHaveStyle({ right: "23px", bottom: "129px" });
+      // Static, so it flows inside the card instead of pinning itself to the pane corner.
+      expect(minimap).toHaveStyle({ width: "200px", height: "120px", margin: "0px", position: "static" });
+      expect(navigator).toHaveStyle({ margin: "16px" });
+      expect(navigator).toContainElement(screen.getByRole("button", { name: "Hide minimap" }));
     });
 
     it("keeps edges visible and scopes native pan state to this canvas", () => {

--- a/src/components/chromeStyles.ts
+++ b/src/components/chromeStyles.ts
@@ -9,13 +9,16 @@ export const CHROME_SURFACE =
   "squircle border border-white/8 bg-neutral-800/92 backdrop-blur-md " +
   "shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_2px_rgba(0,0,0,0.4),0_12px_32px_-8px_rgba(0,0,0,0.5)]";
 
-/** 32px icon button: rest → hover lift → pressed dip. */
+/** Icon button, sized by CHROME_ICON_BUTTON_SIZE: rest → hover lift → pressed dip. */
 export const CHROME_ICON_BUTTON =
-  "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg squircle text-neutral-400 " +
+  "flex shrink-0 items-center justify-center rounded-lg squircle text-neutral-400 " +
   "transition-[background-color,color,transform] duration-[120ms] ease-out " +
   "hover:bg-white/7 hover:text-neutral-100 active:scale-[0.96] active:bg-white/12 active:text-white " +
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 " +
   "disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-400";
+
+/** md: navigator controls (32px). lg: the action bar (36px). */
+export const CHROME_ICON_BUTTON_SIZE = { md: "h-8 w-8", lg: "h-9 w-9" } as const;
 
 /** A button whose popover is up, or a stateful toggle that is on. */
 export const CHROME_ICON_BUTTON_OPEN = "bg-white/10 text-white";

--- a/src/components/chromeStyles.ts
+++ b/src/components/chromeStyles.ts
@@ -1,0 +1,37 @@
+/**
+ * Bottom-chrome surface: one grey ramp shared by the action bar, its popovers
+ * and the canvas navigator. Depth comes from alpha whites over neutral-800,
+ * never from hue, so the minimap's node colours stay the only colour down there.
+ */
+
+/** Glass card: neutral-800 at 92% with blur, hairline border and top light. */
+export const CHROME_SURFACE =
+  "squircle border border-white/8 bg-neutral-800/92 backdrop-blur-md " +
+  "shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_2px_rgba(0,0,0,0.4),0_12px_32px_-8px_rgba(0,0,0,0.5)]";
+
+/** 28px icon button: rest → hover lift → pressed dip. */
+export const CHROME_ICON_BUTTON =
+  "flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] squircle text-neutral-400 " +
+  "transition-[background-color,color,transform] duration-[120ms] ease-out " +
+  "hover:bg-white/7 hover:text-neutral-100 active:scale-[0.96] active:bg-white/12 active:text-white " +
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 " +
+  "disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-400";
+
+/** A button whose popover is up, or a stateful toggle that is on. */
+export const CHROME_ICON_BUTTON_OPEN = "bg-white/10 text-white";
+
+export const CHROME_DIVIDER = "mx-1 h-4 w-px shrink-0 bg-white/10";
+
+/** Popover anchored above a bar button. */
+export const CHROME_MENU =
+  CHROME_SURFACE + " absolute bottom-full mb-2 flex flex-col gap-px rounded-[10px] p-1";
+
+export const CHROME_MENU_ITEM =
+  "flex h-7 w-full items-center gap-2 rounded-md squircle px-2 text-left text-[11px] font-medium " +
+  "text-neutral-300 transition-colors duration-[120ms] hover:bg-white/7 hover:text-neutral-100 " +
+  "disabled:cursor-not-allowed disabled:text-neutral-500 disabled:hover:bg-transparent";
+
+export const CHROME_MENU_HEADING = "px-2 pb-0.5 pt-1.5 text-[10px] uppercase tracking-[0.06em] text-neutral-500";
+
+/** Right-aligned shortcut hint inside a menu item. */
+export const CHROME_MENU_HINT = "ml-auto text-[9px] text-neutral-500";

--- a/src/components/chromeStyles.ts
+++ b/src/components/chromeStyles.ts
@@ -27,7 +27,7 @@ export const CHROME_DIVIDER = "mx-1 h-5 w-px shrink-0 bg-white/10";
 
 /** Popover anchored above a bar button. */
 export const CHROME_MENU =
-  CHROME_SURFACE + " absolute bottom-full mb-2 flex flex-col gap-px rounded-[10px] p-1";
+  CHROME_SURFACE + " absolute bottom-full z-20 mb-2 flex flex-col gap-px rounded-[10px] p-1";
 
 export const CHROME_MENU_ITEM =
   "flex h-7 w-full items-center gap-2 rounded-md squircle px-2 text-left text-[11px] font-medium " +

--- a/src/components/chromeStyles.ts
+++ b/src/components/chromeStyles.ts
@@ -9,9 +9,9 @@ export const CHROME_SURFACE =
   "squircle border border-white/8 bg-neutral-800/92 backdrop-blur-md " +
   "shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_2px_rgba(0,0,0,0.4),0_12px_32px_-8px_rgba(0,0,0,0.5)]";
 
-/** 28px icon button: rest → hover lift → pressed dip. */
+/** 32px icon button: rest → hover lift → pressed dip. */
 export const CHROME_ICON_BUTTON =
-  "flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] squircle text-neutral-400 " +
+  "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg squircle text-neutral-400 " +
   "transition-[background-color,color,transform] duration-[120ms] ease-out " +
   "hover:bg-white/7 hover:text-neutral-100 active:scale-[0.96] active:bg-white/12 active:text-white " +
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 " +
@@ -20,7 +20,7 @@ export const CHROME_ICON_BUTTON =
 /** A button whose popover is up, or a stateful toggle that is on. */
 export const CHROME_ICON_BUTTON_OPEN = "bg-white/10 text-white";
 
-export const CHROME_DIVIDER = "mx-1 h-4 w-px shrink-0 bg-white/10";
+export const CHROME_DIVIDER = "mx-1 h-5 w-px shrink-0 bg-white/10";
 
 /** Popover anchored above a bar button. */
 export const CHROME_MENU =

--- a/src/components/chromeStyles.ts
+++ b/src/components/chromeStyles.ts
@@ -11,11 +11,11 @@ export const CHROME_SURFACE =
 
 /** Icon button, sized by CHROME_ICON_BUTTON_SIZE: rest → hover lift → pressed dip. */
 export const CHROME_ICON_BUTTON =
-  "flex shrink-0 items-center justify-center rounded-lg squircle text-neutral-400 " +
+  "flex shrink-0 items-center justify-center rounded-lg squircle text-neutral-300 " +
   "transition-[background-color,color,transform] duration-[120ms] ease-out " +
-  "hover:bg-white/7 hover:text-neutral-100 active:scale-[0.96] active:bg-white/12 active:text-white " +
+  "hover:bg-white/7 hover:text-white active:scale-[0.96] active:bg-white/12 active:text-white " +
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 " +
-  "disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-400";
+  "disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-300";
 
 /** md: navigator controls (32px). lg: the action bar (36px). */
 export const CHROME_ICON_BUTTON_SIZE = { md: "h-8 w-8", lg: "h-9 w-9" } as const;
@@ -31,7 +31,7 @@ export const CHROME_MENU =
 
 export const CHROME_MENU_ITEM =
   "flex h-7 w-full items-center gap-2 rounded-md squircle px-2 text-left text-[11px] font-medium " +
-  "text-neutral-300 transition-colors duration-[120ms] hover:bg-white/7 hover:text-neutral-100 " +
+  "text-neutral-200 transition-colors duration-[120ms] hover:bg-white/7 hover:text-white " +
   "disabled:cursor-not-allowed disabled:text-neutral-500 disabled:hover:bg-transparent";
 
 export const CHROME_MENU_HEADING = "px-2 pb-0.5 pt-1.5 text-[10px] uppercase tracking-[0.06em] text-neutral-500";


### PR DESCRIPTION
## What changed

The bottom chrome is one designed system now: an icon-only action bar and a navigator card, both on the same neutral-800 glass surface.

**Action bar** (`FloatingActionBar.tsx`)
- Every node-add is a 20px glyph on a 36px button in a 48px bar. Hover shows the label and its shortcut after 300ms.
- Generate is one button. It opens the generator menu (Image, Video, 3D, Text) and never adds a node on its own.
- The bar is `w-max`. Before, a fixed element anchored at `left-1/2` shrank to half the viewport, so "All nodes" and "All models" wrapped onto two lines at 1280 and at 1920.
- Popovers, dividers and the Run button use the same surface and hover ramp.

**Navigator** (new `CanvasMinimap.tsx`)
- The minimap, its show/hide toggle and the React Flow Controls move out of `WorkflowCanvas.tsx` into one bottom-right card: minimap on top, then zoom out, zoom %, zoom in, fit, lock, minimap toggle.
- The card is 280px wide. The minimap fills it edge to edge at 266×150, clipped to a 6px radius so its corners run concentric with the card's 12px.
- Hiding the minimap leaves the control row in place.
- `WorkflowCanvas.tsx` changes by one import and one mount line.

**Shared** (`chromeStyles.ts`, `ChromeIconButton.tsx`)
- One surface, one icon button, one hover label. The bar and the navigator use both.
- The `.react-flow__controls` CSS in `globals.css` styled a component that no longer renders, so it is gone.

**Moved only**: `GlobalImageHistory` sits left of the navigator, offset from the card's width.

## Design

Three rounds on the canvas: https://claude.ai/code/artifact/0946915b-48d3-4691-a10d-b28844233e13

- Round 1 (page "Round 1"): dock, split, rail. The split layout's navigator card was kept.
- Round 2 (page "Round 2"): four icon bars, one with node-type colour tints. Colour was rejected.
- Round 3 (page "Round 3", built): monochrome bar, every state drawn at 2×. Squircle corners where the engine supports them.

## Every former bar action, and where it is now

| Before | Now |
|---|---|
| Image | image glyph, ⇧I |
| Video | video glyph, ⇧Y |
| Prompt | prompt glyph, ⇧P |
| Generate ▾ → Image / Video / 3D / Text (LLM) | sparkle glyph opens the same menu; shortcut hints on the rows |
| Output | output glyph |
| All nodes ▾ | grid glyph |
| All models | cube glyph |
| Connector style cycler | same glyph, same cycle |
| Hide all connections + count badge | eye glyph, badge, "open" fill while connections are hidden |
| Run / Stop / running count | same, white button |
| Run options ▾ (entire / from selected / selected only / selected nodes) | same menu, shortcut hint on the first row |
| Minimap hide (×) / show (corner button) | last button on the navigator row |
| Controls: zoom in / zoom out / fit / lock | navigator row, plus a zoom % readout |

Tutorial anchors (`image-button`, `prompt-button`, `output-button`, `floating-run-button`, `floating-run-dropdown`, `floating-run-menu`) are unchanged.

## Verification

- `npm run test:run`: 142 files, 2828 tests, 0 failures. 10 new tests (8 navigator, 2 bar).
- `npx tsc --noEmit -p .`: 264 errors, the same as develop, all in test files.
- `npm run lint`: not run. `next lint` fails on develop too. Next 16 removed it and the repo has no `eslint.config.*`.
- Screenshots (headless Chrome, `.scratch/`): 1280 and 1920, Prompt hovered with tooltip, Generate menu open with Video hovered, All nodes open, minimap hidden, navigator Zoom in hovered.
- Not captured: the image-history drawer open and the running state. Both need a completed generation and this worktree has no API key.

## Look hardest at

- `GlobalImageHistory` keeps its old grey style and blue badge. The brief limited it to moving. It is the one non-mono element at the bottom edge.
- The lock toggle sets React Flow's store state, as the stock Controls did. Opening a modal re-syncs it, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEDBsS91RMEGW7kF1Wt1p3
