### PR TITLE
feat(chrome): one shell for every dialog and menu

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,15 @@
   /* Faint recess for input wells on the settings panel */
   --shadow-well: inset 0 1px 1.5px rgb(0 0 0 / 0.3), inset 0 0 0 1px rgb(0 0 0 / 0.12), 0 1px 0 rgb(255 255 255 / 0.025);
 
+  /* Floating chrome — dialogs and menus (src/components/ui). Same surface as
+     a node card, one tier up: a solid border where the card's is 60%, and a
+     shadow that reads as height. Menus are controls cards, dialogs are cards. */
+  --color-chrome-border: #404040;
+  --color-scrim: rgb(0 0 0 / 0.6);
+  --color-scrim-heavy: rgb(0 0 0 / 0.9);
+  --shadow-menu: 0 8px 24px -4px rgb(0 0 0 / 0.5), 0 1px 2px rgb(0 0 0 / 0.3);
+  --shadow-dialog: 0 24px 64px -12px rgb(0 0 0 / 0.65);
+
   --text-node: 10px;
   --text-node--line-height: 14px;
 }

--- a/src/components/AnnotationModal.tsx
+++ b/src/components/AnnotationModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { DialogButton } from "@/components/ui/Dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Stage, Layer, Image as KonvaImage, Rect, Ellipse, Arrow, Line, Text, Transformer } from "react-konva";
 import { useAnnotationStore } from "@/store/annotationStore";
@@ -419,46 +420,46 @@ export function AnnotationModal() {
   ];
 
   return (
-    <div className="fixed inset-0 z-[100] bg-neutral-950 flex flex-col">
-      {/* Top Bar */}
-      <div className="h-14 bg-neutral-900 flex items-center justify-between px-4 border-b border-neutral-800">
-        <div className="flex items-center gap-1.5">
+    <div role="dialog" aria-modal="true" aria-label="Annotate image" className="fixed inset-0 z-100 bg-canvas-bg flex flex-col">
+      {/* Top Bar — the dialog header, laid flat across the screen */}
+      <div className="h-12 bg-card flex items-center justify-between px-3 border-b border-chrome-border shrink-0">
+        <div className="flex items-center gap-1">
           {tools.map((tool) => (
             <button
               key={tool.type}
               onClick={() => setCurrentTool(tool.type)}
-              className={`px-3.5 py-1.5 text-xs font-medium rounded transition-colors ${
+              className={`h-7 px-3 text-xs font-medium rounded-md transition-colors ${
                 currentTool === tool.type
                   ? "bg-white text-neutral-900"
-                  : "text-neutral-400 hover:text-white"
+                  : "text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700/50"
               }`}
             >
               {tool.label}
             </button>
           ))}
 
-          <div className="w-px h-6 bg-neutral-700 mx-3" />
+          <div className="w-px h-4 bg-neutral-600 mx-2" />
 
-          <button onClick={undo} className="px-3 py-1.5 text-xs text-neutral-400 hover:text-white">Undo</button>
-          <button onClick={redo} className="px-3 py-1.5 text-xs text-neutral-400 hover:text-white">Redo</button>
+          <button onClick={undo} className="h-7 px-2.5 text-xs text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700/50 rounded-md transition-colors">Undo</button>
+          <button onClick={redo} className="h-7 px-2.5 text-xs text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700/50 rounded-md transition-colors">Redo</button>
 
-          <div className="w-px h-6 bg-neutral-700 mx-3" />
+          <div className="w-px h-4 bg-neutral-600 mx-2" />
 
-          <button onClick={clearAnnotations} className="px-3 py-1.5 text-xs text-neutral-400 hover:text-red-400">Clear</button>
+          <button onClick={clearAnnotations} className="h-7 px-2.5 text-xs text-neutral-400 hover:text-red-400 hover:bg-red-500/10 rounded-md transition-colors">Clear</button>
         </div>
 
-        <div className="flex items-center gap-3">
-          <button onClick={closeModal} className="px-4 py-1.5 text-xs font-medium text-neutral-400 hover:text-white">
+        <div className="flex items-center gap-2">
+          <DialogButton variant="ghost" onClick={closeModal}>
             Cancel
-          </button>
-          <button onClick={handleDone} className="px-4 py-1.5 text-xs font-medium bg-white text-neutral-900 rounded hover:bg-neutral-200">
+          </DialogButton>
+          <DialogButton variant="primary" onClick={handleDone}>
             Done
-          </button>
+          </DialogButton>
         </div>
       </div>
 
       {/* Canvas Container */}
-      <div ref={containerRef} className="flex-1 overflow-hidden bg-neutral-900">
+      <div ref={containerRef} className="flex-1 overflow-hidden bg-canvas-bg">
         <Stage
           ref={stageRef}
           width={containerRef.current?.clientWidth || 800}

--- a/src/components/ConnectionDropMenu.tsx
+++ b/src/components/ConnectionDropMenu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MenuFooter, MenuHeader, MenuHint, MenuItem, MenuList, MenuSectionLabel, MenuSurface } from "@/components/ui/Menu";
 import { useEffect, useRef, useState, useCallback } from "react";
 import { NodeType } from "@/types";
 import { useSavedComfyNodes } from "@/hooks/useSavedComfyNodes";
@@ -937,26 +938,24 @@ export function ConnectionDropMenu({
   if (options.length === 0) return null;
 
   return (
-    <div
+    <MenuSurface
       ref={menuRef}
       tabIndex={-1}
       data-tutorial="connection-drop-menu"
-      className="fixed z-100 bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl overflow-hidden min-w-[160px] outline-none"
       style={{
         left: position.x,
         top: position.y,
         transform: "translate(-50%, -50%)",
       }}
     >
-      <div className="px-2 py-1.5 border-b border-neutral-700">
-        <span className="text-[10px] text-neutral-400 uppercase tracking-wide">
-          Add {handleType} node
-        </span>
-      </div>
-      <div className="py-1">
+      <MenuHeader>
+        <MenuSectionLabel>Add {handleType} node</MenuSectionLabel>
+      </MenuHeader>
+      <MenuList>
         {options.map((option, index) => (
-          <button
+          <MenuItem
             key={optionKey(option)}
+            selected={index === selectedIndex}
             onClick={() =>
               onSelect({
                 type: option.type,
@@ -966,25 +965,16 @@ export function ConnectionDropMenu({
             }
             onMouseEnter={() => setSelectedIndex(index)}
             data-tutorial={option.type === "nanoBanana" ? "generate-image-option" : undefined}
-            className={`w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 transition-colors ${
-              index === selectedIndex
-                ? "bg-neutral-700 text-neutral-100"
-                : "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100"
-            }`}
           >
             {option.icon}
             {option.label}
-          </button>
+          </MenuItem>
         ))}
-      </div>
-      <div className="px-2 py-1.5 border-t border-neutral-700 flex items-center justify-between">
-        <span className="text-[9px] text-neutral-500">
-          <kbd className="px-1 py-0.5 bg-neutral-700 rounded text-[8px]">↑↓</kbd> navigate
-        </span>
-        <span className="text-[9px] text-neutral-500">
-          <kbd className="px-1 py-0.5 bg-neutral-700 rounded text-[8px]">↵</kbd> select
-        </span>
-      </div>
-    </div>
+      </MenuList>
+      <MenuFooter>
+        <MenuHint keys="↑↓">navigate</MenuHint>
+        <MenuHint keys="↵">select</MenuHint>
+      </MenuFooter>
+    </MenuSurface>
   );
 }

--- a/src/components/CostDialog.tsx
+++ b/src/components/CostDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
 import { useWorkflowStore } from "@/store/workflowStore";
+import { Dialog, DialogBody, DialogHeader, DialogTitle } from "@/components/ui/Dialog";
 import { PredictedCostResult, CostBreakdownItem, formatCost } from "@/utils/costCalculator";
 import { ProviderType } from "@/types/providers";
 
@@ -94,16 +94,6 @@ function ExternalLinkIcon() {
 export function CostDialog({ predictedCost, incurredCost, onClose }: CostDialogProps) {
   const resetIncurredCost = useWorkflowStore((state) => state.resetIncurredCost);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
-
   const handleReset = () => {
     if (confirm("Reset incurred cost to $0.00?")) {
       resetIncurredCost();
@@ -134,26 +124,15 @@ export function CostDialog({ predictedCost, incurredCost, onClose }: CostDialogP
   const hasExternal = externalItems.length > 0;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
-      <div className="bg-neutral-800 rounded-lg p-6 w-[400px] border border-neutral-700 shadow-xl">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-neutral-100">
-            Workflow Costs
-          </h2>
-          <button
-            onClick={onClose}
-            className="p-1 text-neutral-400 hover:text-neutral-200 transition-colors"
-          >
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <div className="space-y-4">
+    <Dialog open onClose={onClose} size="sm">
+      <DialogHeader>
+        <DialogTitle>Workflow Costs</DialogTitle>
+      </DialogHeader>
+      <DialogBody className="pb-4">
+        <div className="space-y-3">
           {/* Gemini Cost Section - prices are reliable */}
           {hasGemini && (
-            <div className="bg-neutral-900 rounded-lg p-4">
+            <div className="bg-well border border-card-border rounded-well p-3.5">
               <div className="flex items-center gap-2 mb-2">
                 <ProviderIcon provider="gemini" />
                 <span className="text-sm text-neutral-300">Gemini Cost</span>
@@ -179,7 +158,7 @@ export function CostDialog({ predictedCost, incurredCost, onClose }: CostDialogP
 
           {/* External Providers Section - show model links instead of prices */}
           {hasExternal && (
-            <div className="bg-neutral-900 rounded-lg p-4">
+            <div className="bg-well border border-card-border rounded-well p-3.5">
               <div className="flex items-center justify-between mb-3">
                 <span className="text-sm text-neutral-300">External Providers</span>
                 <span className="text-xs text-neutral-500">
@@ -229,7 +208,7 @@ export function CostDialog({ predictedCost, incurredCost, onClose }: CostDialogP
 
           {/* No nodes message */}
           {predictedCost.nodeCount === 0 && (
-            <div className="bg-neutral-900 rounded-lg p-4">
+            <div className="bg-well border border-card-border rounded-well p-3.5">
               <p className="text-xs text-neutral-500">
                 No generation nodes in workflow
               </p>
@@ -237,7 +216,7 @@ export function CostDialog({ predictedCost, incurredCost, onClose }: CostDialogP
           )}
 
           {/* Incurred Cost Section - Gemini only */}
-          <div className="bg-neutral-900 rounded-lg p-4">
+          <div className="bg-well border border-card-border rounded-well p-3.5">
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm text-neutral-400">Incurred Cost</span>
               <span className="text-lg font-semibold text-green-400">
@@ -263,7 +242,7 @@ export function CostDialog({ predictedCost, incurredCost, onClose }: CostDialogP
             <p>Gemini pricing: $0.034-$0.24/image. External providers not tracked.</p>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogBody>
+    </Dialog>
   );
 }

--- a/src/components/EdgeToolbar.tsx
+++ b/src/components/EdgeToolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MenuSurface } from "@/components/ui/Menu";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { EdgeLabelRenderer, useViewport } from "@xyflow/react";
 import { useWorkflowStore } from "@/store/workflowStore";
@@ -92,8 +93,10 @@ export function EdgeToolbar({ edgeId, x, y }: EdgeToolbarProps) {
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
       >
-        <div
-          className="relative flex items-center gap-1 bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl p-1"
+        <MenuSurface
+          variant="bar"
+          floating={false}
+          className="relative"
           style={{ transform: `translate(-50%, calc(-100% - 12px)) scale(${1 / zoom})`, transformOrigin: "bottom center" }}
         >
           {grouped && (
@@ -238,7 +241,7 @@ export function EdgeToolbar({ edgeId, x, y }: EdgeToolbarProps) {
             aria-hidden="true"
             className="absolute left-1/2 -bottom-[5px] w-2 h-2 -ml-1 bg-neutral-800 border-r border-b border-neutral-600 rotate-45"
           />
-        </div>
+        </MenuSurface>
       </div>
     </EdgeLabelRenderer>
   );

--- a/src/components/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MenuItem, MenuSectionLabel, MenuSurface } from "@/components/ui/Menu";
 import { useRef, useState, useEffect, useMemo, useCallback, type ReactNode } from "react";
 import { ChromeIconButton, type ChromeIconButtonProps } from "./ChromeIconButton";
 import { useWorkflowStore } from "@/store/workflowStore";
@@ -11,10 +12,7 @@ import { useFTUXStore, TutorialStep } from "@/store/ftuxStore";
 import type { EdgeStyle } from "@/types";
 import {
   CHROME_DIVIDER,
-  CHROME_MENU,
-  CHROME_MENU_HEADING,
   CHROME_MENU_HINT,
-  CHROME_MENU_ITEM,
   CHROME_SURFACE,
 } from "./chromeStyles";
 
@@ -265,23 +263,22 @@ function GenerateMenu() {
       </IconButton>
 
       {isOpen && (
-        <div className={`${CHROME_MENU} left-0 min-w-[168px]`} role="menu">
+        <MenuSurface floating={false} role="menu" className="absolute bottom-full left-0 z-20 mb-2 min-w-[168px] py-1">
           {GENERATORS.map((g) => (
-            <button
+            <MenuItem
               key={g.type}
-              type="button"
               role="menuitem"
               onClick={() => handleAddNode(g.type)}
               draggable
               onDragStart={(e) => { dragStart(e, g.type); setIsOpen(false); }}
-              className={`${CHROME_MENU_ITEM} cursor-grab active:cursor-grabbing`}
+              className="cursor-grab active:cursor-grabbing"
             >
               <span className="text-neutral-300">{g.icon}</span>
               {g.label}
               {g.shortcut && <span className={CHROME_MENU_HINT}>{g.shortcut}</span>}
-            </button>
+            </MenuItem>
           ))}
-        </div>
+        </MenuSurface>
       )}
     </div>
   );
@@ -312,26 +309,32 @@ function AllNodesMenu() {
       </IconButton>
 
       {isOpen && (
-        <div className={`${CHROME_MENU} left-0 max-h-[400px] min-w-[188px] overflow-y-auto`} role="menu">
-          {ALL_NODES_CATEGORIES.map((category) => (
+        <MenuSurface
+          floating={false}
+          role="menu"
+          className="absolute bottom-full left-0 z-20 mb-2 max-h-[400px] min-w-[188px] overflow-y-auto"
+        >
+          {ALL_NODES_CATEGORIES.map((category, catIndex) => (
             <div key={category.label}>
-              <div className={CHROME_MENU_HEADING}>{category.label}</div>
+              <MenuSectionLabel className={`px-3 py-1${catIndex > 0 ? " border-t border-chrome-border" : ""}`}>
+                {category.label}
+              </MenuSectionLabel>
               {category.nodes.map((node) => (
-                <button
+                <MenuItem
                   key={node.type}
                   type="button"
                   role="menuitem"
                   onClick={() => handleAddNode(node.type)}
                   draggable
                   onDragStart={(e) => { dragStart(e, node.type); setIsOpen(false); }}
-                  className={`${CHROME_MENU_ITEM} cursor-grab active:cursor-grabbing`}
+                  className="cursor-grab active:cursor-grabbing"
                 >
                   {node.label}
-                </button>
+                </MenuItem>
               ))}
             </div>
           ))}
-        </div>
+        </MenuSurface>
       )}
     </div>
   );
@@ -631,52 +634,44 @@ export function FloatingActionBar() {
 
           {/* Dropdown menu */}
           {runMenuOpen && !isRunning && (
-            <div data-tutorial="floating-run-menu" className={`${CHROME_MENU} right-0 min-w-[196px]`} role="menu">
-              <button
-                type="button"
+            <MenuSurface floating={false} role="menu" data-tutorial="floating-run-menu" className="absolute bottom-full right-0 z-20 mb-2 min-w-[196px] py-1">
+              <MenuItem
                 role="menuitem"
                 onClick={() => {
                   executeWorkflow();
                   setRunMenuOpen(false);
                 }}
-                className={CHROME_MENU_ITEM}
               >
                 <PlayIcon />
                 Run entire workflow
                 <span className={CHROME_MENU_HINT}>{modKey}↵</span>
-              </button>
-              <button
-                type="button"
+              </MenuItem>
+              <MenuItem
                 role="menuitem"
                 onClick={handleRunFromSelected}
                 disabled={!selectedNode}
-                className={CHROME_MENU_ITEM}
                 title={!selectedNode ? "Select a single node first" : undefined}
               >
                 <svg className="h-3.5 w-3.5" {...iconProps} strokeWidth={2}>
                   <path d="M13 5l7 7-7 7M5 5l7 7-7 7" />
                 </svg>
                 Run from selected node
-              </button>
-              <button
-                type="button"
+              </MenuItem>
+              <MenuItem
                 role="menuitem"
                 onClick={handleRunSelectedOnly}
                 disabled={!selectedNode}
-                className={CHROME_MENU_ITEM}
                 title={!selectedNode ? "Select a single node first" : undefined}
               >
                 <svg className="h-3.5 w-3.5" {...iconProps} strokeWidth={2}>
                   <path d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
                 </svg>
                 Run selected node only
-              </button>
-              <button
-                type="button"
+              </MenuItem>
+              <MenuItem
                 role="menuitem"
                 onClick={handleRunSelectedNodes}
                 disabled={selectedNodes.length === 0}
-                className={CHROME_MENU_ITEM}
                 title={selectedNodes.length === 0 ? "Select one or more nodes first" : `Run ${selectedNodes.length} selected node${selectedNodes.length > 1 ? 's' : ''}`}
               >
                 <svg className="h-3.5 w-3.5" {...iconProps} strokeWidth={2}>
@@ -686,8 +681,8 @@ export function FloatingActionBar() {
                 {selectedNodes.length > 0
                   ? `Run ${selectedNodes.length} selected node${selectedNodes.length !== 1 ? 's' : ''}`
                   : 'Run selected nodes'}
-              </button>
-            </div>
+              </MenuItem>
+            </MenuSurface>
           )}
         </div>
       </div>

--- a/src/components/FloatingMenu.tsx
+++ b/src/components/FloatingMenu.tsx
@@ -14,12 +14,12 @@ import { useShallow } from "zustand/shallow";
 import { ProjectSetupModal } from "./ProjectSetupModal";
 import { KeyboardShortcutsDialog } from "./KeyboardShortcutsDialog";
 import { WorkflowBrowserModal } from "./WorkflowBrowserModal";
+import { MenuDivider, MenuSurface, menuItemClass } from "@/components/ui/Menu";
 
 const ICON_BUTTON =
   "relative flex h-7 w-7 items-center justify-center rounded text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50";
 
-const MENU_ROW =
-  "flex h-7 w-full items-center gap-2 rounded px-2 text-left text-xs text-neutral-300 whitespace-nowrap transition-colors hover:bg-neutral-700 hover:text-neutral-100 focus-visible:outline-none focus-visible:bg-neutral-700 focus-visible:text-neutral-100 [&>svg]:shrink-0 [&>svg]:text-neutral-400";
+const MENU_ROW = `${menuItemClass} whitespace-nowrap [&>svg]:shrink-0 [&>svg]:text-neutral-400`;
 
 const MENU_ITEM_SELECTOR = '[role="menuitem"]';
 
@@ -470,12 +470,13 @@ export function FloatingMenu() {
         </div>
 
         {isOpen && (
-          <div
+          <MenuSurface
             ref={menuRef}
+            floating={false}
             role="menu"
             aria-label="Node Banana menu"
             onKeyDown={handleMenuKeyDown}
-            className="flex min-w-[224px] flex-col rounded-lg border border-neutral-600 bg-neutral-800 p-1 shadow-xl"
+            className="flex min-w-[224px] flex-col py-1"
           >
             <MenuRow
               icon={<SaveIcon />}
@@ -520,7 +521,7 @@ export function FloatingMenu() {
               onClick={choose(handleOpenSettings)}
             />
 
-            <div role="separator" className="my-1 h-px bg-neutral-700/60" />
+            <MenuDivider role="separator" className="my-1" />
             <MenuRow
               icon={
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.25}>
@@ -544,7 +545,7 @@ export function FloatingMenu() {
             />
 
             {(previousWorkflowSnapshot || commentCount > 0) && (
-              <div role="separator" className="my-1 h-px bg-neutral-700/60" />
+              <MenuDivider role="separator" className="my-1" />
             )}
             {previousWorkflowSnapshot && (
               <MenuRow
@@ -568,7 +569,7 @@ export function FloatingMenu() {
               />
             )}
 
-            <div role="separator" className="my-1 h-px bg-neutral-700/60" />
+            <MenuDivider role="separator" className="my-1" />
             <MenuRow
               icon={
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
@@ -619,7 +620,7 @@ export function FloatingMenu() {
               hint="↗"
               href="https://x.com/ReflctWillie"
             />
-          </div>
+          </MenuSurface>
         )}
       </div>
 

--- a/src/components/GroupsOverlay.tsx
+++ b/src/components/GroupsOverlay.tsx
@@ -449,6 +449,7 @@ const GroupControls = memo(function GroupControls({
 
                   {/* Background color row */}
                   <button
+                    role="menuitem"
                     onClick={(e) => { e.stopPropagation(); setShowColorPicker(!showColorPicker); }}
                     className="w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors"
                   >
@@ -461,6 +462,7 @@ const GroupControls = memo(function GroupControls({
 
                   {/* Lock/Unlock row */}
                   <button
+                    role="menuitem"
                     onClick={(e) => { e.stopPropagation(); handleToggleLock(); setShowMenu(false); }}
                     className="w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors"
                   >
@@ -478,6 +480,7 @@ const GroupControls = memo(function GroupControls({
 
                   {/* NBP Input toggle row */}
                   <button
+                    role="menuitem"
                     onClick={(e) => { e.stopPropagation(); updateGroup(groupId, { isNbpInput: !group.isNbpInput }); setShowMenu(false); }}
                     className="w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors"
                   >
@@ -494,6 +497,7 @@ const GroupControls = memo(function GroupControls({
 
                   {/* Delete row */}
                   <button
+                    role="menuitem"
                     onClick={(e) => { e.stopPropagation(); handleDelete(); }}
                     className="w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors"
                   >

--- a/src/components/GroupsOverlay.tsx
+++ b/src/components/GroupsOverlay.tsx
@@ -383,7 +383,7 @@ const GroupControls = memo(function GroupControls({
 
               {/* Vertical context menu - appears above the three-dot button */}
               {showMenu && (
-                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 bg-neutral-800/90 backdrop-blur rounded-lg py-1 min-w-[130px] shadow-lg shadow-black/30" ref={colorPickerRef}>
+                <div role="menu" aria-label="Group options" className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 bg-card/90 backdrop-blur border border-chrome-border rounded-controls py-1 min-w-[140px] shadow-menu" ref={colorPickerRef}>
                   {/* Color fan - anchored to top-left corner of menu */}
                   {showColorPicker && (
                     <>
@@ -450,7 +450,7 @@ const GroupControls = memo(function GroupControls({
                   {/* Background color row */}
                   <button
                     onClick={(e) => { e.stopPropagation(); setShowColorPicker(!showColorPicker); }}
-                    className="flex items-center gap-2 px-3 py-1.5 w-full hover:bg-white/10 text-xs text-white/80 transition-colors"
+                    className="w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors"
                   >
                     <div
                       className="w-3 h-3 rounded-full border border-white/30"
@@ -462,7 +462,7 @@ const GroupControls = memo(function GroupControls({
                   {/* Lock/Unlock row */}
                   <button
                     onClick={(e) => { e.stopPropagation(); handleToggleLock(); setShowMenu(false); }}
-                    className="flex items-center gap-2 px-3 py-1.5 w-full hover:bg-white/10 text-xs text-white/80 transition-colors"
+                    className="w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors"
                   >
                     {group.locked ? (
                       <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -479,7 +479,7 @@ const GroupControls = memo(function GroupControls({
                   {/* NBP Input toggle row */}
                   <button
                     onClick={(e) => { e.stopPropagation(); updateGroup(groupId, { isNbpInput: !group.isNbpInput }); setShowMenu(false); }}
-                    className="flex items-center gap-2 px-3 py-1.5 w-full hover:bg-white/10 text-xs text-white/80 transition-colors"
+                    className="w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors"
                   >
                     <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
@@ -495,7 +495,7 @@ const GroupControls = memo(function GroupControls({
                   {/* Delete row */}
                   <button
                     onClick={(e) => { e.stopPropagation(); handleDelete(); }}
-                    className="flex items-center gap-2 px-3 py-1.5 w-full hover:bg-white/10 text-xs text-white/80 transition-colors"
+                    className="w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 transition-colors"
                   >
                     <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />

--- a/src/components/HandleMenu.tsx
+++ b/src/components/HandleMenu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MenuBarLabel, MenuDivider, MenuIconButton, MenuSurface } from "@/components/ui/Menu";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { bundleIdAt, edgesOnHandle } from "@/lib/edges/bundles";
@@ -27,8 +28,6 @@ interface HandleMenuProps {
 /** Gap between the handle's centre and the bar's bottom edge. */
 const GAP = 14;
 
-const iconButton =
-  "p-1.5 rounded transition-colors hover:bg-neutral-700 text-neutral-400 hover:text-neutral-100 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent";
 
 export function HandleMenu({ target, onClose }: HandleMenuProps) {
   const edges = useWorkflowStore((state) => state.edges);
@@ -80,58 +79,55 @@ export function HandleMenu({ target, onClose }: HandleMenuProps) {
   const top = Math.max(8, target.position.y - GAP - size.height);
 
   return (
-    <div
+    <MenuSurface
       ref={measure}
+      variant="bar"
       role="menu"
       aria-label="Handle connections"
       data-testid="handle-menu"
-      className="fixed z-100 flex items-center gap-1 p-1 bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl"
       style={{ left, top }}
     >
-      <span
-        className="inline-flex items-center gap-1.5 pl-2 pr-2.5 text-[10px] font-medium text-neutral-300 border-r border-neutral-600 whitespace-nowrap"
-        data-testid="handle-menu-count"
-      >
+      <MenuBarLabel className="pr-2.5" data-testid="handle-menu-count">
         <span className="w-1.5 h-1.5 rounded-full" style={{ background: color }} />
         {count}
-      </span>
+      </MenuBarLabel>
 
       {allInOneBundle ? (
-        <button type="button" role="menuitem" className={iconButton} title="Unbundle" aria-label="Unbundle" onClick={() => run(() => unbundleEdges(bundled.map((e) => e.id), target.type))}>
+        <MenuIconButton role="menuitem" title="Unbundle" aria-label="Unbundle" onClick={() => run(() => unbundleEdges(bundled.map((e) => e.id), target.type))}>
           <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
             <path d="M2 8h3.5c2 0 2-4 4-4H14M9.5 8H14M5.5 8c2 0 2 4 4 4H14" />
           </svg>
-        </button>
+        </MenuIconButton>
       ) : (
-        <button type="button" role="menuitem" className={iconButton} title="Bundle" aria-label="Bundle" disabled={bundleable.length < 2} onClick={() => run(() => bundleEdges(bundleable.map((e) => e.id), target.type))}>
+        <MenuIconButton role="menuitem" title="Bundle" aria-label="Bundle" disabled={bundleable.length < 2} onClick={() => run(() => bundleEdges(bundleable.map((e) => e.id), target.type))}>
           <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round">
             <path d="M2 4h3.5c2 0 2 4 4 4H14M2 8h3.5M2 12h3.5c2 0 2-4 4-4" />
           </svg>
-        </button>
+        </MenuIconButton>
       )}
 
       {allHidden ? (
-        <button type="button" role="menuitem" className={iconButton} title="Show" aria-label="Show" onClick={() => run(() => setEdgesHidden(ids, false))}>
+        <MenuIconButton role="menuitem" title="Show" aria-label="Show" onClick={() => run(() => setEdgesHidden(ids, false))}>
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M2.4 12C3.7 7.9 7.5 5 12 5s8.3 2.9 9.6 7c-1.3 4.1-5.1 7-9.6 7s-8.3-2.9-9.6-7z" />
             <circle cx="12" cy="12" r="3" />
           </svg>
-        </button>
+        </MenuIconButton>
       ) : (
-        <button type="button" role="menuitem" className={iconButton} title="Hide" aria-label="Hide" disabled={count === 0} onClick={() => run(() => setEdgesHidden(ids, true))}>
+        <MenuIconButton role="menuitem" title="Hide" aria-label="Hide" disabled={count === 0} onClick={() => run(() => setEdgesHidden(ids, true))}>
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M3 3l18 18M10.6 10.6a2 2 0 002.8 2.8M9.9 5.1A9.8 9.8 0 0112 5c4.5 0 8.3 2.9 9.6 7a10 10 0 01-2.2 3.6M6.6 6.6A10 10 0 002.4 12c1.3 4.1 5.1 7 9.6 7 1.4 0 2.8-.3 4-.8" />
           </svg>
-        </button>
+        </MenuIconButton>
       )}
 
-      <div className="w-px h-4 bg-neutral-600" />
+      <MenuDivider variant="bar" />
 
-      <button type="button" role="menuitem" className={`${iconButton} hover:text-red-400`} title="Remove all" aria-label="Remove all" disabled={count === 0} onClick={() => run(() => removeEdges(ids))}>
+      <MenuIconButton role="menuitem" className="hover:text-red-400" title="Remove all" aria-label="Remove all" disabled={count === 0} onClick={() => run(() => removeEdges(ids))}>
         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M10 11v6M14 11v6M6 7l1 12a2 2 0 002 2h6a2 2 0 002-2l1-12M9 7V4h6v3" />
         </svg>
-      </button>
-    </div>
+      </MenuIconButton>
+    </MenuSurface>
   );
 }

--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { Dialog, DialogBody, DialogHeader, DialogSectionHeader, DialogTitle } from "@/components/ui/Dialog";
 
 interface ShortcutItem {
   keys: string[];
@@ -62,7 +62,7 @@ const shortcutGroups: ShortcutGroup[] = [
 
 function Kbd({ children }: { children: string }) {
   return (
-    <kbd className="inline-flex items-center justify-center min-w-[24px] h-6 px-1.5 text-[11px] font-medium text-neutral-200 bg-neutral-700 border border-neutral-600 rounded shadow-sm">
+    <kbd className="inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 text-[11px] font-medium text-neutral-200 bg-neutral-700 border border-neutral-600 rounded shadow-sm">
       {children}
     </kbd>
   );
@@ -74,52 +74,23 @@ interface KeyboardShortcutsDialogProps {
 }
 
 export function KeyboardShortcutsDialog({ isOpen, onClose }: KeyboardShortcutsDialogProps) {
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
-
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
-      <div className="bg-neutral-800 rounded-lg w-[520px] max-h-[80vh] border border-neutral-700 shadow-xl flex flex-col overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-700">
-          <h2 className="text-base font-semibold text-neutral-100">
-            Keyboard Shortcuts
-          </h2>
-          <button
-            onClick={onClose}
-            className="p-1 text-neutral-400 hover:text-neutral-200 hover:bg-neutral-700 rounded transition-colors"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+    <Dialog open={isOpen} onClose={onClose} className="w-[520px] max-h-[80vh]">
+      <DialogHeader>
+        <DialogTitle>Keyboard Shortcuts</DialogTitle>
+      </DialogHeader>
 
-        {/* Content */}
-        <div className="overflow-y-auto px-5 py-4 space-y-5">
+      <DialogBody className="pb-4 space-y-4">
           {shortcutGroups.map((group) => (
             <div key={group.title}>
-              <h3 className="text-[11px] font-semibold text-neutral-400 uppercase tracking-wider mb-2">
-                {group.title}
-              </h3>
-              <div className="space-y-1.5">
+              <DialogSectionHeader className="mb-2">{group.title}</DialogSectionHeader>
+              <div className="space-y-0.5">
                 {group.shortcuts.map((shortcut, idx) => (
                   <div
                     key={idx}
-                    className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-neutral-700/40 transition-colors"
+                    className="flex items-center justify-between h-8 px-2 rounded hover:bg-neutral-700/40 transition-colors"
                   >
-                    <span className="text-sm text-neutral-300">
+                    <span className="text-[13px] text-neutral-300">
                       {shortcut.description}
                     </span>
                     <div className="flex items-center gap-1 ml-4 shrink-0">
@@ -137,19 +108,8 @@ export function KeyboardShortcutsDialog({ isOpen, onClose }: KeyboardShortcutsDi
               </div>
             </div>
           ))}
-        </div>
-
-        {/* Footer */}
-        <div className="px-5 py-3 border-t border-neutral-700 flex justify-end">
-          <button
-            onClick={onClose}
-            className="px-3 py-1.5 text-xs font-medium text-neutral-300 hover:text-neutral-100 bg-neutral-700 hover:bg-neutral-600 rounded transition-colors"
-          >
-            Close
-          </button>
-        </div>
-      </div>
-    </div>
+      </DialogBody>
+    </Dialog>
   );
 }
 

--- a/src/components/MultiSelectToolbar.tsx
+++ b/src/components/MultiSelectToolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MenuDivider, MenuIconButton, MenuSurface } from "@/components/ui/Menu";
 import { useReactFlow } from "@xyflow/react";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { useMemo, useCallback } from "react";
@@ -217,81 +218,75 @@ export function MultiSelectToolbar() {
   if (!toolbarPosition || selectedNodes.length < 2) return null;
 
   return (
-    <div
-      className="fixed z-[100] flex items-center gap-1 bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl p-1"
+    <MenuSurface
+      variant="bar"
       style={{
         left: toolbarPosition.x,
         top: toolbarPosition.y,
         transform: "translateX(-50%)",
       }}
     >
-      <button
+      <MenuIconButton
         onClick={handleStackHorizontally}
-        className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-100 transition-colors"
         title="Stack horizontally (H)"
       >
         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M6 4h4v16H6zM14 4h4v16h-4z" />
         </svg>
-      </button>
-      <button
+      </MenuIconButton>
+      <MenuIconButton
         onClick={handleStackVertically}
-        className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-100 transition-colors"
         title="Stack vertically (V)"
       >
         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16v4H4zM4 14h16v4H4z" />
         </svg>
-      </button>
-      <button
+      </MenuIconButton>
+      <MenuIconButton
         onClick={handleArrangeAsGrid}
-        className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-100 transition-colors"
         title="Arrange as grid (G)"
       >
         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
         </svg>
-      </button>
+      </MenuIconButton>
 
       {/* Separator */}
-      <div className="w-px h-4 bg-neutral-600 mx-0.5" />
+      <MenuDivider variant="bar" className="mx-0.5" />
 
       {/* Group/Ungroup buttons */}
       {someInGroup ? (
-        <button
+        <MenuIconButton
           onClick={handleUngroup}
-          className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-100 transition-colors"
-          title="Remove from group"
+            title="Remove from group"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 9V4.5M9 9H4.5M9 9L3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5m0-4.5l5.25 5.25" />
           </svg>
-        </button>
+        </MenuIconButton>
       ) : (
-        <button
+        <MenuIconButton
           onClick={handleCreateGroup}
-          className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-100 transition-colors"
-          title="Create group"
+            title="Create group"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 7.125C2.25 6.504 2.754 6 3.375 6h6c.621 0 1.125.504 1.125 1.125v3.75c0 .621-.504 1.125-1.125 1.125h-6a1.125 1.125 0 01-1.125-1.125v-3.75zM14.25 8.625c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v8.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 01-1.125-1.125v-8.25zM3.75 16.125c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 01-1.125-1.125v-2.25z" />
           </svg>
-        </button>
+        </MenuIconButton>
       )}
 
       {/* Separator */}
-      <div className="w-px h-4 bg-neutral-600 mx-0.5" />
+      <MenuDivider variant="bar" className="mx-0.5" />
 
       {/* Download images button */}
-      <button
+      <MenuIconButton
         onClick={handleDownloadImages}
-        className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-100 transition-colors"
         title="Download images as ZIP"
       >
         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
         </svg>
-      </button>
-    </div>
+      </MenuIconButton>
+    </MenuSurface>
   );
 }

--- a/src/components/NodeSearchMenu.tsx
+++ b/src/components/NodeSearchMenu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MenuEmpty, MenuFooter, MenuHeader, MenuHint, MenuItem, MenuList, MenuSectionLabel, MenuSurface } from "@/components/ui/Menu";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { NodeType } from "@/types";
 import { useSavedComfyNodes } from "@/hooks/useSavedComfyNodes";
@@ -119,12 +120,12 @@ export function NodeSearchMenu({ position, onSelect, onClose }: NodeSearchMenuPr
   const top = Math.max(8, Math.min(position.y, viewportH - MENU_MAX_HEIGHT - 8));
 
   return (
-    <div
+    <MenuSurface
       ref={menuRef}
-      className="fixed z-100 bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl overflow-hidden w-56 outline-none"
+      className="w-56"
       style={{ left, top }}
     >
-      <div className="px-2 py-1.5 border-b border-neutral-700">
+      <MenuHeader>
         <input
           ref={inputRef}
           value={search}
@@ -134,24 +135,21 @@ export function NodeSearchMenu({ position, onSelect, onClose }: NodeSearchMenuPr
           className="w-full bg-transparent text-[11px] text-neutral-100 placeholder-neutral-500 outline-none"
           aria-label="Search nodes"
         />
-      </div>
-      <div ref={listRef} className="py-1 max-h-64 overflow-y-auto overscroll-contain nowheel">
+      </MenuHeader>
+      <MenuList ref={listRef} className="max-h-64 overflow-y-auto overscroll-contain nowheel">
         {filtered.length === 0 ? (
-          <div className="px-3 py-2 text-[11px] text-neutral-500">
-            No matching nodes
-          </div>
+          <MenuEmpty>No matching nodes</MenuEmpty>
         ) : (
           filtered.map((option, index) => (
             <Fragment key={optionKey(option)}>
               {/* Once, above the first of them — the built-ins above are a
                   fixed set, these are the user's own. */}
               {option.savedNodeId && !filtered[index - 1]?.savedNodeId && (
-                <div className="px-3 pt-2 pb-1 text-[9px] uppercase tracking-wide text-neutral-500">
-                  Saved nodes
-                </div>
+                <MenuSectionLabel className="px-3 pt-2 pb-1">Saved nodes</MenuSectionLabel>
               )}
-            <button
+            <MenuItem
               data-index={index}
+              selected={index === selectedIndex}
               onClick={() => onSelect(option.type as NodeType, option.savedNodeId)}
               onMouseMove={(e) => {
                 // Only re-select on genuine cursor movement. When keyboard nav
@@ -163,31 +161,20 @@ export function NodeSearchMenu({ position, onSelect, onClose }: NodeSearchMenuPr
                 lastPointerRef.current = { x: e.clientX, y: e.clientY };
                 setSelectedIndex(index);
               }}
-              className={`w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 transition-colors ${
-                index === selectedIndex
-                  ? "bg-neutral-700 text-neutral-100"
-                  : "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100"
-              }`}
             >
               {option.icon}
               {/* min-w-0, or a long saved-node name pushes the menu wider
                   instead of ellipsing. */}
               <span className="min-w-0 truncate">{option.label}</span>
-            </button>
+            </MenuItem>
             </Fragment>
           ))
         )}
-      </div>
-      <div className="px-2 py-1.5 border-t border-neutral-700 flex items-center justify-between">
-        <span className="text-[9px] text-neutral-500">
-          <kbd className="px-1 py-0.5 bg-neutral-700 rounded text-[8px]">↑↓</kbd>{" "}
-          navigate
-        </span>
-        <span className="text-[9px] text-neutral-500">
-          <kbd className="px-1 py-0.5 bg-neutral-700 rounded text-[8px]">↵</kbd>{" "}
-          add
-        </span>
-      </div>
-    </div>
+      </MenuList>
+      <MenuFooter>
+        <MenuHint keys="↑↓">navigate</MenuHint>
+        <MenuHint keys="↵">add</MenuHint>
+      </MenuFooter>
+    </MenuSurface>
   );
 }

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -455,9 +455,8 @@ export function ProjectSetupModal({
           aria-label="Settings pages"
           className="w-44 shrink-0 flex flex-col gap-0.5 p-2 pt-3.5 bg-neutral-900/50 border-r border-chrome-border/50"
         >
-          <div className="flex items-center gap-2 px-2.5 pb-3">
-            <img src="/banana_icon.png" alt="" className="w-5 h-5" />
-            <DialogTitle compact>{mode === "new" ? "New Project" : "Project Settings"}</DialogTitle>
+          <div className="px-2.5 pb-3">
+            <DialogTitle>{mode === "new" ? "New Project" : "Project Settings"}</DialogTitle>
           </div>
           {SETTINGS_PAGES.map((p) => (
             <button

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -446,7 +446,7 @@ export function ProjectSetupModal({
     <Dialog
       open={isOpen}
       onClose={onClose}
-      className="w-[720px] h-[480px]"
+      className="w-[820px] max-w-[92vw] h-[560px]"
       panelProps={{ onKeyDown: handleKeyDown }}
     >
       <div className="flex-1 min-h-0 flex">

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -12,6 +12,15 @@ import { ModelSearchDialog } from "@/components/modals/ModelSearchDialog";
 import { ComfySettingsTab, useComfySettingsDraft } from "@/components/settings/ComfySettingsTab";
 import { saveComfySettings } from "@/lib/comfy/settings";
 import { ConnectionSettings } from "@/components/settings/ConnectionSettings";
+import {
+  Dialog,
+  DialogBody,
+  DialogButton,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/Dialog";
+import { cn } from "@/components/nodes/ui/cn";
 
 // LLM provider and model options (mirrored from LLMGenerateNode)
 const LLM_PROVIDERS: { value: LLMProvider; label: string }[] = [
@@ -83,6 +92,18 @@ const getProviderIcon = (provider: ProviderType) => {
   }
 };
 
+type SettingsTab = "project" | "providers" | "comfy" | "nodeDefaults" | "canvas" | "noodles";
+
+/** The rail's entries, with each page's heading and one-line subtitle. */
+const SETTINGS_PAGES: { id: SettingsTab; label: string; title: string; description: string }[] = [
+  { id: "project", label: "Project", title: "Project", description: "Name, location and how the file is written." },
+  { id: "providers", label: "Providers", title: "Providers", description: "API keys for the model providers this project can call." },
+  { id: "comfy", label: "ComfyUI", title: "ComfyUI", description: "Where Comfy app nodes run." },
+  { id: "nodeDefaults", label: "Node Defaults", title: "Node defaults", description: "Applied when a node is added from the bar or a shortcut." },
+  { id: "canvas", label: "Canvas", title: "Canvas", description: "How you navigate and select on the canvas." },
+  { id: "noodles", label: "Noodles", title: "Noodles", description: "How the connections between nodes are drawn." },
+];
+
 interface ProjectSetupModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -150,7 +171,7 @@ export function ProjectSetupModal({
 
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<"project" | "providers" | "comfy" | "nodeDefaults" | "canvas" | "noodles">("project");
+  const [activeTab, setActiveTab] = useState<SettingsTab>("project");
 
   // Project tab state
   const [name, setName] = useState("");
@@ -400,9 +421,6 @@ export function ProjectSetupModal({
     if (e.key === "Enter" && !isValidating && !isBrowsing) {
       handleSave();
     }
-    if (e.key === "Escape") {
-      onClose();
-    }
   };
 
   const updateLocalProvider = (
@@ -422,69 +440,52 @@ export function ProjectSetupModal({
 
   if (!isOpen) return null;
 
+  const page = SETTINGS_PAGES.find((p) => p.id === activeTab) ?? SETTINGS_PAGES[0];
+
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-      onWheelCapture={(e) => e.stopPropagation()}
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      className="w-[720px] h-[480px]"
+      panelProps={{ onKeyDown: handleKeyDown }}
     >
-      <div
-        className="bg-neutral-800 rounded-xl w-[580px] border border-neutral-700 shadow-2xl overflow-clip flex flex-col max-h-[80vh]"
-        onKeyDown={handleKeyDown}
-      >
-        <div className="px-8 pt-8 pb-0 shrink-0">
-          <div className="flex items-center gap-2 mb-5">
-            <img src="/banana_icon.png" alt="" className="w-6 h-6" />
-            <h2 className="text-xl font-medium text-neutral-100">
-              {mode === "new" ? "New Project" : "Project Settings"}
-            </h2>
+      <div className="flex-1 min-h-0 flex">
+        {/* Rail: one entry per page, the dialog's title at its head */}
+        <nav
+          aria-label="Settings pages"
+          className="w-40 shrink-0 flex flex-col gap-0.5 p-2 pt-3.5 bg-neutral-900/50 border-r border-chrome-border/50"
+        >
+          <div className="flex items-center gap-2 px-2.5 pb-3">
+            <img src="/banana_icon.png" alt="" className="w-5 h-5" />
+            <DialogTitle compact>{mode === "new" ? "New Project" : "Project Settings"}</DialogTitle>
+          </div>
+          {SETTINGS_PAGES.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setActiveTab(p.id)}
+              aria-current={activeTab === p.id ? "page" : undefined}
+              className={cn(
+                "h-[30px] px-2.5 rounded-md text-left text-[13px] whitespace-nowrap transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-selection",
+                activeTab === p.id
+                  ? "bg-neutral-700 text-neutral-100 font-medium"
+                  : "text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800/50"
+              )}
+            >
+              {p.label}
+            </button>
+          ))}
+        </nav>
+
+        <div className="flex-1 min-w-0 flex flex-col">
+          <div className="px-5 pt-3.5 pb-2 shrink-0 flex flex-col gap-0.5">
+            <h3 className="text-base font-semibold leading-6 text-neutral-100">{page.title}</h3>
+            <DialogDescription>{page.description}</DialogDescription>
           </div>
 
-          {/* Tab Bar */}
-          <div className="flex gap-1.5 p-1 bg-neutral-900/50 rounded-lg">
-          <button
-            onClick={() => setActiveTab("project")}
-            className={`px-3 py-1.5 text-sm rounded-md transition-all duration-150 ${activeTab === "project" ? "bg-neutral-700 text-neutral-100 font-medium" : "text-neutral-400 hover:text-neutral-300 hover:bg-neutral-800/50"}`}
-          >
-            Project
-          </button>
-          <button
-            onClick={() => setActiveTab("providers")}
-            className={`px-3 py-1.5 text-sm rounded-md transition-all duration-150 ${activeTab === "providers" ? "bg-neutral-700 text-neutral-100 font-medium" : "text-neutral-400 hover:text-neutral-300 hover:bg-neutral-800/50"}`}
-          >
-            Providers
-          </button>
-          <button
-            onClick={() => setActiveTab("comfy")}
-            className={`px-3 py-1.5 text-sm rounded-md transition-all duration-150 ${activeTab === "comfy" ? "bg-neutral-700 text-neutral-100 font-medium" : "text-neutral-400 hover:text-neutral-300 hover:bg-neutral-800/50"}`}
-          >
-            ComfyUI
-          </button>
-          <button
-            onClick={() => setActiveTab("nodeDefaults")}
-            className={`px-3 py-1.5 text-sm rounded-md transition-all duration-150 ${activeTab === "nodeDefaults" ? "bg-neutral-700 text-neutral-100 font-medium" : "text-neutral-400 hover:text-neutral-300 hover:bg-neutral-800/50"}`}
-          >
-            Node Defaults
-          </button>
-          <button
-            onClick={() => setActiveTab("canvas")}
-            className={`px-3 py-1.5 text-sm rounded-md transition-all duration-150 ${activeTab === "canvas" ? "bg-neutral-700 text-neutral-100 font-medium" : "text-neutral-400 hover:text-neutral-300 hover:bg-neutral-800/50"}`}
-          >
-            Canvas
-          </button>
-          <button
-            onClick={() => setActiveTab("noodles")}
-            className={`px-3 py-1.5 text-sm rounded-md transition-all duration-150 ${activeTab === "noodles" ? "bg-neutral-700 text-neutral-100 font-medium" : "text-neutral-400 hover:text-neutral-300 hover:bg-neutral-800/50"}`}
-          >
-            Noodles
-          </button>
-          </div>
-        </div>
-
-        {/* Scrollable tab content area */}
-        <div className="flex-1 min-h-0 overflow-y-auto px-8 py-5">
+        {/* Scrollable page content */}
+        <DialogBody className="pt-1">
 
         {/* Project Tab Content */}
         {activeTab === "project" && (
@@ -1270,26 +1271,23 @@ export function ProjectSetupModal({
           </div>
         )}
 
-        </div>
+        </DialogBody>
 
-        {/* Fixed footer */}
-        <div className="flex justify-end gap-2 px-8 py-5 border-t border-neutral-700/50 shrink-0">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm text-neutral-400 hover:text-neutral-100 transition-colors"
-          >
+        <DialogFooter>
+          <DialogButton variant="ghost" onClick={onClose}>
             Cancel
-          </button>
-          <button
+          </DialogButton>
+          <DialogButton
+            variant="primary"
             onClick={handleSave}
             disabled={activeTab === "project" && (isValidating || isBrowsing)}
-            className="px-4 py-2 text-sm bg-white text-neutral-900 rounded-lg hover:bg-neutral-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {activeTab === "project"
               ? (isValidating ? "Validating..." : mode === "new" ? "Create" : "Save")
               : "Save"
             }
-          </button>
+          </DialogButton>
+        </DialogFooter>
         </div>
       </div>
 
@@ -1336,6 +1334,6 @@ export function ProjectSetupModal({
           initialCapabilityFilter="video"
         />
       )}
-    </div>
+    </Dialog>
   );
 }

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -466,7 +466,7 @@ export function ProjectSetupModal({
               onClick={() => setActiveTab(p.id)}
               aria-current={activeTab === p.id ? "page" : undefined}
               className={cn(
-                "h-[30px] px-2.5 rounded-md text-left text-[13px] whitespace-nowrap transition-colors",
+                "h-8 px-2.5 rounded-md text-left text-sm whitespace-nowrap transition-colors",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-selection",
                 activeTab === p.id
                   ? "bg-neutral-700 text-neutral-100 font-medium"

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -1150,7 +1150,6 @@ export function ProjectSetupModal({
         {/* Canvas Tab Content */}
         {activeTab === "canvas" && (
           <div className="space-y-3">
-            <p className="text-xs text-neutral-400">Configure how you navigate and interact with the canvas.</p>
             {/* Pan Mode */}
             <div className="p-3 bg-neutral-900 rounded-lg border border-neutral-700">
               <div className="flex flex-col gap-3">
@@ -1258,7 +1257,6 @@ export function ProjectSetupModal({
         {/* Noodles Tab Content */}
         {activeTab === "noodles" && (
           <div className="space-y-3">
-            <p className="text-xs text-neutral-400">How the connections between nodes are drawn.</p>
             <ConnectionSettings
               edgeStyle={localEdgeStyle}
               appearance={localEdgeAppearance}

--- a/src/components/ProjectSetupModal.tsx
+++ b/src/components/ProjectSetupModal.tsx
@@ -453,7 +453,7 @@ export function ProjectSetupModal({
         {/* Rail: one entry per page, the dialog's title at its head */}
         <nav
           aria-label="Settings pages"
-          className="w-40 shrink-0 flex flex-col gap-0.5 p-2 pt-3.5 bg-neutral-900/50 border-r border-chrome-border/50"
+          className="w-44 shrink-0 flex flex-col gap-0.5 p-2 pt-3.5 bg-neutral-900/50 border-r border-chrome-border/50"
         >
           <div className="flex items-center gap-2 px-2.5 pb-3">
             <img src="/banana_icon.png" alt="" className="w-5 h-5" />

--- a/src/components/WorkflowBrowserModal.tsx
+++ b/src/components/WorkflowBrowserModal.tsx
@@ -2,6 +2,7 @@
 
 import { WorkflowFile } from "@/store/workflowStore";
 import { WorkflowBrowserView } from "./quickstart/WorkflowBrowserView";
+import { Dialog } from "@/components/ui/Dialog";
 
 interface WorkflowBrowserModalProps {
   isOpen: boolean;
@@ -14,26 +15,12 @@ export function WorkflowBrowserModal({
   onClose,
   onWorkflowLoaded,
 }: WorkflowBrowserModalProps) {
-  if (!isOpen) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
-      onWheelCapture={(e) => e.stopPropagation()}
-      onClick={onClose}
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="workflow-browser-title"
-        className="w-full max-w-2xl mx-4 bg-neutral-800 rounded-xl border border-neutral-700 shadow-2xl overflow-clip max-h-[85vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <WorkflowBrowserView
-          onWorkflowLoaded={onWorkflowLoaded}
-          onClose={onClose}
-        />
-      </div>
-    </div>
+    <Dialog open={isOpen} onClose={onClose} labelledBy="workflow-browser-title" className="w-full max-w-2xl">
+      <WorkflowBrowserView
+        onWorkflowLoaded={onWorkflowLoaded}
+        onClose={onClose}
+      />
+    </Dialog>
   );
 }

--- a/src/components/__tests__/AnnotationModal.test.tsx
+++ b/src/components/__tests__/AnnotationModal.test.tsx
@@ -505,9 +505,9 @@ describe("AnnotationModal", () => {
     it("should render bottom options bar", () => {
       const { container } = render(<AnnotationModal />);
 
-      // Find bottom bar (h-14 at the bottom with border-t)
-      const bottomBars = container.querySelectorAll(".h-14.bg-neutral-900");
-      expect(bottomBars.length).toBe(2); // Top and bottom bars
+      // Top bar is the shared dialog header; the bottom options bar keeps its own
+      expect(container.querySelector(".h-12.bg-card")).toBeInTheDocument();
+      expect(container.querySelectorAll(".h-14.bg-neutral-900").length).toBe(1);
     });
 
     it("should render canvas container in the middle", () => {

--- a/src/components/__tests__/FTUXModal.test.tsx
+++ b/src/components/__tests__/FTUXModal.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { FTUXModal } from "../onboarding/FTUXModal";
+
+vi.mock("../onboarding/FTUXWelcomeStep", () => ({ FTUXWelcomeStep: () => <div>welcome step</div> }));
+vi.mock("../onboarding/FTUXApiKeysStep", () => ({ FTUXApiKeysStep: () => <div>keys step</div> }));
+vi.mock("../onboarding/FTUXModelDefaultsStep", () => ({ FTUXModelDefaultsStep: () => <div>defaults step</div> }));
+vi.mock("../onboarding/FTUXReadyStep", () => ({ FTUXReadyStep: () => <div>ready step</div> }));
+
+describe("FTUXModal", () => {
+  it("renders the welcome step in a labelled dialog that Escape does not dismiss", () => {
+    const onComplete = vi.fn();
+    render(<FTUXModal onComplete={onComplete} onStartTutorial={vi.fn()} />);
+    expect(screen.getByRole("dialog", { name: "Welcome to Node Banana" })).toBeInTheDocument();
+    expect(screen.getByText("welcome step")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("steps forward with Next and asks before skipping from the close button", () => {
+    const onComplete = vi.fn();
+    render(<FTUXModal onComplete={onComplete} onStartTutorial={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("keys step")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(screen.getByText("Skip setup?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/KeyboardShortcutsDialog.test.tsx
+++ b/src/components/__tests__/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { KeyboardShortcutsDialog } from "../KeyboardShortcutsDialog";
+
+describe("KeyboardShortcutsDialog", () => {
+  it("renders nothing when closed", () => {
+    render(<KeyboardShortcutsDialog isOpen={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders the shortcut groups in a labelled dialog", () => {
+    render(<KeyboardShortcutsDialog isOpen onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog", { name: "Keyboard Shortcuts" })).toBeInTheDocument();
+    expect(screen.getByText("Run workflow")).toBeInTheDocument();
+    expect(screen.getByText("Add Prompt node")).toBeInTheDocument();
+  });
+
+  it("closes from the header button and on Escape", () => {
+    const onClose = vi.fn();
+    render(<KeyboardShortcutsDialog isOpen onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("Close"));
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/__tests__/ModelSearchDialog.test.tsx
+++ b/src/components/__tests__/ModelSearchDialog.test.tsx
@@ -564,8 +564,7 @@ describe("ModelSearchDialog", () => {
       );
 
       // Find close button in the header (first button after title)
-      const headerCloseButton = container.querySelector("button.p-1\\.5");
-      fireEvent.click(headerCloseButton!);
+      fireEvent.click(screen.getByLabelText("Close"));
 
       expect(onClose).toHaveBeenCalled();
     });
@@ -593,9 +592,8 @@ describe("ModelSearchDialog", () => {
         </TestWrapper>
       );
 
-      // Click on the backdrop (the outer div with bg-black/60)
-      const backdrop = container.querySelector(".bg-black\\/60");
-      fireEvent.click(backdrop!);
+      // Click on the backdrop (the dialog's overlay, in a body portal)
+      fireEvent.click(document.querySelector("[data-dialog-overlay]")!);
 
       expect(onClose).toHaveBeenCalled();
     });

--- a/src/components/__tests__/ProjectSetupModal.test.tsx
+++ b/src/components/__tests__/ProjectSetupModal.test.tsx
@@ -149,8 +149,8 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      expect(screen.getByText("Project")).toBeInTheDocument();
-      expect(screen.getByText("Providers")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Project" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Providers" })).toBeInTheDocument();
     });
 
     it("should start on Project tab in new mode", () => {
@@ -177,7 +177,7 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      fireEvent.click(screen.getByText("Providers"));
+      fireEvent.click(screen.getByRole("button", { name: "Providers" }));
 
       // Should show provider names
       expect(screen.getByText("Google Gemini")).toBeInTheDocument();
@@ -897,8 +897,7 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      const modalDiv = container.querySelector(".bg-neutral-800");
-      fireEvent.keyDown(modalDiv!, { key: "Escape" });
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
 
       expect(onClose).toHaveBeenCalled();
     });
@@ -939,8 +938,7 @@ describe("ProjectSetupModal", () => {
         target: { value: "/path/to/project" },
       });
 
-      const modalDiv = container.querySelector(".bg-neutral-800");
-      fireEvent.keyDown(modalDiv!, { key: "Enter" });
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Enter" });
 
       await waitFor(() => {
         expect(onSave).toHaveBeenCalled();
@@ -961,7 +959,7 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      fireEvent.click(screen.getByText("Providers"));
+      fireEvent.click(screen.getByRole("button", { name: "Providers" }));
 
       await waitFor(() => {
         expect(screen.getByText("Google Gemini")).toBeInTheDocument();
@@ -981,7 +979,7 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      fireEvent.click(screen.getByText("Providers"));
+      fireEvent.click(screen.getByRole("button", { name: "Providers" }));
 
       await waitFor(() => {
         // Check for placeholder texts
@@ -1011,7 +1009,7 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      fireEvent.click(screen.getByText("Providers"));
+      fireEvent.click(screen.getByRole("button", { name: "Providers" }));
 
       await waitFor(() => {
         expect(screen.getByText("Configured via .env")).toBeInTheDocument();
@@ -1038,7 +1036,7 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      fireEvent.click(screen.getByText("Providers"));
+      fireEvent.click(screen.getByRole("button", { name: "Providers" }));
 
       await waitFor(() => {
         expect(screen.getByText("Override")).toBeInTheDocument();
@@ -1055,7 +1053,7 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      fireEvent.click(screen.getByText("Providers"));
+      fireEvent.click(screen.getByRole("button", { name: "Providers" }));
 
       await waitFor(() => {
         const showButtons = screen.getAllByText("Show");
@@ -1082,7 +1080,7 @@ describe("ProjectSetupModal", () => {
         />
       );
 
-      fireEvent.click(screen.getByText("Providers"));
+      fireEvent.click(screen.getByRole("button", { name: "Providers" }));
 
       await waitFor(() => {
         expect(screen.getByText("Google Gemini")).toBeInTheDocument();
@@ -1106,11 +1104,11 @@ describe("Noodles tab", () => {
     );
     mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
     render(<ProjectSetupModal isOpen={true} onClose={vi.fn()} onSave={vi.fn()} mode="settings" />);
-    fireEvent.click(screen.getByText("Noodles"));
+    fireEvent.click(screen.getByRole("button", { name: "Noodles" }));
     expect(screen.getByText("Connections")).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Curved" })).toHaveAttribute("aria-checked", "true");
     // The Canvas tab no longer carries them
-    fireEvent.click(screen.getByText("Canvas"));
+    fireEvent.click(screen.getByRole("button", { name: "Canvas" }));
     expect(screen.queryByText("Connections")).toBeNull();
   });
 });

--- a/src/components/__tests__/WelcomeModal.test.tsx
+++ b/src/components/__tests__/WelcomeModal.test.tsx
@@ -104,7 +104,7 @@ describe("WelcomeModal", () => {
         />
       );
 
-      const backdrop = container.querySelector(".bg-black\\/60");
+      const backdrop = container.querySelector("[data-dialog-overlay]");
       expect(backdrop).toBeInTheDocument();
     });
   });

--- a/src/components/modals/ComfyNodePreview.tsx
+++ b/src/components/modals/ComfyNodePreview.tsx
@@ -59,7 +59,7 @@ export function ComfyNodePreview({
   }, [params, edits]);
 
   return (
-    <div className="h-full rounded-lg bg-neutral-900/70 ring-1 ring-inset ring-black/40 overflow-auto flex justify-center p-6">
+    <div className="h-full rounded-well bg-well ring-1 ring-inset ring-black/40 overflow-auto flex justify-center p-6">
       {/* The node sits at its real width, so the preview is a measurement and
           not an impression.
 
@@ -75,10 +75,10 @@ export function ComfyNodePreview({
           </span>
         </div>
 
-        <div className="relative bg-neutral-800 rounded-lg shadow-lg">
+        <div className="relative bg-card rounded-controls shadow-lg">
           <Handles inputs={inputs} outputs={outputs} />
 
-          <div className="rounded-t-lg border border-b-0 border-neutral-700/60 px-3 pb-4">
+          <div className="rounded-t-controls border border-b-0 border-card-border px-3 pb-4">
             <div className="flex items-center gap-2 pt-2 pb-1.5">
               <div className="min-w-0 flex-1">
                 <p className="text-[11px] font-medium text-neutral-200 truncate">
@@ -96,7 +96,7 @@ export function ComfyNodePreview({
 
           {/* Always open here. Collapsed, the one thing this view exists to
               show would be a chevron. */}
-          <div className="bg-[#2a2a2a] rounded-b-lg">
+          <div className="bg-panel rounded-b-controls">
             <div className="w-full flex items-center justify-center gap-1 py-1 text-neutral-500">
               <span className="text-[10px]">Settings</span>
               <svg
@@ -111,7 +111,7 @@ export function ComfyNodePreview({
                 <polyline points="6 9 12 15 18 9" />
               </svg>
             </div>
-            <div className="px-3 pb-3 rounded-b-lg">
+            <div className="px-3 pb-3 rounded-b-controls">
               {params.length > 0 ? (
                 <ComfyAppParameters params={params} values={values} onChange={setEdits} />
               ) : (

--- a/src/components/modals/ComfyWorkflowImportModal.tsx
+++ b/src/components/modals/ComfyWorkflowImportModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { Dialog } from "@/components/ui/Dialog";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 
 import { ComfyMark } from "@/components/icons/ComfyMark";
 import { ComfyNodePreview } from "./ComfyNodePreview";
@@ -127,12 +127,12 @@ const APP_MODE_DOCS = "https://docs.comfy.org/interface/app-mode";
 
 /** The dialog's one committing action, wherever the current step puts it. */
 const PRIMARY_BUTTON =
-  "px-4 py-2 text-sm rounded-lg bg-neutral-100 text-neutral-900 font-medium hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed transition-[background-color,scale] duration-150 active:scale-[0.96] disabled:active:scale-100";
+  "h-8 px-3.5 text-[13px] rounded-lg bg-white text-neutral-900 font-medium hover:bg-neutral-200 disabled:opacity-50 disabled:cursor-not-allowed transition-[background-color,scale] duration-150 active:scale-[0.96] disabled:active:scale-100";
 
 /** Beside it: keeping this node is a different act from attaching it, and a
  *  second filled button would make the dialog ask twice which one you meant. */
 const SECONDARY_BUTTON =
-  "px-3 py-2 text-sm rounded-lg bg-neutral-700/60 text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100 disabled:opacity-40 disabled:cursor-not-allowed transition-[background-color,color,scale] duration-150 active:scale-[0.96] disabled:active:scale-100";
+  "h-8 px-3.5 text-[13px] rounded-lg bg-neutral-700 text-neutral-200 font-medium hover:bg-neutral-600 disabled:opacity-50 disabled:cursor-not-allowed transition-[background-color,color,scale] duration-150 active:scale-[0.96] disabled:active:scale-100";
 
 /**
  * Import a ComfyUI workflow and confirm what it exposes.
@@ -192,55 +192,12 @@ export function ComfyWorkflowImportModal({
   const [settingsSaved, setSettingsSaved] = useState(0);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
   const settings = useMemo(
     () => (isOpen ? getComfySettings() : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isOpen, settingsSaved]
   );
   const configError = settings ? comfyConfigError(settings) : null;
-
-  // Escape belongs to the dialog, not to whatever happens to be focused. Bound
-  // on the document because opening the dialog does not move focus into it —
-  // a keydown on the page would otherwise never reach the panel.
-  useEffect(() => {
-    if (!isOpen) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.stopPropagation();
-        onClose();
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [isOpen, onClose]);
-
-  // Focus starts inside, so the first Tab continues through the dialog rather
-  // than through the canvas behind it.
-  useEffect(() => {
-    if (!isOpen) return;
-    const frame = requestAnimationFrame(() => panelRef.current?.focus());
-    return () => cancelAnimationFrame(frame);
-  }, [isOpen]);
-
-  /** Keep Tab inside the dialog: a modal the keyboard can walk out of is not one. */
-  const trapFocus = useCallback((event: React.KeyboardEvent) => {
-    if (event.key !== "Tab" || !panelRef.current) return;
-    const focusable = panelRef.current.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-    );
-    if (focusable.length === 0) return;
-    const first = focusable[0]!;
-    const last = focusable[focusable.length - 1]!;
-    const active = document.activeElement;
-    if (event.shiftKey && (active === first || active === panelRef.current)) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && active === last) {
-      event.preventDefault();
-      first.focus();
-    }
-  }, []);
 
   /**
    * Keep the new connection and go back to what the dialog was doing.
@@ -655,30 +612,21 @@ export function ComfyWorkflowImportModal({
   const showPreview = Boolean(isMain && inspection);
 
   const dialog = (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 animate-dialog-backdrop"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-      onWheelCapture={(e) => e.stopPropagation()}
+    <Dialog
+      open
+      onClose={onClose}
+      portal
+      labelledBy="comfy-import-title"
+      // Wider only where there is a second column to hold: every other step
+      // is a single list, and stretching it would leave a hall of empty grey.
+      className={`max-h-[82vh] transition-[width] duration-200 ${
+        showPreview ? "w-[880px]" : "w-[600px]"
+      }`}
     >
-      <div
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="comfy-import-title"
-        tabIndex={-1}
-        // Wider only where there is a second column to hold: every other step
-        // is a single list, and stretching it would leave a hall of empty grey.
-        className={`bg-neutral-800 rounded-xl border border-neutral-700 shadow-2xl overflow-clip flex flex-col max-h-[82vh] focus:outline-none animate-dialog-panel transition-[width] duration-200 ${
-          showPreview ? "w-[880px]" : "w-[600px]"
-        }`}
-        onKeyDown={trapFocus}
-      >
-        <div className="px-4 pt-4 pb-0 shrink-0 animate-dialog-section">
+        <div className="px-5 pt-3.5 pb-0 shrink-0 animate-dialog-section">
           <div className="flex items-center gap-2">
             <ComfyMark className="w-4 h-[19px] text-neutral-300 shrink-0" />
-            <h2 id="comfy-import-title" className="text-xl font-medium text-neutral-100 truncate">
+            <h2 id="comfy-import-title" className="text-base font-semibold leading-6 text-neutral-100 truncate">
               {showHelp
                 ? "Preparing a workflow"
                 : showSettings
@@ -704,7 +652,7 @@ export function ComfyWorkflowImportModal({
                 title="How to prepare a workflow for this"
                 aria-label="How to prepare a workflow"
                 aria-pressed={showHelp}
-                className={`w-10 h-10 flex items-center justify-center rounded-lg transition-[background-color,color,scale] duration-150 active:scale-[0.96] ${
+                className={`w-7 h-7 flex items-center justify-center rounded-md transition-[background-color,color,scale] duration-150 active:scale-[0.96] ${
                   showHelp
                     ? "bg-neutral-700 text-neutral-100"
                     : "text-neutral-500 hover:text-neutral-200 hover:bg-neutral-700/50"
@@ -730,7 +678,7 @@ export function ComfyWorkflowImportModal({
                 title="ComfyUI connection — engine, API key"
                 aria-label="ComfyUI connection settings"
                 aria-pressed={showSettings}
-                className={`w-10 h-10 flex items-center justify-center rounded-lg transition-[background-color,color,scale] duration-150 active:scale-[0.96] ${
+                className={`w-7 h-7 flex items-center justify-center rounded-md transition-[background-color,color,scale] duration-150 active:scale-[0.96] ${
                   showSettings
                     ? "bg-neutral-700 text-neutral-100"
                     : "text-neutral-500 hover:text-neutral-200 hover:bg-neutral-700/50"
@@ -779,7 +727,7 @@ export function ComfyWorkflowImportModal({
             heading inside a padded scroller stops at the *content* edge, and
             rows then scroll through the padding band above it in full view. */}
         <div
-          className="flex-1 min-w-0 overflow-y-auto px-4 animate-dialog-section"
+          className="flex-1 min-w-0 overflow-y-auto px-5 animate-dialog-section"
           style={{ animationDelay: "80ms" }}
         >
           <div className="py-4">
@@ -885,7 +833,7 @@ export function ComfyWorkflowImportModal({
         </div>
 
         <div
-          className="flex items-center justify-between gap-3 p-4 border-t border-neutral-700/60 shrink-0 animate-dialog-section"
+          className="flex items-center justify-between gap-3 px-5 py-3 border-t border-chrome-border/50 shrink-0 animate-dialog-section"
           style={{ animationDelay: "160ms" }}
         >
           <button
@@ -899,7 +847,7 @@ export function ComfyWorkflowImportModal({
                   : onClose
                 : () => setView("main")
             }
-            className="px-4 py-2 text-sm text-neutral-400 hover:text-neutral-200 transition-[color,scale] duration-150 active:scale-[0.96]"
+            className="h-8 px-3.5 -ml-3.5 text-[13px] font-medium rounded-lg text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700/40 transition-[color,background-color,scale] duration-150 active:scale-[0.96]"
           >
             {!isMain || (inspection && !reconfigure) ? "Back" : "Cancel"}
           </button>
@@ -977,7 +925,6 @@ export function ComfyWorkflowImportModal({
             )
           )}
         </div>
-      </div>
 
       <input
         ref={fileInputRef}
@@ -990,15 +937,14 @@ export function ComfyWorkflowImportModal({
           e.target.value = "";
         }}
       />
-    </div>
+    </Dialog>
   );
 
-  // Portalled to the body: this dialog is rendered from inside a node, and
-  // React Flow's viewport carries a `transform`, which makes it the containing
-  // block for `position: fixed` — so without this the dialog is scaled and
-  // shifted by the canvas zoom.
-  if (typeof document === "undefined") return null;
-  return createPortal(dialog, document.body);
+  // In a body portal (Dialog's `portal`): this dialog is rendered from inside
+  // a node, and React Flow's viewport carries a `transform`, which makes it
+  // the containing block for `position: fixed` — without the portal the
+  // dialog is scaled and shifted by the canvas zoom.
+  return dialog;
 }
 
 function TabButton({
@@ -1667,7 +1613,7 @@ function Section({
       {/* Sticky, and bled to the dialog's edges so rows pass behind it rather
           than beside it — three sections deep, the heading is the only thing
           saying which list you are in. */}
-      <div className="sticky top-0 z-10 -mx-4 px-4 py-2 bg-neutral-800 flex items-baseline gap-2">
+      <div className="sticky top-0 z-10 -mx-5 px-5 py-2 bg-card flex items-baseline gap-2">
         <h3 className="text-sm text-neutral-200 font-medium shrink-0">{title}</h3>
         <span className="text-[10px] text-neutral-600 truncate">{hint}</span>
         {count && !isEmpty && (

--- a/src/components/modals/ModelSearchDialog.tsx
+++ b/src/components/modals/ModelSearchDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { Dialog, DialogHeader, DialogTitle } from "@/components/ui/Dialog";
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { createPortal } from "react-dom";
 import { useWorkflowStore, useProviderApiKeys } from "@/store/workflowStore";
 import { deduplicatedFetch, clearFetchCache } from "@/utils/deduplicatedFetch";
 import { useReactFlow } from "@xyflow/react";
@@ -180,8 +180,6 @@ export function ModelSearchDialog({
 }: ModelSearchDialogProps) {
   const {
     addNode,
-    incrementModalCount,
-    decrementModalCount,
     recentModels,
     trackModelUsage,
   } = useWorkflowStore();
@@ -207,14 +205,6 @@ export function ModelSearchDialog({
   const searchInputRef = useRef<HTMLInputElement>(null);
   // Track request version to ignore stale responses
   const requestVersionRef = useRef(0);
-
-  // Register modal with store
-  useEffect(() => {
-    if (isOpen) {
-      incrementModalCount();
-      return () => decrementModalCount();
-    }
-  }, [isOpen, incrementModalCount, decrementModalCount]);
 
   // Debounce search query
   useEffect(() => {
@@ -428,33 +418,6 @@ export function ModelSearchDialog({
     [screenToFlowPosition, addNode, onClose, onModelSelected, trackModelUsage]
   );
 
-  // Handle escape key
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      window.addEventListener("keydown", handleKeyDown);
-    }
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen, onClose]);
-
-  // Handle backdrop click
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose]
-  );
-
   // Get provider badge color
   const getProviderBadgeColor = (provider: ProviderType) => {
     switch (provider) {
@@ -643,38 +606,13 @@ export function ModelSearchDialog({
   if (!isOpen) return null;
 
   const dialogContent = (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
-      onClick={handleBackdropClick}
-    >
-      <div className="relative bg-neutral-800 border border-neutral-700 rounded-lg shadow-2xl w-full max-w-5xl max-h-[85vh] flex flex-col mx-4">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-neutral-700">
-          <h2 className="text-lg font-semibold text-neutral-100">
-            {title}
-          </h2>
-          <button
-            onClick={onClose}
-            className="p-1.5 text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700 rounded transition-colors"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
+    <Dialog open onClose={onClose} portal size="xl">
+        <DialogHeader divider>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
 
         {/* Filter Bar */}
-        <div className="px-6 py-4 border-b border-neutral-700">
+        <div className="px-5 py-3 border-b border-chrome-border/50">
           <div className="flex flex-col sm:flex-row gap-3">
             {/* Search Input */}
             <div className="flex-1 relative">
@@ -1013,10 +951,10 @@ export function ModelSearchDialog({
                 <button
                   key={`${model.provider}-${model.id}`}
                   onClick={() => handleSelectModel(model)}
-                  className="flex items-start gap-3 p-4 bg-neutral-700/50 hover:bg-neutral-700 border border-neutral-600/50 hover:border-neutral-500 rounded-lg transition-colors text-left cursor-pointer group"
+                  className="flex items-stretch min-h-[108px] bg-well hover:bg-neutral-700/40 border border-card-border hover:border-neutral-500 rounded-well overflow-hidden transition-colors text-left cursor-pointer group"
                 >
-                  {/* Cover Image - larger */}
-                  <div className="w-20 h-20 rounded bg-neutral-600 overflow-hidden flex-shrink-0">
+                  {/* Cover Image - full height of the card */}
+                  <div className="w-24 self-stretch bg-neutral-700/60 overflow-hidden flex-shrink-0">
                     {model.coverImage ? (
                       <img
                         src={model.coverImage}
@@ -1047,9 +985,9 @@ export function ModelSearchDialog({
                   </div>
 
                   {/* Model Info */}
-                  <div className="flex-1 min-w-0">
+                  <div className="flex-1 min-w-0 p-3">
                     {/* Model name with variant suffix for fal.ai */}
-                    <div className="font-medium text-neutral-100 text-sm truncate">
+                    <div className="font-medium text-neutral-100 text-[13px] truncate">
                       {getDisplayName(model)}
                     </div>
 
@@ -1096,14 +1034,14 @@ export function ModelSearchDialog({
 
                     {/* Description - more lines */}
                     {model.description && (
-                      <p className="mt-1.5 text-xs text-neutral-400 line-clamp-3">
+                      <p className="mt-1.5 text-[11px] leading-[15px] text-neutral-400 line-clamp-2">
                         {model.description}
                       </p>
                     )}
                   </div>
 
                   {/* Hover indicator */}
-                  <div className="opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 self-center">
+                  <div className="opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 self-center pr-3">
                     <svg
                       className="w-5 h-5 text-neutral-400"
                       fill="none"
@@ -1127,14 +1065,13 @@ export function ModelSearchDialog({
 
         {/* Footer with model count */}
         {!isLoading && !error && models.length > 0 && (
-          <div className="px-6 py-3 border-t border-neutral-700 text-xs text-neutral-400">
+          <div className="px-5 py-2.5 border-t border-chrome-border/50 text-xs text-neutral-500">
             {models.length} model{models.length !== 1 ? "s" : ""} found
           </div>
         )}
-      </div>
-    </div>
+    </Dialog>
   );
 
-  // Use portal to render outside React Flow stacking context
-  return createPortal(dialogContent, document.body);
+  // In a body portal (Dialog's `portal`), outside React Flow's stacking context
+  return dialogContent;
 }

--- a/src/components/modals/PromptConstructorEditorModal.tsx
+++ b/src/components/modals/PromptConstructorEditorModal.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
+
+import { Dialog, DialogButton, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/Dialog";
 import { AvailableVariable } from "@/types";
 import { usePromptAutocomplete } from "@/hooks/usePromptAutocomplete";
 
@@ -129,15 +131,6 @@ export const PromptConstructorEditorModal: React.FC<PromptConstructorEditorModal
     setFontSize(parseInt(e.target.value, 10));
   }, []);
 
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) {
-        handleAttemptClose();
-      }
-    },
-    [handleAttemptClose]
-  );
-
   const handleDismissConfirmation = useCallback(() => {
     setShowConfirmation(false);
   }, []);
@@ -171,33 +164,36 @@ export const PromptConstructorEditorModal: React.FC<PromptConstructorEditorModal
     [template]
   );
 
-  if (!isOpen) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50"
-      onClick={handleBackdropClick}
+    <Dialog
+      open={isOpen}
+      onClose={handleAttemptClose}
+      closeOnEscape={false}
+      size="lg"
+      className="h-[85vh]"
     >
-      <div className="relative bg-neutral-800 border border-neutral-700 rounded-lg shadow-2xl w-full max-w-3xl h-[85vh] flex flex-col mx-4">
-        {/* Header */}
-        <div className="px-6 pt-6 pb-4 flex items-center gap-3">
-          <h2 className="text-xl font-semibold text-neutral-100">Edit Prompt Constructor</h2>
-          {unresolvedVars.length > 0 && (
-            <span className="px-2 py-0.5 bg-amber-900/30 border border-amber-700/50 rounded text-[11px] text-amber-400">
-              Unresolved: {unresolvedVars.map((v) => `@${v}`).join(", ")}
-            </span>
-          )}
-        </div>
+        <DialogHeader
+          closeButton={false}
+          actions={
+            unresolvedVars.length > 0 ? (
+              <span className="px-2 py-0.5 bg-amber-900/30 border border-amber-700/50 rounded text-[11px] text-amber-400">
+                Unresolved: {unresolvedVars.map((v) => `@${v}`).join(", ")}
+              </span>
+            ) : undefined
+          }
+        >
+          <DialogTitle>Edit Prompt Constructor</DialogTitle>
+        </DialogHeader>
 
         {/* Box containing toolbar and textarea */}
-        <div className="mx-6 flex-1 flex flex-col border border-neutral-700 rounded bg-neutral-900/30 overflow-hidden mb-4">
+        <div className="mx-5 flex-1 flex flex-col border border-chrome-border rounded-well bg-well overflow-hidden">
           {/* Toolbar */}
-          <div className="min-h-[48px] bg-neutral-900 border-b border-neutral-700 flex items-center px-4 gap-3 shrink-0 flex-wrap py-2">
+          <div className="min-h-[40px] bg-canvas-bg border-b border-chrome-border flex items-center px-3 gap-3 shrink-0 flex-wrap py-2">
             {/* Font Size Control */}
             <select
               value={fontSize}
               onChange={handleFontSizeChange}
-              className="text-sm py-1 px-2 border border-neutral-700 rounded bg-neutral-900/50 focus:outline-none focus:ring-1 focus:ring-neutral-600 text-neutral-300"
+              className="text-xs h-[26px] px-2 border border-chrome-border rounded-md bg-well focus:outline-none focus:ring-1 focus:ring-neutral-600 text-neutral-300"
             >
               {FONT_SIZE_OPTIONS.map((size) => (
                 <option key={size} value={size}>
@@ -283,28 +279,22 @@ export const PromptConstructorEditorModal: React.FC<PromptConstructorEditorModal
         )}
 
         {/* Footer with buttons */}
-        <div className="flex justify-end gap-3 px-6 pb-6">
-          <button
-            onClick={handleAttemptClose}
-            className="px-4 py-2 text-sm font-medium text-neutral-300 bg-neutral-700 hover:bg-neutral-600 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-neutral-500"
-          >
+        <DialogFooter className="mt-3">
+          <DialogButton variant="ghost" onClick={handleAttemptClose}>
             Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-blue-400"
-          >
+          </DialogButton>
+          <DialogButton variant="primary" onClick={handleSubmit}>
             Submit
-          </button>
-        </div>
+          </DialogButton>
+        </DialogFooter>
 
         {/* Confirmation overlay */}
         {showConfirmation && (
           <div
-            className="absolute inset-0 flex items-center justify-center bg-black/60 rounded-lg"
+            className="absolute inset-0 flex items-center justify-center bg-black/60 rounded-card"
             onClick={handleConfirmationBackdropClick}
           >
-            <div className="relative bg-neutral-800 border border-neutral-600 rounded-lg p-6 mx-4 max-w-sm shadow-xl">
+            <div className="relative bg-card border border-chrome-border rounded-card p-5 mx-4 max-w-sm shadow-dialog">
               <button
                 onClick={handleDismissConfirmation}
                 className="absolute top-3 right-3 text-neutral-400 hover:text-neutral-200 transition-colors focus:outline-none"
@@ -320,25 +310,18 @@ export const PromptConstructorEditorModal: React.FC<PromptConstructorEditorModal
                 </svg>
               </button>
 
-              <p className="text-neutral-100 text-center mb-6">You have unsaved changes</p>
+              <p className="text-neutral-100 text-[13px] text-center mb-5">You have unsaved changes</p>
               <div className="flex justify-center gap-3">
-                <button
-                  onClick={onClose}
-                  className="px-4 py-2 text-sm font-medium text-neutral-300 bg-neutral-700 hover:bg-neutral-600 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-neutral-500"
-                >
+                <DialogButton variant="danger" onClick={onClose}>
                   Discard
-                </button>
-                <button
-                  onClick={handleSubmit}
-                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-blue-400"
-                >
+                </DialogButton>
+                <DialogButton variant="primary" onClick={handleSubmit}>
                   Submit
-                </button>
+                </DialogButton>
               </div>
             </div>
           </div>
         )}
-      </div>
-    </div>
+    </Dialog>
   );
 };

--- a/src/components/modals/PromptEditorModal.tsx
+++ b/src/components/modals/PromptEditorModal.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 
+import { Dialog, DialogButton, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/Dialog";
+
 const FONT_SIZE_STORAGE_KEY = 'prompt-editor-font-size';
 const DEFAULT_FONT_SIZE = 14;
 const MIN_FONT_SIZE = 10;
@@ -85,16 +87,6 @@ export const PromptEditorModal: React.FC<PromptEditorModalProps> = ({
     setFontSize(parseInt(e.target.value, 10));
   }, []);
 
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      // Only close if clicking the backdrop itself, not the dialog content
-      if (e.target === e.currentTarget) {
-        handleAttemptClose();
-      }
-    },
-    [handleAttemptClose]
-  );
-
   const handleDismissConfirmation = useCallback(() => {
     setShowConfirmation(false);
   }, []);
@@ -109,30 +101,27 @@ export const PromptEditorModal: React.FC<PromptEditorModalProps> = ({
     [handleDismissConfirmation]
   );
 
-  if (!isOpen) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50"
-      onClick={handleBackdropClick}
+    <Dialog
+      open={isOpen}
+      onClose={handleAttemptClose}
+      closeOnEscape={false}
+      size="lg"
+      className="h-[85vh]"
     >
-      <div className="relative bg-neutral-800 border border-neutral-700 rounded-lg shadow-2xl w-full max-w-3xl h-[85vh] flex flex-col mx-4">
-        {/* Header */}
-        <div className="px-6 pt-6 pb-4">
-          <h2 className="text-xl font-semibold text-neutral-100">
-            Edit Prompt
-          </h2>
-        </div>
+        <DialogHeader closeButton={false}>
+          <DialogTitle>Edit Prompt</DialogTitle>
+        </DialogHeader>
 
         {/* Box containing toolbar and textarea */}
-        <div className="mx-6 flex-1 flex flex-col border border-neutral-700 rounded bg-neutral-900/30 overflow-hidden mb-4">
+        <div className="mx-5 flex-1 flex flex-col border border-chrome-border rounded-well bg-well overflow-hidden">
           {/* Toolbar - header of the box */}
-          <div className="h-12 bg-neutral-900 border-b border-neutral-700 flex items-center px-4 gap-3 shrink-0">
+          <div className="h-10 bg-canvas-bg border-b border-chrome-border flex items-center px-3 gap-3 shrink-0">
             {/* Font Size Control */}
             <select
               value={fontSize}
               onChange={handleFontSizeChange}
-              className="text-sm py-1 px-2 border border-neutral-700 rounded bg-neutral-900/50 focus:outline-none focus:ring-1 focus:ring-neutral-600 text-neutral-300"
+              className="text-xs h-[26px] px-2 border border-chrome-border rounded-md bg-well focus:outline-none focus:ring-1 focus:ring-neutral-600 text-neutral-300"
             >
               {FONT_SIZE_OPTIONS.map((size) => (
                 <option key={size} value={size}>
@@ -154,28 +143,22 @@ export const PromptEditorModal: React.FC<PromptEditorModalProps> = ({
         </div>
 
         {/* Footer with buttons */}
-        <div className="flex justify-end gap-3 px-6 pb-6">
-          <button
-            onClick={handleAttemptClose}
-            className="px-4 py-2 text-sm font-medium text-neutral-300 bg-neutral-700 hover:bg-neutral-600 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-neutral-500"
-          >
+        <DialogFooter className="mt-3">
+          <DialogButton variant="ghost" onClick={handleAttemptClose}>
             Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-blue-400"
-          >
+          </DialogButton>
+          <DialogButton variant="primary" onClick={handleSubmit}>
             Submit
-          </button>
-        </div>
+          </DialogButton>
+        </DialogFooter>
 
         {/* Confirmation overlay */}
         {showConfirmation && (
           <div
-            className="absolute inset-0 flex items-center justify-center bg-black/60 rounded-lg"
+            className="absolute inset-0 flex items-center justify-center bg-black/60 rounded-card"
             onClick={handleConfirmationBackdropClick}
           >
-            <div className="relative bg-neutral-800 border border-neutral-600 rounded-lg p-6 mx-4 max-w-sm shadow-xl">
+            <div className="relative bg-card border border-chrome-border rounded-card p-5 mx-4 max-w-sm shadow-dialog">
               {/* Close button */}
               <button
                 onClick={handleDismissConfirmation}
@@ -197,27 +180,20 @@ export const PromptEditorModal: React.FC<PromptEditorModalProps> = ({
                 </svg>
               </button>
 
-              <p className="text-neutral-100 text-center mb-6">
+              <p className="text-neutral-100 text-[13px] text-center mb-5">
                 You have unsaved changes
               </p>
               <div className="flex justify-center gap-3">
-                <button
-                  onClick={onClose}
-                  className="px-4 py-2 text-sm font-medium text-neutral-300 bg-neutral-700 hover:bg-neutral-600 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-neutral-500"
-                >
+                <DialogButton variant="danger" onClick={onClose}>
                   Discard
-                </button>
-                <button
-                  onClick={handleSubmit}
-                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-blue-400"
-                >
+                </DialogButton>
+                <DialogButton variant="primary" onClick={handleSubmit}>
                   Submit
-                </button>
+                </DialogButton>
               </div>
             </div>
           </div>
         )}
-      </div>
-    </div>
+    </Dialog>
   );
 };

--- a/src/components/nodes/LLMFallbackPopover.tsx
+++ b/src/components/nodes/LLMFallbackPopover.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect } from "react";
-import { createPortal } from "react-dom";
+import { Dialog, DialogBody, DialogButton, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/Dialog";
 import { useWorkflowStore } from "@/store/workflowStore";
 import type {
   LLMGenerateNodeData,
@@ -92,24 +92,17 @@ export function LLMFallbackPopover({ nodeId, onClose }: LLMFallbackPopoverProps)
     onClose();
   };
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60"
-      onClick={onClose}
-    >
-      <div
-        className="w-80 bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl p-4"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2 className="text-sm font-semibold text-neutral-200 mb-3">
-          Select fallback LLM
-        </h2>
-
+  return (
+    <Dialog open onClose={onClose} size="xs" portal>
+      <DialogHeader compact closeButton={false}>
+        <DialogTitle compact>Select fallback LLM</DialogTitle>
+      </DialogHeader>
+      <DialogBody compact>
         <label className="block text-xs text-neutral-400 mb-1">Provider</label>
         <select
           value={provider}
           onChange={(e) => setProvider(e.target.value as LLMProvider)}
-          className="w-full mb-3 px-2 py-1.5 text-sm bg-neutral-800 border border-neutral-700 rounded text-neutral-200 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+          className="w-full mb-3 px-2 py-1.5 text-sm bg-well border border-card-border rounded-well text-neutral-200 focus:outline-none focus:ring-1 focus:ring-neutral-600"
         >
           {LLM_PROVIDERS.map((p) => (
             <option key={p.value} value={p.value}>
@@ -122,7 +115,7 @@ export function LLMFallbackPopover({ nodeId, onClose }: LLMFallbackPopoverProps)
         <select
           value={model}
           onChange={(e) => setModel(e.target.value as LLMModelType)}
-          className="w-full mb-4 px-2 py-1.5 text-sm bg-neutral-800 border border-neutral-700 rounded text-neutral-200 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+          className="w-full mb-1 px-2 py-1.5 text-sm bg-well border border-card-border rounded-well text-neutral-200 focus:outline-none focus:ring-1 focus:ring-neutral-600"
         >
           {LLM_MODELS[provider].map((m) => (
             <option key={m.value} value={m.value}>
@@ -131,30 +124,20 @@ export function LLMFallbackPopover({ nodeId, onClose }: LLMFallbackPopoverProps)
           ))}
         </select>
 
-        <div className="flex items-center justify-between gap-2">
-          <button
-            onClick={handleRemove}
-            className="px-2 py-1 text-xs text-red-400 hover:text-red-300 transition-colors"
-          >
-            Remove fallback
-          </button>
-          <div className="flex gap-2">
-            <button
-              onClick={onClose}
-              className="px-3 py-1 text-xs text-neutral-400 hover:text-neutral-200 transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleSave}
-              className="px-3 py-1 text-xs text-white bg-emerald-600 hover:bg-emerald-500 rounded transition-colors"
-            >
-              Save
-            </button>
-          </div>
+      </DialogBody>
+      <DialogFooter compact className="justify-between">
+        <DialogButton compact variant="danger" onClick={handleRemove}>
+          Remove fallback
+        </DialogButton>
+        <div className="flex gap-1.5">
+          <DialogButton compact variant="ghost" onClick={onClose}>
+            Cancel
+          </DialogButton>
+          <DialogButton compact variant="primary" onClick={handleSave}>
+            Save
+          </DialogButton>
         </div>
-      </div>
-    </div>,
-    document.body
+      </DialogFooter>
+    </Dialog>
   );
 }

--- a/src/components/nodes/OutputGalleryNode.tsx
+++ b/src/components/nodes/OutputGalleryNode.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
-import { createPortal } from "react-dom";
 import { NodeProps, Node, useReactFlow } from "@xyflow/react";
+import { Dialog } from "@/components/ui/Dialog";
 import { NodeShell } from "./NodeShell";
 import { ControlsCard, EmptyState, type SocketSpec } from "./ui";
 import { useWorkflowStore } from "@/store/workflowStore";
@@ -386,14 +386,9 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
         )}
       </NodeShell>
 
-      {/* Lightbox Portal */}
-      {lightboxIndex !== null && currentItem && typeof document !== "undefined" &&
-        createPortal(
-          <div
-            className="fixed inset-0 bg-black/90 z-[100] flex items-center justify-center p-8"
-            onClick={closeLightbox}
-          >
-            <div className="relative max-w-full max-h-full" onClick={(e) => e.stopPropagation()}>
+      {/* Lightbox */}
+      {lightboxIndex !== null && currentItem && (
+        <Dialog open onClose={closeLightbox} variant="lightbox" portal label={`Gallery image ${lightboxIndex + 1}`}>
               {currentItem.type === "video" ? (
                 <LightboxVideo src={currentItem.src} />
               ) : (
@@ -464,10 +459,8 @@ export function OutputGalleryNode({ id, data, selected }: NodeProps<OutputGaller
               <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1.5 bg-black/50 rounded text-white text-xs font-medium">
                 {lightboxIndex + 1} / {displayMedia.length}
               </div>
-            </div>
-          </div>,
-          document.body
-        )}
+        </Dialog>
+      )}
     </>
   );
 }

--- a/src/components/nodes/OutputNode.tsx
+++ b/src/components/nodes/OutputNode.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState, useMemo, useEffect, useRef } from "react";
 import { NodeProps, Node } from "@xyflow/react";
+import { Dialog } from "@/components/ui/Dialog";
 import { NodeShell } from "./NodeShell";
 import { useCommentNavigation } from "@/hooks/useCommentNavigation";
 import { useWorkflowStore } from "@/store/workflowStore";
@@ -176,11 +177,7 @@ export function OutputNode({ id, data, selected }: NodeProps<OutputNodeType>) {
 
       {/* Lightbox Modal (skip for audio) */}
       {showLightbox && contentSrc && !isAudio && (
-        <div
-          className="fixed inset-0 bg-black/90 z-[100] flex items-center justify-center p-8"
-          onClick={() => setShowLightbox(false)}
-        >
-          <div className="relative max-w-full max-h-full">
+        <Dialog open onClose={() => setShowLightbox(false)} variant="lightbox" portal label="Output full size">
             {isVideo ? (
               <video
                 src={videoBlobUrl ?? undefined}
@@ -206,8 +203,7 @@ export function OutputNode({ id, data, selected }: NodeProps<OutputNodeType>) {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
-          </div>
-        </div>
+        </Dialog>
       )}
     </>
   );

--- a/src/components/nodes/OutputNode.tsx
+++ b/src/components/nodes/OutputNode.tsx
@@ -193,6 +193,8 @@ export function OutputNode({ id, data, selected }: NodeProps<OutputNodeType>) {
                 src={contentSrc}
                 alt="Output full size"
                 className="max-w-full max-h-[90vh] object-contain rounded"
+                // A click on the image closes, as it always has; the video keeps its controls
+                onClick={() => setShowLightbox(false)}
               />
             )}
             <button

--- a/src/components/nodes/PromptNode.tsx
+++ b/src/components/nodes/PromptNode.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useCallback, useState, useEffect, useMemo, useRef } from "react";
-import { createPortal } from "react-dom";
 import { NodeProps, Node } from "@xyflow/react";
+import { Dialog, DialogBody, DialogButton, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/Dialog";
 import { NodeShell } from "./NodeShell";
 import { useWorkflowStore } from "@/store/workflowStore";
 import { PromptNodeData } from "@/types";
@@ -133,15 +133,14 @@ export function PromptNode({ id, data, selected }: NodeProps<PromptNodeType>) {
         <HeightGrip height={mediaHeight} onChange={(h) => updateNodeData(id, { mediaHeight: h })} />
       </NodeShell>
 
-      {/* Variable Naming Dialog - rendered via portal */}
-      {showVarDialog && createPortal(
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[9999]">
-          <div className="bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl p-4 w-96">
-            <h3 className="text-sm font-semibold text-neutral-100 mb-3">Set Variable Name</h3>
-            <p className="text-xs text-neutral-400 mb-3">
-              Use this prompt as a variable in PromptConstructor nodes
-            </p>
-            <div className="mb-4">
+      {/* Variable Naming Dialog - on the dialog tier, in a body portal */}
+      <Dialog open={showVarDialog} onClose={() => setShowVarDialog(false)} size="xs" portal>
+          <DialogHeader compact closeButton={false}>
+            <DialogTitle compact>Set Variable Name</DialogTitle>
+            <DialogDescription>Use this prompt as a variable in PromptConstructor nodes</DialogDescription>
+          </DialogHeader>
+          <DialogBody compact>
+            <div className="mb-1">
               <label className="block text-xs text-neutral-300 mb-1">Variable name</label>
               <input
                 type="text"
@@ -153,7 +152,7 @@ export function PromptNode({ id, data, selected }: NodeProps<PromptNodeType>) {
                   }
                 }}
                 placeholder="e.g. color, style, subject"
-                className="w-full px-3 py-2 text-sm text-neutral-100 bg-neutral-900 border border-neutral-700 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full px-2.5 py-1.5 text-[13px] text-neutral-100 bg-well border border-card-border rounded-well focus:outline-none focus:border-selection"
                 autoFocus
               />
               {varNameInput && (
@@ -162,33 +161,21 @@ export function PromptNode({ id, data, selected }: NodeProps<PromptNodeType>) {
                 </div>
               )}
             </div>
-            <div className="flex gap-2 justify-end">
-              {nodeData.variableName && (
-                <button
-                  onClick={handleClearVariableName}
-                  className="px-3 py-1.5 text-xs font-medium text-red-400 hover:text-red-300 hover:bg-red-900/30 rounded transition-colors"
-                >
-                  Clear
-                </button>
-              )}
-              <button
-                onClick={() => setShowVarDialog(false)}
-                className="px-3 py-1.5 text-xs font-medium text-neutral-400 hover:text-neutral-300 hover:bg-neutral-700 rounded transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSaveVariableName}
-                disabled={!varNameInput}
-                className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
+          </DialogBody>
+          <DialogFooter compact>
+            {nodeData.variableName && (
+              <DialogButton compact variant="danger" onClick={handleClearVariableName} className="mr-auto">
+                Clear
+              </DialogButton>
+            )}
+            <DialogButton compact variant="ghost" onClick={() => setShowVarDialog(false)}>
+              Cancel
+            </DialogButton>
+            <DialogButton compact variant="primary" onClick={handleSaveVariableName} disabled={!varNameInput}>
+              Save
+            </DialogButton>
+          </DialogFooter>
+      </Dialog>
     </>
   );
 }

--- a/src/components/nodes/ui/cn.ts
+++ b/src/components/nodes/ui/cn.ts
@@ -12,7 +12,7 @@ const twMerge = extendTailwindMerge({
     classGroups: {
       "font-size": [{ text: ["node"] }],
       rounded: [{ rounded: ["card", "media", "controls", "well"] }],
-      shadow: [{ shadow: ["well"] }],
+      shadow: [{ shadow: ["well", "menu", "dialog"] }],
     },
   },
 });

--- a/src/components/onboarding/FTUXModal.tsx
+++ b/src/components/onboarding/FTUXModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Dialog, DialogButton, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/Dialog";
 import { useState } from "react";
 import { FTUXModalProps, FTUXStep } from "@/types/ftux";
 import { setFTUXCompleted } from "@/store/utils/localStorage";
@@ -59,45 +60,35 @@ export function FTUXModal({ onComplete, onStartTutorial }: FTUXModalProps) {
   };
 
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
-      onWheelCapture={(e) => e.stopPropagation()}
+    <Dialog
+      open
+      label={currentStep === 4 ? "Ready" : undefined}
+      className={`w-full ${currentStep === 4 ? "max-w-[420px]" : "max-w-[640px] max-h-[80vh]"}`}
     >
-      <div className={`relative bg-neutral-800 rounded-xl w-full ${currentStep === 4 ? 'max-w-[420px]' : 'max-w-[640px]'} mx-4 border border-neutral-700 shadow-2xl overflow-clip flex flex-col ${currentStep === 4 ? '' : 'max-h-[80vh]'}`}>
         {/* Header */}
         {currentStep !== 4 && (
-          <div className="px-8 pt-8 pb-4 border-b border-neutral-700/50 shrink-0">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <img src="/banana_icon.png" alt="" className="w-6 h-6" />
-                <h2 className="text-xl font-medium text-neutral-100">
-                  Welcome to Node Banana
-                </h2>
-              </div>
-              <button
-                type="button"
-                onClick={() => setShowSkipConfirm(true)}
-                className="text-neutral-400 hover:text-neutral-100 transition-colors"
-                aria-label="Close"
-              >
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
+          <div className="shrink-0 border-b border-chrome-border/50">
+            <DialogHeader
+              icon={<img src="/banana_icon.png" alt="" className="w-5 h-5" />}
+              actions={
+                <button
+                  type="button"
+                  onClick={() => setShowSkipConfirm(true)}
+                  className="w-7 h-7 flex items-center justify-center rounded-md text-neutral-500 hover:text-neutral-200 hover:bg-neutral-700/50 transition-colors"
+                  aria-label="Close"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              }
+              className="pb-3"
+            >
+              <DialogTitle>Welcome to Node Banana</DialogTitle>
+            </DialogHeader>
 
             {/* Step indicators */}
-            <div className="flex gap-2 mt-4">
+            <div className="flex gap-2 px-5 pb-4">
               {([1, 2, 3, 4] as const).map((step) => (
                 <div
                   key={step}
@@ -125,57 +116,42 @@ export function FTUXModal({ onComplete, onStartTutorial }: FTUXModalProps) {
 
         {/* Footer */}
         {currentStep !== 4 && (
-          <div className="flex justify-between gap-2 px-8 py-5 border-t border-neutral-700/50 shrink-0">
-            <button
-              type="button"
+          <DialogFooter className="justify-between">
+            <DialogButton
+              variant="ghost"
               onClick={handleBack}
               disabled={currentStep === 1}
-              className={`px-4 py-2 text-sm text-neutral-400 hover:text-neutral-100 transition-all ${
-                currentStep === 1 ? "opacity-0 pointer-events-none" : ""
-              }`}
+              className={currentStep === 1 ? "opacity-0 pointer-events-none" : ""}
             >
               Back
-            </button>
-            <button
-              type="button"
-              onClick={handleNext}
-              className="px-4 py-2 text-sm bg-white text-neutral-900 rounded-lg hover:bg-neutral-200 transition-colors font-medium"
-            >
+            </DialogButton>
+            <DialogButton variant="primary" onClick={handleNext}>
               {getButtonText()}
-            </button>
-          </div>
+            </DialogButton>
+          </DialogFooter>
         )}
 
         {/* Skip confirmation dialog */}
         {showSkipConfirm && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/40 z-10">
-            <div className="bg-neutral-800 rounded-xl p-6 border border-neutral-700 shadow-2xl max-w-sm mx-4">
-              <h3 className="text-lg font-semibold text-neutral-100 mb-2">
+          <div className="absolute inset-0 flex items-center justify-center bg-scrim z-10">
+            <div className="bg-card rounded-card p-5 border border-chrome-border shadow-dialog max-w-sm mx-4">
+              <h3 className="text-base font-semibold text-neutral-100 mb-1">
                 Skip setup?
               </h3>
-              <p className="text-sm text-neutral-400 mb-4">
+              <p className="text-[13px] text-neutral-400 mb-4">
                 You can configure API keys and model defaults later in settings.
               </p>
               <div className="flex gap-2 justify-end">
-                <button
-                  type="button"
-                  onClick={() => setShowSkipConfirm(false)}
-                  className="px-4 py-2 text-sm text-neutral-400 hover:text-neutral-100 transition-colors"
-                >
+                <DialogButton variant="ghost" onClick={() => setShowSkipConfirm(false)}>
                   Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={handleSkip}
-                  className="px-4 py-2 text-sm bg-white text-neutral-900 rounded-lg hover:bg-neutral-200 transition-colors"
-                >
+                </DialogButton>
+                <DialogButton variant="primary" onClick={handleSkip}>
                   Skip
-                </button>
+                </DialogButton>
               </div>
             </div>
           </div>
         )}
-      </div>
-    </div>
+    </Dialog>
   );
 }

--- a/src/components/quickstart/WelcomeModal.tsx
+++ b/src/components/quickstart/WelcomeModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Dialog } from "@/components/ui/Dialog";
 import { useState, useCallback } from "react";
 import { WorkflowFile } from "@/store/workflowStore";
 import { QuickstartView } from "@/types/quickstart";
@@ -53,12 +54,7 @@ export function WelcomeModal({
   const dialogHeight = currentView === "templates" || currentView === "browse" ? "max-h-[85vh]" : "max-h-[80vh]";
 
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
-      onWheelCapture={(e) => e.stopPropagation()}
-      onClick={onClose}
-    >
-      <div className={`w-full ${dialogWidth} mx-4 bg-neutral-800 rounded-xl border border-neutral-700 shadow-2xl overflow-clip ${dialogHeight} flex flex-col`} onClick={(e) => e.stopPropagation()}>
+    <Dialog open onClose={onClose} label="Welcome" className={`w-full ${dialogWidth} ${dialogHeight}`}>
         {currentView === "initial" && (
           <QuickstartInitialView
             onNewProject={handleNewProject}
@@ -88,7 +84,6 @@ export function WelcomeModal({
             onClose={onClose}
           />
         )}
-      </div>
-    </div>
+    </Dialog>
   );
 }

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -10,8 +10,17 @@
  * group per cell.
  */
 
+import {
+  Dialog,
+  DialogButton,
+  DialogCloseButton,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/Dialog";
+import { MenuHeader, MenuIconButton, MenuItem, MenuList, MenuSectionLabel, MenuSurface } from "@/components/ui/Menu";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -299,39 +308,35 @@ function TemplateConnectionMenu({
   if (options.length === 0) return null;
 
   return (
-    <div
+    <MenuSurface
       ref={menuRef}
       tabIndex={-1}
-      className="fixed z-[110] bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl overflow-hidden min-w-[160px] outline-none"
+      // Inside the dialog's own stacking context, so any positive value sits
+      // above the mini canvas
+      className="z-[110]"
       style={{
         left: menu.screen.x,
         top: menu.screen.y,
         transform: "translate(-50%, -50%)",
       }}
     >
-      <div className="px-2 py-1.5 border-b border-neutral-700">
-        <span className="text-[10px] text-neutral-400 uppercase tracking-wide">
-          Add {menu.fromHandleId} node
-        </span>
-      </div>
-      <div className="py-1">
+      <MenuHeader>
+        <MenuSectionLabel>Add {menu.fromHandleId} node</MenuSectionLabel>
+      </MenuHeader>
+      <MenuList>
         {options.map((option, index) => (
-          <button
+          <MenuItem
             key={option.type}
+            selected={index === selectedIndex}
             onClick={() => onSelect(option.type)}
             onMouseEnter={() => setSelectedIndex(index)}
-            className={`w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 transition-colors ${
-              index === selectedIndex
-                ? "bg-neutral-700 text-neutral-100"
-                : "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100"
-            }`}
           >
             {getTemplateNodeIcon(option.type)}
             {option.label}
-          </button>
+          </MenuItem>
         ))}
-      </div>
-    </div>
+      </MenuList>
+    </MenuSurface>
   );
 }
 
@@ -344,8 +349,6 @@ interface SplitGridTemplateModalProps {
 function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTemplateModalProps) {
   const materializeSplitGridCells = useWorkflowStore((state) => state.materializeSplitGridCells);
   const isRunning = useWorkflowStore((state) => state.isRunning);
-  const incrementModalCount = useWorkflowStore((state) => state.incrementModalCount);
-  const decrementModalCount = useWorkflowStore((state) => state.decrementModalCount);
   const canvasNavigationSettings = useWorkflowStore((state) => state.canvasNavigationSettings);
 
   // Match the main canvas's wheel navigation (scroll-to-pan when zoomMode is
@@ -388,10 +391,6 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
   }, [fitView]);
 
   // Freeze the main canvas while the editor is open
-  useEffect(() => {
-    incrementModalCount();
-    return () => decrementModalCount();
-  }, [incrementModalCount, decrementModalCount]);
 
   // Track the canvas wrapper size so the fixed rail can be placed + hit-tested
   useEffect(() => {
@@ -774,39 +773,48 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
     onClose();
   }, [isRunning, baseNodeId, rfNodes, rfEdges, routerWires, nodeId, materializeSplitGridCells, onClose]);
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
-      // Bubble-phase (not capture): the mini-canvas's native wheel-to-pan
-      // listener on the wrapper must run first; we still stop the wheel from
-      // leaking to the frozen main canvas behind the modal.
-      onWheel={(event) => event.stopPropagation()}
-      onPointerDown={(event) => {
-        backdropPointerDownRef.current = event.target === event.currentTarget;
-      }}
-      onClick={(event) => {
-        if (event.target === event.currentTarget && backdropPointerDownRef.current) {
-          requestClose();
-        }
-        backdropPointerDownRef.current = false;
+  return (
+    <Dialog
+      open
+      onClose={requestClose}
+      // Escape and the backdrop have their own rules here: Escape closes a
+      // menu or toolbar first, and a drag that ends on the backdrop is not a
+      // click. Both stay with this component.
+      closeOnEscape={false}
+      closeOnBackdrop={false}
+      stopWheel={false}
+      portal
+      labelledBy="split-grid-title"
+      className="w-[min(1080px,94vw)] h-[min(720px,88vh)] max-h-none"
+      overlayProps={{
+        // Bubble-phase (not capture): the mini-canvas's native wheel-to-pan
+        // listener on the wrapper must run first; we still stop the wheel from
+        // leaking to the frozen main canvas behind the modal.
+        onWheel: (event) => event.stopPropagation(),
+        onPointerDown: (event) => {
+          backdropPointerDownRef.current = event.target === event.currentTarget;
+        },
+        onClick: (event) => {
+          if (event.target === event.currentTarget && backdropPointerDownRef.current) {
+            requestClose();
+          }
+          backdropPointerDownRef.current = false;
+        },
       }}
     >
-      <div className="relative w-[min(1080px,94vw)] h-[min(720px,88vh)] bg-neutral-800 rounded-xl border border-neutral-700 shadow-2xl overflow-clip flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between gap-4 px-5 py-3.5 border-b border-neutral-700/60 shrink-0">
-          <div className="min-w-0">
-            <h2 className="text-base font-semibold text-neutral-100">Cell Node Set</h2>
-            <p className="text-xs text-neutral-500 mt-0.5 truncate">
-              These nodes are created for every split image and grouped per cell
-            </p>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <span className="text-[10px] font-semibold text-neutral-500 uppercase tracking-wider">
+        <DialogHeader
+          divider
+          closeButton={false}
+          className="pb-2.5"
+          actions={
+            <>
+            <span className="text-[10px] font-semibold text-neutral-500 uppercase tracking-wider mr-1">
               Presets
             </span>
             <button
               onClick={() => applyPreset(createDefaultSplitGridTemplate())}
-              className="px-2.5 py-1.5 text-xs text-neutral-400 hover:text-neutral-100 bg-neutral-900 border border-neutral-700 hover:border-neutral-500 rounded-md transition-colors"
+              className="h-7 px-2.5 text-xs text-neutral-400 hover:text-neutral-100 bg-well border border-chrome-border hover:border-neutral-500 rounded-md transition-colors"
             >
               Image only
             </button>
@@ -816,25 +824,25 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
                   createClassicSplitGridTemplate(nodeData.defaultPrompt, nodeData.generateSettings)
                 )
               }
-              className="px-2.5 py-1.5 text-xs text-neutral-400 hover:text-neutral-100 bg-neutral-900 border border-neutral-700 hover:border-neutral-500 rounded-md transition-colors"
+              className="h-7 px-2.5 text-xs text-neutral-400 hover:text-neutral-100 bg-well border border-chrome-border hover:border-neutral-500 rounded-md transition-colors"
             >
               Prompt + Generate
             </button>
-            <div className="w-px h-6 bg-neutral-700 mx-1" />
-            <button
-              onClick={requestClose}
-              className="p-1.5 text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700 rounded transition-colors"
-              aria-label="Close"
-            >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        </div>
+            <div className="w-px h-4 bg-neutral-600 mx-1" />
+            <DialogCloseButton />
+            </>
+          }
+        >
+          <DialogTitle>
+            <span id="split-grid-title">Cell Node Set</span>
+          </DialogTitle>
+          <DialogDescription className="truncate">
+            These nodes are created for every split image and grouped per cell
+          </DialogDescription>
+        </DialogHeader>
 
         {/* Mini canvas */}
-        <div ref={canvasWrapperRef} className="flex-1 min-h-0 relative bg-neutral-900">
+        <div ref={canvasWrapperRef} className="flex-1 min-h-0 relative bg-well">
           {/* Router wires render BEHIND the canvas so nodes occlude them, like
               normal edges (the pane is transparent, so they show in the gaps) */}
           <RouterWires wires={routerWires} nodes={rfNodes} size={wrapperSize} />
@@ -891,14 +899,15 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
           {/* Floating delete toolbar — same look/behavior as the main canvas
               EdgeToolbar, minus pause (cells run in one shot) */}
           {edgeToolbar && (
-            <div
+            <MenuSurface
+              variant="bar"
               data-edge-toolbar
-              className="fixed z-[110] flex items-center gap-1 bg-neutral-800 border border-neutral-600 rounded-lg shadow-xl p-1"
+              className="z-[110]"
               style={{ left: edgeToolbar.x, top: edgeToolbar.y, transform: "translateX(-50%)" }}
             >
-              <button
+              <MenuIconButton
                 onClick={handleToolbarDelete}
-                className="p-1.5 rounded hover:bg-neutral-700 text-neutral-400 hover:text-red-400 transition-colors"
+                className="hover:text-red-400"
                 title="Delete"
                 aria-label="Delete connection"
               >
@@ -909,13 +918,13 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
                     d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
                   />
                 </svg>
-              </button>
-            </div>
+              </MenuIconButton>
+            </MenuSurface>
           )}
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between gap-4 px-5 py-3.5 border-t border-neutral-700/50 shrink-0">
+        <DialogFooter className="justify-between gap-4">
           <div className="text-xs text-neutral-500 min-w-0">
             <span>
               {perCellNodeCount} node{perCellNodeCount === 1 ? "" : "s"} per cell · {nodeData.gridRows}×{nodeData.gridCols} grid → {cellCount} group{cellCount === 1 ? "" : "s"}
@@ -927,51 +936,40 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
             ))}
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            <button
-              onClick={requestClose}
-              className="px-4 py-2 text-sm text-neutral-400 hover:text-neutral-100 transition-colors"
-            >
+            <DialogButton variant="ghost" onClick={requestClose}>
               Cancel
-            </button>
-            <button
+            </DialogButton>
+            <DialogButton
+              variant="primary"
               onClick={handleApply}
               disabled={isRunning}
               title={isRunning ? "Wait for the current run to finish" : undefined}
-              className="px-4 py-2 text-sm bg-white text-neutral-900 rounded-lg hover:bg-neutral-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               Apply to {cellCount} cell{cellCount === 1 ? "" : "s"}
-            </button>
+            </DialogButton>
           </div>
-        </div>
+        </DialogFooter>
 
         {/* Discard-changes confirmation */}
         {showDiscardConfirm && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/60">
-            <div className="bg-neutral-800 border border-neutral-600 rounded-lg p-5 mx-4 max-w-sm shadow-xl">
-              <h3 className="text-sm font-semibold text-neutral-100">Discard changes?</h3>
-              <p className="text-xs text-neutral-400 mt-1">
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-scrim">
+            <div className="bg-card border border-chrome-border rounded-card p-5 mx-4 max-w-sm shadow-dialog">
+              <h3 className="text-base font-semibold text-neutral-100">Discard changes?</h3>
+              <p className="text-[13px] text-neutral-400 mt-1">
                 Your edits to the cell node set haven&apos;t been applied.
               </p>
               <div className="flex justify-end gap-2 mt-4">
-                <button
-                  onClick={() => setShowDiscardConfirm(false)}
-                  className="px-3 py-1.5 text-xs font-medium text-neutral-300 bg-neutral-700 hover:bg-neutral-600 rounded transition-colors"
-                >
+                <DialogButton variant="secondary" onClick={() => setShowDiscardConfirm(false)}>
                   Keep editing
-                </button>
-                <button
-                  onClick={onClose}
-                  className="px-3 py-1.5 text-xs font-medium text-red-400 hover:text-red-300 hover:bg-red-900/30 rounded transition-colors"
-                >
+                </DialogButton>
+                <DialogButton variant="danger" onClick={onClose}>
                   Discard
-                </button>
+                </DialogButton>
               </div>
             </div>
           </div>
         )}
-      </div>
-    </div>,
-    document.body
+    </Dialog>
   );
 }
 

--- a/src/components/splitgrid/SplitGridTemplateModal.tsx
+++ b/src/components/splitgrid/SplitGridTemplateModal.tsx
@@ -784,7 +784,6 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
       closeOnBackdrop={false}
       stopWheel={false}
       portal
-      labelledBy="split-grid-title"
       className="w-[min(1080px,94vw)] h-[min(720px,88vh)] max-h-none"
       overlayProps={{
         // Bubble-phase (not capture): the mini-canvas's native wheel-to-pan
@@ -833,9 +832,7 @@ function SplitGridTemplateModalInner({ nodeId, nodeData, onClose }: SplitGridTem
             </>
           }
         >
-          <DialogTitle>
-            <span id="split-grid-title">Cell Node Set</span>
-          </DialogTitle>
+          <DialogTitle>Cell Node Set</DialogTitle>
           <DialogDescription className="truncate">
             These nodes are created for every split image and grouped per cell
           </DialogDescription>

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -31,8 +31,9 @@ import { cn } from "@/components/nodes/ui/cn";
  * - Body scroll is locked, wheel events do not reach the canvas, and the
  *   store's modal count is held so canvas shortcuts stay off.
  *
- * Nothing about *what* a dialog does lives here: content, actions and data
- * flow are the caller's. Pass `onClose` undefined to make a dialog
+ * The scale is the compact one from the design canvas: 20px sides, 32px
+ * footer buttons at 13px, a 16px semibold title. Nothing about *what* a
+ * dialog does lives here: content, actions and data flow are the caller's. Pass `onClose` undefined to make a dialog
  * undismissable (no Escape, no backdrop click), as the onboarding flow is.
  */
 
@@ -91,12 +92,28 @@ export interface DialogProps {
   closeOnEscape?: boolean;
   /** Put focus here on open instead of the first focusable element. */
   initialFocusRef?: RefObject<HTMLElement | null>;
-  /** Render inline (inside the caller's tree) rather than in a body portal. */
+  /**
+   * Render in a body portal. Off by default: top-level dialogs mount inline
+   * where they are used, as they always have; node-local dialogs turn this on
+   * so they escape the canvas's transformed stacking context.
+   */
   portal?: boolean;
   /** Extra classes on the panel — width, height, transitions. */
   className?: string;
   /** Extra classes on the backdrop (the `fixed inset-0` layer). */
   overlayClassName?: string;
+  /**
+   * Handlers on the backdrop, for a dialog with its own rules about what a
+   * backdrop click means (the split-grid editor: a drag that ends outside
+   * the panel is not a click).
+   */
+  overlayProps?: HTMLAttributes<HTMLDivElement>;
+  /**
+   * Stop wheel events in the capture phase so the canvas behind never scrolls.
+   * Off for a dialog whose own content has native wheel listeners that must
+   * run first (the split-grid mini canvas); it then stops the bubble itself.
+   */
+  stopWheel?: boolean;
   /** `aria-labelledby` target when the title is not a `<DialogTitle>`. */
   labelledBy?: string;
   /** `aria-label` when the dialog has no visible title. */
@@ -114,9 +131,11 @@ export function Dialog({
   closeOnBackdrop = onClose !== undefined,
   closeOnEscape = onClose !== undefined,
   initialFocusRef,
-  portal = true,
+  portal = false,
   className,
   overlayClassName,
+  overlayProps,
+  stopWheel = true,
   labelledBy,
   label,
   panelProps,
@@ -135,14 +154,15 @@ export function Dialog({
   const decrementModalCount = useWorkflowStore((state) => state.decrementModalCount);
 
   // Canvas shortcuts (delete, pan, zoom) are off while any dialog is open.
+  // Optional calls: component tests stub the store with a bare state object.
   useEffect(() => {
     if (!open) return;
-    incrementModalCount();
+    incrementModalCount?.();
     const overlay = overlayRef.current;
     if (overlay) openOverlays.add(overlay);
     return () => {
       if (overlay) openOverlays.delete(overlay);
-      decrementModalCount();
+      decrementModalCount?.();
     };
   }, [open, incrementModalCount, decrementModalCount]);
 
@@ -223,15 +243,20 @@ export function Dialog({
   const node = (
     <DialogContext.Provider value={{ titleId, onClose }}>
       <div
+        {...overlayProps}
         ref={overlayRef}
         data-dialog-overlay=""
         className={cn(
           "fixed inset-0 z-100 flex items-center justify-center animate-dialog-backdrop",
           isLightbox ? "bg-scrim-heavy p-8" : "bg-scrim",
-          overlayClassName
+          overlayClassName,
+          overlayProps?.className
         )}
-        onClick={onBackdropClick}
-        onWheelCapture={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          onBackdropClick(event);
+          overlayProps?.onClick?.(event);
+        }}
+        onWheelCapture={stopWheel ? (event) => event.stopPropagation() : overlayProps?.onWheelCapture}
       >
         <div
           {...panelProps}
@@ -297,12 +322,12 @@ export function DialogHeader({
     <div
       className={cn(
         "flex items-start gap-3 shrink-0",
-        compact ? "px-5 pt-4 pb-1" : "px-6 pt-5 pb-4",
+        compact ? "px-4 pt-3 pb-1" : "px-5 pt-3.5 pb-2.5",
         divider && "border-b border-chrome-border/50",
         className
       )}
     >
-      {icon && <div className="shrink-0 flex items-center h-6">{icon}</div>}
+      {icon && <div className="shrink-0 flex items-center h-6 [&>*]:w-5 [&>*]:h-5">{icon}</div>}
       <div className="flex-1 min-w-0 flex flex-col gap-0.5">{children}</div>
       {(actions || showClose) && (
         <div className="shrink-0 flex items-center gap-1 -my-0.5">
@@ -329,7 +354,7 @@ export function DialogTitle({
       id={titleId}
       className={cn(
         "font-semibold text-neutral-100 truncate",
-        compact ? "text-sm leading-5" : "text-base leading-6",
+        compact ? "text-[13px] leading-5" : "text-base leading-6",
         className
       )}
     >
@@ -350,7 +375,7 @@ export function DialogCloseButton({ className, label = "Close" }: { className?: 
       onClick={onClose}
       aria-label={label}
       className={cn(
-        "w-7 h-7 flex items-center justify-center rounded-lg text-neutral-500 hover:text-neutral-200 hover:bg-neutral-700/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-selection",
+        "w-7 h-7 flex items-center justify-center rounded-md text-neutral-500 hover:text-neutral-200 hover:bg-neutral-700/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-selection",
         className
       )}
     >
@@ -374,7 +399,7 @@ export function DialogBody({
       className={cn(
         "flex-1 min-h-0",
         scroll && "overflow-y-auto",
-        compact ? "px-5 py-2" : "px-6 py-4",
+        compact ? "px-4 py-2" : "px-5 py-3",
         className
       )}
     >
@@ -398,7 +423,7 @@ export function DialogFooter({
     <div
       className={cn(
         "flex items-center justify-end gap-2 shrink-0",
-        compact ? "px-5 py-3" : "px-6 py-4",
+        compact ? "px-4 py-2.5" : "px-5 py-3",
         divider && "border-t border-chrome-border/50",
         className
       )}
@@ -450,7 +475,7 @@ export function DialogButton({
         "inline-flex items-center justify-center font-medium rounded-lg transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-selection focus-visible:ring-offset-2 focus-visible:ring-offset-card",
         "disabled:opacity-50 disabled:cursor-not-allowed",
-        compact ? "h-[30px] px-3 text-xs" : "h-9 px-4 text-sm",
+        compact ? "h-7 px-2.5 text-xs" : "h-8 px-3.5 text-[13px]",
         BUTTON_VARIANT[variant],
         className
       )}

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { useWorkflowStore } from "@/store/workflowStore";
+import { cn } from "@/components/nodes/ui/cn";
+
+/**
+ * The one dialog shell. Every modal in the app — settings, editors, the
+ * welcome screen, node-local popovers, lightboxes — is this scrim and this
+ * panel, so they share a surface, a radius, a type scale and one set of
+ * keyboard rules:
+ *
+ * - Escape closes, from anywhere in the document (nested inputs included).
+ * - Tab cycles inside the panel; focus lands in the panel on open and goes
+ *   back to whatever opened it on close.
+ * - Body scroll is locked, wheel events do not reach the canvas, and the
+ *   store's modal count is held so canvas shortcuts stay off.
+ *
+ * Nothing about *what* a dialog does lives here: content, actions and data
+ * flow are the caller's. Pass `onClose` undefined to make a dialog
+ * undismissable (no Escape, no backdrop click), as the onboarding flow is.
+ */
+
+type DialogSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+/** Widths, matching what the dialogs used before they shared a shell. */
+const SIZE_CLASS: Record<DialogSize, string> = {
+  xs: "w-80",
+  sm: "w-[400px]",
+  md: "w-[580px]",
+  lg: "w-full max-w-3xl",
+  xl: "w-full max-w-5xl",
+};
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+interface DialogContextValue {
+  titleId: string;
+  onClose?: () => void;
+}
+
+const DialogContext = createContext<DialogContextValue>({ titleId: "" });
+
+/**
+ * Every open dialog's overlay. Escape is a document-level listener so it
+ * works from any focused input, which means every open dialog hears it —
+ * only the one on top may act, or closing a model picker would also close
+ * the settings it was opened from. "On top" is document order: overlays
+ * share a z-index, so the one painted last is the one the user sees.
+ */
+const openOverlays = new Set<HTMLElement>();
+
+function topmostOverlay(): HTMLElement | null {
+  let top: HTMLElement | null = null;
+  for (const overlay of openOverlays) {
+    if (!overlay.isConnected) continue;
+    if (!top || top.compareDocumentPosition(overlay) & Node.DOCUMENT_POSITION_FOLLOWING) {
+      top = overlay;
+    }
+  }
+  return top;
+}
+
+export interface DialogProps {
+  open: boolean;
+  /** Absent: the dialog cannot be dismissed by Escape or the backdrop. */
+  onClose?: () => void;
+  /** Preset width; `className` on the panel overrides it. */
+  size?: DialogSize;
+  /** Heavier scrim and no panel chrome — the media lightboxes. */
+  variant?: "panel" | "lightbox";
+  /** Close when the backdrop itself is clicked. Defaults to on when `onClose` is given. */
+  closeOnBackdrop?: boolean;
+  /** Escape closes. Defaults to on when `onClose` is given. */
+  closeOnEscape?: boolean;
+  /** Put focus here on open instead of the first focusable element. */
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  /** Render inline (inside the caller's tree) rather than in a body portal. */
+  portal?: boolean;
+  /** Extra classes on the panel — width, height, transitions. */
+  className?: string;
+  /** Extra classes on the backdrop (the `fixed inset-0` layer). */
+  overlayClassName?: string;
+  /** `aria-labelledby` target when the title is not a `<DialogTitle>`. */
+  labelledBy?: string;
+  /** `aria-label` when the dialog has no visible title. */
+  label?: string;
+  /** Marker attributes for tests and tutorials on the panel. */
+  panelProps?: HTMLAttributes<HTMLDivElement>;
+  children: ReactNode;
+}
+
+export function Dialog({
+  open,
+  onClose,
+  size = "md",
+  variant = "panel",
+  closeOnBackdrop = onClose !== undefined,
+  closeOnEscape = onClose !== undefined,
+  initialFocusRef,
+  portal = true,
+  className,
+  overlayClassName,
+  labelledBy,
+  label,
+  panelProps,
+  children,
+}: DialogProps) {
+  const generatedTitleId = useId();
+  const titleId = labelledBy ?? generatedTitleId;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  // The element that had focus when the dialog opened — it gets focus back.
+  const openerRef = useRef<HTMLElement | null>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  const incrementModalCount = useWorkflowStore((state) => state.incrementModalCount);
+  const decrementModalCount = useWorkflowStore((state) => state.decrementModalCount);
+
+  // Canvas shortcuts (delete, pan, zoom) are off while any dialog is open.
+  useEffect(() => {
+    if (!open) return;
+    incrementModalCount();
+    const overlay = overlayRef.current;
+    if (overlay) openOverlays.add(overlay);
+    return () => {
+      if (overlay) openOverlays.delete(overlay);
+      decrementModalCount();
+    };
+  }, [open, incrementModalCount, decrementModalCount]);
+
+  // Scroll lock on the document; the canvas behind must not move.
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  // Focus in on open, back to the opener on close.
+  useEffect(() => {
+    if (!open) return;
+    openerRef.current = document.activeElement as HTMLElement | null;
+    const frame = requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      if (!panel) return;
+      const preferred = initialFocusRef?.current;
+      const target =
+        preferred ?? panel.querySelector<HTMLElement>("[autofocus]") ?? panel;
+      // A caller's autoFocus element may already have taken focus.
+      if (!panel.contains(document.activeElement)) target.focus();
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      const opener = openerRef.current;
+      if (opener && opener.isConnected && typeof opener.focus === "function") {
+        opener.focus();
+      }
+    };
+    // initialFocusRef is a ref object; its identity is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Escape closes from anywhere, so a focused input inside still dismisses.
+  useEffect(() => {
+    if (!open || !closeOnEscape) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      if (topmostOverlay() !== overlayRef.current) return;
+      event.preventDefault();
+      onCloseRef.current?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, closeOnEscape]);
+
+  const trapFocus = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Tab" || !panelRef.current) return;
+    const focusable = panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusable[0]!;
+    const last = focusable[focusable.length - 1]!;
+    const active = document.activeElement;
+    if (event.shiftKey && (active === first || active === panelRef.current)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }, []);
+
+  const onBackdropClick = (event: ReactMouseEvent<HTMLDivElement>) => {
+    if (closeOnBackdrop && event.target === event.currentTarget) onClose?.();
+  };
+
+  if (!open) return null;
+
+  const isLightbox = variant === "lightbox";
+
+  const node = (
+    <DialogContext.Provider value={{ titleId, onClose }}>
+      <div
+        ref={overlayRef}
+        data-dialog-overlay=""
+        className={cn(
+          "fixed inset-0 z-100 flex items-center justify-center animate-dialog-backdrop",
+          isLightbox ? "bg-scrim-heavy p-8" : "bg-scrim",
+          overlayClassName
+        )}
+        onClick={onBackdropClick}
+        onWheelCapture={(event) => event.stopPropagation()}
+      >
+        <div
+          {...panelProps}
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={label ? undefined : titleId}
+          aria-label={label}
+          tabIndex={-1}
+          className={cn(
+            "relative focus:outline-none animate-dialog-panel",
+            isLightbox
+              ? "max-w-full max-h-full"
+              : "flex flex-col bg-card border border-chrome-border rounded-card shadow-dialog overflow-clip max-h-[85vh] mx-4",
+            !isLightbox && SIZE_CLASS[size],
+            className,
+            panelProps?.className
+          )}
+          onKeyDown={(event) => {
+            trapFocus(event);
+            panelProps?.onKeyDown?.(event);
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </DialogContext.Provider>
+  );
+
+  if (!portal || typeof document === "undefined") return node;
+  return createPortal(node, document.body);
+}
+
+/* ---------------------------------------------------------------- pieces */
+
+interface DialogHeaderProps {
+  /** Small mark before the title (the banana, the Comfy logo). */
+  icon?: ReactNode;
+  /** Right-hand slot next to the close button (badges, help toggles). */
+  actions?: ReactNode;
+  /** Show the close button. Defaults to on when the dialog has `onClose`. */
+  closeButton?: boolean;
+  /** Separate the header from the body with a rule. */
+  divider?: boolean;
+  /** Tight spacing for the xs popover dialogs. */
+  compact?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+export function DialogHeader({
+  icon,
+  actions,
+  closeButton,
+  divider = false,
+  compact = false,
+  className,
+  children,
+}: DialogHeaderProps) {
+  const { onClose } = useContext(DialogContext);
+  const showClose = closeButton ?? onClose !== undefined;
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-3 shrink-0",
+        compact ? "px-5 pt-4 pb-1" : "px-6 pt-5 pb-4",
+        divider && "border-b border-chrome-border/50",
+        className
+      )}
+    >
+      {icon && <div className="shrink-0 flex items-center h-6">{icon}</div>}
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5">{children}</div>
+      {(actions || showClose) && (
+        <div className="shrink-0 flex items-center gap-1 -my-0.5">
+          {actions}
+          {showClose && <DialogCloseButton />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DialogTitle({
+  compact = false,
+  className,
+  children,
+}: {
+  compact?: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  const { titleId } = useContext(DialogContext);
+  return (
+    <h2
+      id={titleId}
+      className={cn(
+        "font-semibold text-neutral-100 truncate",
+        compact ? "text-sm leading-5" : "text-base leading-6",
+        className
+      )}
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function DialogDescription({ className, children }: { className?: string; children: ReactNode }) {
+  return <p className={cn("text-xs leading-4 text-neutral-400", className)}>{children}</p>;
+}
+
+export function DialogCloseButton({ className, label = "Close" }: { className?: string; label?: string }) {
+  const { onClose } = useContext(DialogContext);
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label={label}
+      className={cn(
+        "w-7 h-7 flex items-center justify-center rounded-lg text-neutral-500 hover:text-neutral-200 hover:bg-neutral-700/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-selection",
+        className
+      )}
+    >
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  );
+}
+
+export function DialogBody({
+  compact = false,
+  scroll = true,
+  className,
+  children,
+  ...rest
+}: HTMLAttributes<HTMLDivElement> & { compact?: boolean; scroll?: boolean }) {
+  return (
+    <div
+      {...rest}
+      className={cn(
+        "flex-1 min-h-0",
+        scroll && "overflow-y-auto",
+        compact ? "px-5 py-2" : "px-6 py-4",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DialogFooter({
+  compact = false,
+  divider = true,
+  className,
+  children,
+}: {
+  compact?: boolean;
+  divider?: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-end gap-2 shrink-0",
+        compact ? "px-5 py-3" : "px-6 py-4",
+        divider && "border-t border-chrome-border/50",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Uppercase label above a group of fields or rows inside a dialog body. */
+export function DialogSectionHeader({ className, children }: { className?: string; children: ReactNode }) {
+  return (
+    <h3 className={cn("text-[11px] font-semibold uppercase tracking-wider text-neutral-500", className)}>
+      {children}
+    </h3>
+  );
+}
+
+/* --------------------------------------------------------------- buttons */
+
+type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+
+const BUTTON_VARIANT: Record<ButtonVariant, string> = {
+  primary: "bg-white text-neutral-900 hover:bg-neutral-200",
+  secondary: "bg-neutral-700 text-neutral-200 hover:bg-neutral-600",
+  ghost: "text-neutral-400 hover:text-neutral-100 hover:bg-neutral-700/40",
+  danger: "text-red-400 hover:text-red-300 hover:bg-red-500/10",
+};
+
+export interface DialogButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  /** Smaller button for the xs popover dialogs. */
+  compact?: boolean;
+}
+
+/** Footer action. One set of sizes and colours for every dialog. */
+export function DialogButton({
+  variant = "secondary",
+  compact = false,
+  className,
+  type = "button",
+  children,
+  ...rest
+}: DialogButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(
+        "inline-flex items-center justify-center font-medium rounded-lg transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-selection focus-visible:ring-offset-2 focus-visible:ring-offset-card",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        compact ? "h-[30px] px-3 text-xs" : "h-9 px-4 text-sm",
+        BUTTON_VARIANT[variant],
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/Menu.tsx
+++ b/src/components/ui/Menu.tsx
@@ -83,20 +83,20 @@ export interface MenuItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   selected?: boolean;
 }
 
+/** Item classes alone, for a row that must be an `<a>` or keep its own element. */
+export const menuItemClass = cn(
+  "w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 transition-colors",
+  "focus-visible:outline-none focus-visible:bg-neutral-700 focus-visible:text-neutral-100",
+  "disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent",
+  "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100"
+);
+
 export function MenuItem({ selected = false, className, type = "button", children, ...rest }: MenuItemProps) {
   return (
     <button
       {...rest}
       type={type}
-      className={cn(
-        "w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 transition-colors",
-        "focus-visible:outline-none focus-visible:bg-neutral-700 focus-visible:text-neutral-100",
-        "disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent",
-        selected
-          ? "bg-neutral-700 text-neutral-100"
-          : "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100",
-        className
-      )}
+      className={cn(menuItemClass, selected && "bg-neutral-700 text-neutral-100", className)}
     >
       {children}
     </button>
@@ -134,11 +134,15 @@ export function MenuHint({ keys, children }: { keys: string; children: ReactNode
 }
 
 /** Rule between groups: a line across a list, a short vertical tick in a bar. */
-export function MenuDivider({ variant = "list", className }: { variant?: "list" | "bar"; className?: string }) {
+export function MenuDivider({
+  variant = "list",
+  className,
+  ...rest
+}: HTMLAttributes<HTMLDivElement> & { variant?: "list" | "bar" }) {
   return variant === "bar" ? (
-    <div className={cn("w-px h-4 bg-neutral-600", className)} />
+    <div {...rest} className={cn("w-px h-4 bg-neutral-600", className)} />
   ) : (
-    <div className={cn("border-t border-chrome-border", className)} />
+    <div {...rest} className={cn("border-t border-chrome-border", className)} />
   );
 }
 

--- a/src/components/ui/Menu.tsx
+++ b/src/components/ui/Menu.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import type { ButtonHTMLAttributes, ComponentPropsWithRef, HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "@/components/nodes/ui/cn";
+
+/**
+ * The one menu surface. Context menus, the node search, connection-drop
+ * pickers and the small floating toolbars (handle, edge, multi-select) all
+ * sit on this skin, which is the node's controls card lifted a tier: the
+ * same surface, a solid border in place of the card's faint one, and a real
+ * shadow.
+ *
+ * Two shapes: a `list` stacks rows, a `bar` lines up icon buttons. Position,
+ * focus and dismissal stay with the caller — they differ per menu and are
+ * all behaviour, which this file does not own.
+ */
+
+/** Surface classes alone, for a menu that must keep its own element. */
+export const menuSurfaceClass = "bg-card border border-chrome-border rounded-controls shadow-menu";
+
+export interface MenuSurfaceProps extends ComponentPropsWithRef<"div"> {
+  variant?: "list" | "bar";
+  /** `position: fixed` on the menu tier (z-100). Off for menus anchored inside a parent. */
+  floating?: boolean;
+}
+
+export function MenuSurface({
+  variant = "list",
+  floating = true,
+  className,
+  children,
+  ...rest
+}: MenuSurfaceProps) {
+  return (
+    <div
+      {...rest}
+      className={cn(
+        menuSurfaceClass,
+        floating && "fixed z-100",
+        variant === "list"
+          ? "overflow-hidden min-w-[160px] outline-none"
+          : "flex items-center gap-1 p-1",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Top row of a list menu: a search well or a section label. */
+export function MenuHeader({ className, children, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div {...rest} className={cn("px-2 py-1.5 border-b border-chrome-border", className)}>
+      {children}
+    </div>
+  );
+}
+
+/** Uppercase label over a run of items. */
+export function MenuSectionLabel({ className, children, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      {...rest}
+      className={cn("text-[10px] font-semibold uppercase tracking-wider text-neutral-500", className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function MenuList({ className, children, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div {...rest} className={cn("py-1", className)}>
+      {children}
+    </div>
+  );
+}
+
+export interface MenuItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Keyboard or pointer highlight. */
+  selected?: boolean;
+}
+
+export function MenuItem({ selected = false, className, type = "button", children, ...rest }: MenuItemProps) {
+  return (
+    <button
+      {...rest}
+      type={type}
+      className={cn(
+        "w-full px-3 py-2 text-left text-[11px] font-medium flex items-center gap-2 transition-colors",
+        "focus-visible:outline-none focus-visible:bg-neutral-700 focus-visible:text-neutral-100",
+        "disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent",
+        selected
+          ? "bg-neutral-700 text-neutral-100"
+          : "text-neutral-300 hover:bg-neutral-700 hover:text-neutral-100",
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Empty-result row. */
+export function MenuEmpty({ className, children, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div {...rest} className={cn("px-3 py-2 text-[11px] text-neutral-500", className)}>
+      {children}
+    </div>
+  );
+}
+
+/** Bottom row of a list menu, for keyboard hints. */
+export function MenuFooter({ className, children, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      {...rest}
+      className={cn("px-2 py-1.5 border-t border-chrome-border flex items-center justify-between", className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** `⌘ + K`-style hint: a key cap and what it does. */
+export function MenuHint({ keys, children }: { keys: string; children: ReactNode }) {
+  return (
+    <span className="text-[9px] text-neutral-500">
+      <kbd className="px-1 py-0.5 bg-neutral-700 rounded text-[8px]">{keys}</kbd> {children}
+    </span>
+  );
+}
+
+/** Rule between groups: a line across a list, a short vertical tick in a bar. */
+export function MenuDivider({ variant = "list", className }: { variant?: "list" | "bar"; className?: string }) {
+  return variant === "bar" ? (
+    <div className={cn("w-px h-4 bg-neutral-600", className)} />
+  ) : (
+    <div className={cn("border-t border-chrome-border", className)} />
+  );
+}
+
+/** Icon button in a bar menu. 28px, rounded inside the bar's 10px corners. */
+export function MenuIconButton({ className, type = "button", children, ...rest }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      {...rest}
+      type={type}
+      className={cn(
+        "p-1.5 rounded-md transition-colors text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-selection",
+        "disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent",
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Text chip at the start of a bar menu (a count, "Image 2"), ruled off from the buttons. */
+export function MenuBarLabel({ className, children, ...rest }: HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      {...rest}
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2 text-[10px] font-medium text-neutral-300 border-r border-neutral-600 whitespace-nowrap",
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Menu.tsx
+++ b/src/components/ui/Menu.tsx
@@ -70,7 +70,7 @@ export function MenuSectionLabel({ className, children, ...rest }: HTMLAttribute
   );
 }
 
-export function MenuList({ className, children, ...rest }: HTMLAttributes<HTMLDivElement>) {
+export function MenuList({ className, children, ...rest }: ComponentPropsWithRef<"div">) {
   return (
     <div {...rest} className={cn("py-1", className)}>
       {children}

--- a/src/components/ui/__tests__/Dialog.test.tsx
+++ b/src/components/ui/__tests__/Dialog.test.tsx
@@ -152,14 +152,15 @@ describe("Dialog", () => {
     expect(document.body.style.overflow).toBe("");
   });
 
-  it("renders inline when asked not to portal", () => {
+  it("renders inline by default and in a body portal when asked", () => {
     const { container } = render(<Basic onClose={() => {}} />);
-    expect(container.querySelector("[role=dialog]")).toBeNull();
-    const inline = render(
-      <Dialog open portal={false} label="Inline">
+    expect(container.querySelector("[role=dialog]")).not.toBeNull();
+    const portaled = render(
+      <Dialog open portal label="Portaled">
         <p>x</p>
       </Dialog>
     );
-    expect(inline.container.querySelector("[role=dialog]")).not.toBeNull();
+    expect(portaled.container.querySelector("[role=dialog]")).toBeNull();
+    expect(screen.getByRole("dialog", { name: "Portaled" })).toBeInTheDocument();
   });
 });

--- a/src/components/ui/__tests__/Dialog.test.tsx
+++ b/src/components/ui/__tests__/Dialog.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { useState } from "react";
+
+import { Dialog, DialogHeader, DialogTitle, DialogBody, DialogFooter, DialogButton } from "../Dialog";
+import { useWorkflowStore } from "@/store/workflowStore";
+
+function Basic({ onClose, open = true }: { onClose?: () => void; open?: boolean }) {
+  return (
+    <Dialog open={open} onClose={onClose} size="sm">
+      <DialogHeader>
+        <DialogTitle>Example</DialogTitle>
+      </DialogHeader>
+      <DialogBody>
+        <input aria-label="First" />
+        <input aria-label="Second" />
+      </DialogBody>
+      <DialogFooter>
+        <DialogButton variant="ghost" onClick={onClose}>Cancel</DialogButton>
+        <DialogButton variant="primary">Save</DialogButton>
+      </DialogFooter>
+    </Dialog>
+  );
+}
+
+describe("Dialog", () => {
+  beforeEach(() => {
+    useWorkflowStore.setState({ openModalCount: 0, isModalOpen: false });
+  });
+
+  it("renders a labelled modal dialog", () => {
+    render(<Basic onClose={() => {}} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", screen.getByText("Example").id);
+  });
+
+  it("renders nothing when closed", () => {
+    render(<Basic open={false} onClose={() => {}} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("closes on Escape from anywhere in the document", () => {
+    const onClose = vi.fn();
+    render(<Basic onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape from a focused input inside it", () => {
+    const onClose = vi.fn();
+    render(<Basic onClose={onClose} />);
+    fireEvent.keyDown(screen.getByLabelText("Second"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on a backdrop click but not on a click inside the panel", () => {
+    const onClose = vi.fn();
+    render(<Basic onClose={onClose} />);
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(document.querySelector("[data-dialog-overlay]")!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Escape and the backdrop when it has no onClose", () => {
+    render(<Basic />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.click(document.querySelector("[data-dialog-overlay]")!);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("only the topmost dialog answers Escape", () => {
+    const closeOuter = vi.fn();
+    function Outer() {
+      const [inner, setInner] = useState(false);
+      return (
+        <Dialog open onClose={closeOuter} label="Outer">
+          <button onClick={() => setInner(true)}>Pick</button>
+          <Dialog open={inner} onClose={() => setInner(false)} label="Inner">
+            <p>inner</p>
+          </Dialog>
+        </Dialog>
+      );
+    }
+    render(<Outer />);
+    fireEvent.click(screen.getByText("Pick"));
+    expect(screen.getByRole("dialog", { name: "Inner" })).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Inner" })).toBeNull();
+    expect(closeOuter).not.toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(closeOuter).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Tab inside the panel", () => {
+    render(<Basic onClose={() => {}} />);
+    const first = screen.getByLabelText("First");
+    const save = screen.getByText("Save");
+    save.focus();
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Tab" });
+    // The close button in the header is the first focusable element.
+    expect(document.activeElement).toBe(screen.getByLabelText("Close"));
+    screen.getByLabelText("Close").focus();
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(save);
+    first.focus();
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Tab" });
+    // A Tab from the middle is left to the browser.
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("moves focus into the panel on open and back to the opener on close", () => {
+    function Host() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open</button>
+          <Basic open={open} onClose={() => setOpen(false)} />
+        </>
+      );
+    }
+    vi.useFakeTimers();
+    try {
+      render(<Host />);
+      const opener = screen.getByText("Open");
+      opener.focus();
+      fireEvent.click(opener);
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(true);
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(document.activeElement).toBe(opener);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("holds the store's modal count while open", () => {
+    const { unmount } = render(<Basic onClose={() => {}} />);
+    expect(useWorkflowStore.getState().isModalOpen).toBe(true);
+    unmount();
+    expect(useWorkflowStore.getState().isModalOpen).toBe(false);
+  });
+
+  it("locks body scroll while open", () => {
+    const { unmount } = render(<Basic onClose={() => {}} />);
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("renders inline when asked not to portal", () => {
+    const { container } = render(<Basic onClose={() => {}} />);
+    expect(container.querySelector("[role=dialog]")).toBeNull();
+    const inline = render(
+      <Dialog open portal={false} label="Inline">
+        <p>x</p>
+      </Dialog>
+    );
+    expect(inline.container.querySelector("[role=dialog]")).not.toBeNull();
+  });
+});

--- a/src/components/ui/__tests__/Menu.test.tsx
+++ b/src/components/ui/__tests__/Menu.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import {
+  MenuSurface,
+  MenuHeader,
+  MenuSectionLabel,
+  MenuList,
+  MenuItem,
+  MenuFooter,
+  MenuHint,
+  MenuDivider,
+  MenuIconButton,
+  MenuBarLabel,
+} from "../Menu";
+
+describe("Menu", () => {
+  it("renders a list menu with its rows", () => {
+    const onSelect = vi.fn();
+    render(
+      <MenuSurface role="menu" aria-label="Add node">
+        <MenuHeader>
+          <MenuSectionLabel>Add image node</MenuSectionLabel>
+        </MenuHeader>
+        <MenuList>
+          <MenuItem role="menuitem" selected onClick={onSelect}>Annotate</MenuItem>
+          <MenuItem role="menuitem" disabled>Generate Image</MenuItem>
+        </MenuList>
+        <MenuFooter>
+          <MenuHint keys="↑↓">navigate</MenuHint>
+        </MenuFooter>
+      </MenuSurface>
+    );
+    const menu = screen.getByRole("menu", { name: "Add node" });
+    expect(menu.className).toContain("fixed");
+    fireEvent.click(screen.getByText("Annotate"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Generate Image")).toBeDisabled();
+    expect(screen.getByText("Add image node")).toBeInTheDocument();
+    expect(screen.getByText("navigate")).toBeInTheDocument();
+  });
+
+  it("renders a bar menu anchored in place when not floating", () => {
+    render(
+      <MenuSurface variant="bar" floating={false} data-testid="bar">
+        <MenuBarLabel>3</MenuBarLabel>
+        <MenuIconButton aria-label="Hide" />
+        <MenuDivider variant="bar" />
+        <MenuIconButton aria-label="Remove" disabled />
+      </MenuSurface>
+    );
+    const bar = screen.getByTestId("bar");
+    expect(bar.className).not.toContain("fixed");
+    expect(screen.getByLabelText("Hide")).toBeEnabled();
+    expect(screen.getByLabelText("Remove")).toBeDisabled();
+  });
+
+  it("lets a caller's classes override the surface defaults", () => {
+    render(<MenuSurface data-testid="m" className="min-w-[220px]" />);
+    const cls = screen.getByTestId("m").className;
+    expect(cls).toContain("min-w-[220px]");
+    expect(cls).not.toContain("min-w-[160px]");
+  });
+});


### PR DESCRIPTION
## What changed

Every dialog, popover and context menu now sits on one of two shared primitives, so they share one surface, border, radius, spacing, type scale and keyboard behaviour. No dialog does anything different from before. Only the shell around its content changed.

**New primitives** in `src/components/ui/`:

- `Dialog.tsx`: scrim, panel, header, title, description, body, footer, close button, footer buttons. The shell owns `role="dialog"`, `aria-modal`, `aria-labelledby`, Escape from anywhere (only the topmost dialog answers), a focus trap, focus restore to the opener, body scroll lock, wheel isolation, and the store's modal count. Dialogs mount inline by default. Node-local dialogs pass `portal` to escape the canvas's transformed stacking context.
- `Menu.tsx`: one surface in two shapes (list, bar) with header, section label, item, empty row, footer hints, divider, icon button and bar label.
- Five new `@theme` tokens: `chrome-border`, `scrim`, `scrim-heavy`, `shadow-menu`, `shadow-dialog`. They are registered in `cn.ts`.

**Scale**: the compact density from the design canvas. 20px sides, 32px footer buttons at 13px, 16px semibold titles, 32px controls. Informational dialogs (cost, shortcuts) close from the header and carry no footer. Dialogs that commit something carry Cancel and one primary action.

**Layout changes agreed on the canvas**:

- Settings is a full-height rail (720 by 480). Each page has a heading and a one-line subtitle. Long pages scroll in the content column.
- Model search cards run the thumbnail the full card height and clamp the description to two lines.
- The LLM fallback popover, the variable-name dialog and both lightboxes leave `z-[9999]` for the dialog tier at `z-100`, in a body portal.

**Migrated**: settings, cost, shortcuts, workflow browser, welcome, onboarding, prompt editor, prompt constructor editor, model search, Comfy import (and its node preview), split grid cell editor, LLM fallback popover, variable-name dialog, both lightboxes, the annotation editor (overlay and header only), node search, connection drop, all-nodes list, handle bar, edge toolbar (surface only; its `EdgeLabelRenderer` mount and z-index 2100 stay), multi-select bar, group menus.

**Not migrated**: `ConnectionSettings` keeps its own segmented control and switch. No equivalent exists in the primitives yet.

Design canvas: https://claude.ai/code/artifact/64902e2e-83e0-475b-a550-4c33b596fecc

## Why

Each dialog copied the same overlay string and reimplemented Escape and focus on its own. Two of fifteen declared `role="dialog"`. Look and behaviour drifted from one to the next.

## How it was verified

| Check | Result |
|---|---|
| `npm run test:run` | 145 files, 2838 tests pass (baseline 2818) |
| `npx tsc --noEmit -p .` | 264 errors, all pre-existing in test files (baseline 264) |
| `npm run lint` | Not runnable on this branch or on `develop`: it calls `next lint`, which Next 16 removed, and the repo has no `eslint.config` |
| Browser | Dev server on port 3103. Every dialog and menu opened before and after. Contact sheet below. |

New tests: 15 for the primitives (aria, Escape, topmost-only Escape, focus trap, focus restore, modal count, scroll lock, portal), plus smoke tests for the shortcuts and onboarding dialogs. Existing tests changed only where the DOM changed: rail entries are queried by role, backdrop clicks use the overlay marker, and one annotation selector.

## What to look at hardest

1. `Dialog.tsx`: the topmost-dialog rule for Escape is document order of open overlays. Model search inside settings is the case it exists for.
2. `SplitGridTemplateModal.tsx`: it opts out of the shell's Escape and backdrop close and supplies its own overlay handlers, because a drag that ends on the backdrop is not a click and its mini canvas has a native wheel listener that must run first.
3. `ProjectSetupModal.tsx`: the rail replaces the tab bar. The tab content is unchanged.
4. The prompt editors opt out of the shell's Escape to keep their unsaved-changes prompt.

## Contact sheet

Before (develop) on the left, after (this branch) on the right.

Dialogs (settings pages, model search, Comfy import, prompt editor, split grid, cost, shortcuts, welcome, workflow browser, onboarding, variable name, annotation):

![Dialogs before and after](https://raw.githubusercontent.com/shrimbly/node-banana/assets/dialogs-and-menus/contact-sheet-dialogs.png)

Menus (node search, connection drop, all nodes, handle bar, edge toolbar, multi-select bar, group menu). The "before" node search shot is missing: the capture script did not open that menu on develop.

![Menus before and after](https://raw.githubusercontent.com/shrimbly/node-banana/assets/dialogs-and-menus/contact-sheet-menus.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjDqjv7RK1B9k5EAWdi7t3
