### PR TITLE
polish(chrome): 16px before the first workflow tab

### DIFF
--- a/src/components/WorkflowTabs.tsx
+++ b/src/components/WorkflowTabs.tsx
@@ -74,7 +74,7 @@ export function WorkflowTabs() {
     <div
       role="tablist"
       aria-label="Open workflows"
-      className="flex h-[38px] shrink-0 items-end overflow-x-auto bg-[#0f0f0f] px-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="flex h-[38px] shrink-0 items-end overflow-x-auto bg-[#0f0f0f] pl-4 pr-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
       {summaries.map((tab, index) => {
         const name = tab.name ?? "Untitled";


### PR DESCRIPTION
The workflow tab strip now has 16px of left padding instead of 8px, so the first tab lines up with the floating menu's 16px inset below it. Right padding is unchanged.

Tab tests pass. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)